### PR TITLE
Multi-doc nav rail: per-document outline close + vertical resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ changes in each release, written for users of the editor. For
 in-depth rationale and implementation context behind each entry,
 see `DETAILED_CHANGELOG.md`.
 
+## Unreleased
+
+### Added
+
+- **Per-document outlines in the multi-doc workspace.** Each open document's
+  outline section in the navigation rail can now be managed on its own. Click
+  the **×** on a section (or the outline button in that document's title bar)
+  to hide just that document's outline — the document stays open and the other
+  outlines are untouched; the title-bar button brings it back. Drag the divider
+  between two sections to resize them, and double-click the divider to even them
+  out again. Previously the × closed the whole rail and the sections always
+  split the rail evenly.
+
 ## 0.1.0-beta.4 — 2026-06-29
 
 ### Added

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -5,7 +5,30 @@ behavior, rationale, and (where useful) the implementation context
 behind a change. For a shorter, jargon-free summary of what's new
 in each release, see `CHANGELOG.md`.
 
-## 0.1.0-beta.4 — 2026-06-29
+## Unreleased
+
+- **Per-document outline close + vertical resize in the multi-doc rail**
+  (`editor/nav-panel.ts`, `editor/multi-pane-shell.ts`, `editor/style.css`). In
+  the multi-doc workspace the navigation rail stacks one `NavigationPanel`
+  section per open document. The section header's × previously called
+  `settings.set('navPaneVisible', false)`, which hid the whole rail for every
+  document; and the sections were locked to `flex: 1 1 0`, so they always split
+  the rail evenly. `NavigationPanel` now takes an optional `onClose` callback —
+  when set (multi-doc), the × routes to it instead of the global setting; the
+  single-doc panel keeps the old "hide the pane" behavior. The shell wires
+  `onClose` to a per-slot `navHidden` flag and a new `reconcileNavRail()` that is
+  the single source of truth for section visibility (expand mode → only the
+  expanded slot; otherwise every populated slot, minus individually-closed ones),
+  the resize handles, the per-slot flex weights, and whether the rail shows at
+  all. When every open document's outline is closed the rail is dropped
+  (`pmd-multi-nav-empty` body class zeroes `#app`'s left margin, mirroring the
+  global nav toggle). Each non-topmost section grows a top-edge `row-resize`
+  handle; dragging it trades flex weight between the section and its visible
+  neighbour above (combined weight held constant so the rest hold their size),
+  double-click resets to an even split, and any composition change (open / close
+  / hide / show) re-evens the split so a reopened section doesn't inherit a stale
+  weight. Each pane's title chip gains an outline-toggle button (the reopen
+  affordance and a one-click hide), pressed when the outline is shown.
 
 - **Discontinuous (Ctrl/Cmd) selection** (`editor/word-selection-plugin.ts`,
   `editor/similar-selection-plugin.ts`, `editor/style.css`,

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -718,6 +718,21 @@ as you open more.
 - When you have more than one document in a slot, jump between them using
   the drop-down in the document's title bar or by using **Ctrl-Tab**.
 
+### Per-document outlines
+
+The navigation rail stacks one outline section per open document. Each is
+independent:
+
+- **Close one outline** — click the **×** at the top of a section (or the
+  outline button in that document's title bar) to hide just that
+  document's outline. The document stays open; the other outlines are
+  untouched. Click the title-bar outline button again to bring it back.
+  When every open document's outline is closed, the rail collapses and the
+  panes reclaim the space.
+- **Resize** — drag the divider between two sections to give one outline
+  more height and the other less; double-click the divider to even them
+  back out.
+
 ### Layouts
 
 When all three slots are full, two layouts are available (pick in

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -453,10 +453,28 @@ class Slot {
   readonly navSectionEl: HTMLElement;
   /** Nav body — DocRecord.navEl mounts here. */
   private navBodyEl: HTMLElement;
+  /** Top-edge drag handle that resizes this section against the one
+   *  above it. Hidden on the topmost visible section. */
+  private navResizeHandle: HTMLElement;
   /** Last width we wrote into `--pmd-card-intrinsic-width`. Skips
    *  no-op writes on repeated sync calls (e.g. multiple events
    *  firing in one frame for the same final width). */
   private lastIntrinsicWidth = -1;
+  /** Chip outline-toggle button — shows / hides THIS slot's nav
+   *  section. The reopen path for a section closed via its × (and a
+   *  one-click hide without reaching into the rail). */
+  private chipNavBtn: HTMLButtonElement;
+  /** True when the user has closed this slot's outline section (via the
+   *  section × or the chip toggle). The section stays out of the rail —
+   *  the doc itself stays open — until the user reopens it. Per-slot, so
+   *  closing one document's outline leaves the others' untouched. */
+  navHidden = false;
+  /** Vertical flex weight of this slot's nav section within the rail.
+   *  All start at 1 (equal share); dragging a section's resize handle
+   *  shifts weight between it and its neighbour. Reset to 1 whenever the
+   *  set of open sections changes (so a closed doc doesn't strand a
+   *  lopsided split). */
+  navFlex = 1;
 
   /** Live stack. Index 0 = bottom (least recently active);
    *  `visibleIndex` is the doc currently shown. */
@@ -517,6 +535,19 @@ class Slot {
       this.shell.toggleExpanded(this);
     });
     chip.appendChild(this.chipExpandBtn);
+    // Outline-toggle — shows / hides this slot's nav section. Pressed
+    // = outline visible. Doubles as the reopen affordance after the
+    // user closes the section with its own × button.
+    this.chipNavBtn = document.createElement('button');
+    this.chipNavBtn.type = 'button';
+    this.chipNavBtn.className = 'pmd-pane-chip-nav';
+    setIcon(this.chipNavBtn, 'nav-toggle');
+    this.chipNavBtn.addEventListener('mousedown', (e) => e.preventDefault());
+    this.chipNavBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.shell.setSlotNavHidden(this, !this.navHidden);
+    });
+    chip.appendChild(this.chipNavBtn);
     this.chipCloseBtn = document.createElement('button');
     this.chipCloseBtn.type = 'button';
     this.chipCloseBtn.className = 'pmd-pane-chip-close';
@@ -586,6 +617,23 @@ class Slot {
     // focused, which feels broken when the user is navigating
     // via the nav pane.
     this.navSectionEl.addEventListener('mousedown', () => this.shell.focusSlot(this));
+    // Vertical resize handle along the section's TOP edge — drags
+    // weight between this section and the visible one above it. The
+    // topmost visible section's handle has nothing above it and is
+    // hidden by `reconcileNavRail`.
+    this.navResizeHandle = document.createElement('div');
+    this.navResizeHandle.className = 'pmd-multi-nav-resize';
+    this.navResizeHandle.setAttribute('role', 'separator');
+    this.navResizeHandle.setAttribute('aria-orientation', 'horizontal');
+    this.navResizeHandle.setAttribute('aria-label', 'Resize outline section');
+    this.navResizeHandle.title = 'Drag to resize · double-click to reset';
+    this.navResizeHandle.addEventListener('mousedown', (e) =>
+      this.shell.beginNavSectionResize(this, e),
+    );
+    this.navResizeHandle.addEventListener('dblclick', () =>
+      this.shell.resetNavSectionSizes(),
+    );
+    this.navSectionEl.appendChild(this.navResizeHandle);
     this.navBodyEl = document.createElement('div');
     this.navBodyEl.className = 'pmd-multi-nav-body';
     this.navSectionEl.appendChild(this.navBodyEl);
@@ -598,6 +646,28 @@ class Slot {
     this.chipExpandBtn.title = pressed
       ? 'Restore the multi-pane layout'
       : 'Expand this pane to fill the workspace';
+  }
+
+  /** Sync the chip's outline-toggle button + the section's flex weight
+   *  to current per-slot state. Called by the shell's nav reconcile. */
+  applyNavState(): void {
+    const shown = !this.navHidden;
+    this.chipNavBtn.setAttribute('aria-pressed', shown ? 'true' : 'false');
+    this.chipNavBtn.title = shown
+      ? "Hide this document's outline"
+      : "Show this document's outline";
+    this.navSectionEl.style.flexGrow = String(this.navFlex);
+  }
+
+  /** Toggle the resize handle. Hidden on the topmost visible section
+   *  (no neighbour above to trade height with). */
+  setResizeHandleEnabled(enabled: boolean): void {
+    this.navResizeHandle.hidden = !enabled;
+  }
+
+  /** Live pixel height of the section in the rail (0 when hidden). */
+  navSectionHeight(): number {
+    return this.navSectionEl.getBoundingClientRect().height;
   }
 
   /** Read the visible ProseMirror element's content-area width and
@@ -715,8 +785,11 @@ class Slot {
     if (this.stack.length === 0) {
       this.visibleIndex = -1;
       this.paneEl.hidden = true;
-      this.navSectionEl.hidden = true;
+      // Reset the per-slot outline-closed flag so a doc opened into
+      // this slot later starts with its outline shown.
+      this.navHidden = false;
       this.shell.notifySlotEmptied(this);
+      this.shell.reconcileNavRail();
       this.shell.refreshLayout();
       this.shell.handleSlotEmptied(this);
       return record;
@@ -784,10 +857,13 @@ class Slot {
     if (this.stack.length === 0) {
       this.visibleIndex = -1;
       this.paneEl.hidden = true;
-      this.navSectionEl.hidden = true;
+      // Reset the per-slot outline-closed flag so a doc opened into
+      // this slot later starts with its outline shown.
+      this.navHidden = false;
       // If this empty slot was the expanded one, exit expand mode —
       // no doc to expand any more.
       this.shell.notifySlotEmptied(this);
+      this.shell.reconcileNavRail();
       this.shell.refreshLayout();
       // If this slot was focused, hand focus to the next active slot.
       this.shell.handleSlotEmptied(this);
@@ -1291,7 +1367,6 @@ class MultiPaneShell {
         ? slot === expanded
         : slot.stack.length > 0;
       slot.paneEl.hidden = !show;
-      slot.navSectionEl.hidden = !show;
       slot.setExpandButtonPressed(slot === expanded);
     }
     if (expanded) {
@@ -1301,8 +1376,115 @@ class MultiPaneShell {
       delete this.rowEl.dataset['expanded'];
       delete this.navRailEl.dataset['expanded'];
     }
+    // Nav-section visibility (per-slot, honours navHidden) is owned by
+    // reconcileNavRail; pane visibility above stays independent.
+    this.reconcileNavRail();
     this.refreshLayout();
     if (expanded) this.focusSlot(expanded);
+  }
+
+  /** Count of visible nav sections at the last reconcile — used to
+   *  detect a composition change (open / close / hide / show) so we
+   *  can re-even the vertical split. */
+  private lastNavVisibleCount = -1;
+
+  /** Single source of truth for which nav sections show in the rail,
+   *  their vertical split, their resize handles, and whether the rail
+   *  itself is shown at all. Derives visibility from: expand mode →
+   *  only the expanded slot; otherwise every slot with a loaded doc —
+   *  minus any the user has individually closed (`navHidden`). */
+  reconcileNavRail(): void {
+    const expanded = this.expandedSlot;
+    const visible: Slot[] = [];
+    for (const id of SLOT_IDS) {
+      const slot = this.slots[id];
+      const showByLayout = expanded ? slot === expanded : slot.stack.length > 0;
+      const show = showByLayout && !slot.navHidden;
+      slot.navSectionEl.hidden = !show;
+      if (show) visible.push(slot);
+    }
+    // Composition changed → reset to an even split so a reopened or
+    // newly-opened section doesn't inherit a stale, lopsided weight.
+    if (visible.length !== this.lastNavVisibleCount) {
+      for (const id of SLOT_IDS) this.slots[id].navFlex = 1;
+      this.lastNavVisibleCount = visible.length;
+    }
+    // The topmost visible section has no neighbour above to trade
+    // height with, so it gets no resize handle.
+    for (let i = 0; i < visible.length; i++) {
+      visible[i]!.setResizeHandleEnabled(i > 0);
+    }
+    // Chip toggle pressed-state + flex weight apply to every slot (a
+    // closed section's chip still needs to show the reopen affordance).
+    for (const id of SLOT_IDS) this.slots[id].applyNavState();
+    // Every open doc's outline closed → drop the rail so the editor row
+    // reclaims its width; the CSS `pmd-multi-nav-empty` body class zeroes
+    // `#app`'s left margin.
+    const railEmpty = visible.length === 0;
+    this.navRailEl.hidden = railEmpty;
+    document.body.classList.toggle('pmd-multi-nav-empty', railEmpty);
+    this.scheduleSyncAllCardIntrinsicWidths();
+  }
+
+  /** Show / hide a single slot's outline section. The doc stays open;
+   *  only its rail section toggles. Reopen via the same chip button or
+   *  the section's × (close only). */
+  setSlotNavHidden(slot: Slot, hidden: boolean): void {
+    if (slot.navHidden === hidden) return;
+    slot.navHidden = hidden;
+    this.reconcileNavRail();
+  }
+
+  /** Reset every section back to an even vertical split (double-click
+   *  on a resize handle). */
+  resetNavSectionSizes(): void {
+    for (const id of SLOT_IDS) this.slots[id].navFlex = 1;
+    for (const id of SLOT_IDS) this.slots[id].applyNavState();
+  }
+
+  /** Begin a vertical drag on `slot`'s resize handle. Trades flex
+   *  weight between `slot` and the visible section directly above it,
+   *  keeping their combined weight constant so the other sections hold
+   *  their size. Pixel delta → flex delta via the live combined height. */
+  beginNavSectionResize(slot: Slot, e: MouseEvent): void {
+    e.preventDefault();
+    // The section directly above this one in rail (document) order,
+    // skipping hidden ones.
+    const order = SLOT_IDS.map((id) => this.slots[id]).filter(
+      (s) => !s.navSectionEl.hidden,
+    );
+    const idx = order.indexOf(slot);
+    if (idx <= 0) return;
+    const above = order[idx - 1]!;
+
+    const startY = e.clientY;
+    const aboveH = above.navSectionHeight();
+    const selfH = slot.navSectionHeight();
+    const totalH = aboveH + selfH;
+    const totalFlex = above.navFlex + slot.navFlex;
+    if (totalH <= 0 || totalFlex <= 0) return;
+    // Don't let a section collapse to nothing — keep room for at least
+    // its sticky header.
+    const MIN_PX = 48;
+
+    const onMove = (ev: MouseEvent) => {
+      let newAboveH = aboveH + (ev.clientY - startY);
+      newAboveH = Math.max(MIN_PX, Math.min(totalH - MIN_PX, newAboveH));
+      const aboveFlex = (newAboveH / totalH) * totalFlex;
+      above.navFlex = aboveFlex;
+      slot.navFlex = totalFlex - aboveFlex;
+      above.applyNavState();
+      slot.applyNavState();
+    };
+    const onUp = () => {
+      document.body.classList.remove('pmd-nav-resize-vertical');
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      this.scheduleSyncAllCardIntrinsicWidths();
+    };
+    document.body.classList.add('pmd-nav-resize-vertical');
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
   }
 
   /** Pending rAF id for the next card-intrinsic-width batch. */
@@ -1758,11 +1940,12 @@ class MultiPaneShell {
   notifySlotPopulated(slot: Slot): void {
     if (this.expandedSlot && this.expandedSlot !== slot) {
       slot.paneEl.hidden = true;
-      slot.navSectionEl.hidden = true;
     } else {
       slot.paneEl.hidden = false;
-      slot.navSectionEl.hidden = false;
     }
+    // Section visibility (honouring navHidden + expand mode) is owned
+    // by reconcileNavRail.
+    this.reconcileNavRail();
     this.refreshLayout();
   }
 
@@ -2435,7 +2618,13 @@ function buildDocRecord(
 
   // Per-pane nav panel with an INDEPENDENT outline-level filter
   // (`localMaxLevel`). Each section's 1/2/3/4 buttons act locally.
-  const navPanel = new NavigationPanel(navEl, { localMaxLevel: true });
+  // Its × closes just THIS document's outline section (via the slot
+  // the record currently lives in — records can move between slots, so
+  // resolve `owner` lazily at click time, not build time).
+  const navPanel = new NavigationPanel(navEl, {
+    localMaxLevel: true,
+    onClose: () => record.owner.shell.setSlotNavHidden(record.owner, true),
+  });
   navPanel.attach(view);
   // Initial caret-heading highlight so a freshly-mounted pane reflects the
   // cursor before the first selection change (parity with index.ts).

--- a/src/editor/nav-panel.ts
+++ b/src/editor/nav-panel.ts
@@ -131,6 +131,12 @@ export class NavigationPanel {
   private unsubscribeDrag: (() => void) | null = null;
   private unregisterSurface: (() => void) | null = null;
   private destroyed = false;
+  /** Custom handler for the header × button. When set (multi-pane,
+   *  where each section is one document's outline) the × closes just
+   *  THIS section via the callback; otherwise it falls back to
+   *  toggling the global `navPaneVisible` setting (single-doc, where
+   *  there's only one pane and × means "hide the nav pane"). */
+  private onClose: (() => void) | null = null;
 
   // ---- Selection state (multi-select) ----
   private selectedIds: Set<string> = new Set();
@@ -232,10 +238,18 @@ export class NavigationPanel {
     return settings.get('navMaxLevel');
   }
 
-  constructor(parent: HTMLElement, opts?: { localMaxLevel?: boolean; initialMaxLevel?: number }) {
+  constructor(
+    parent: HTMLElement,
+    opts?: {
+      localMaxLevel?: boolean;
+      initialMaxLevel?: number;
+      onClose?: () => void;
+    },
+  ) {
     if (opts?.localMaxLevel) {
       this.localMaxLevel = opts.initialMaxLevel ?? settings.get('navMaxLevel');
     }
+    this.onClose = opts?.onClose ?? null;
     this.root = document.createElement('aside');
     this.root.className = 'pmd-nav-panel';
 
@@ -264,10 +278,14 @@ export class NavigationPanel {
     closeBtn.type = 'button';
     closeBtn.className = 'pmd-nav-close';
     setIcon(closeBtn, 'close');
-    closeBtn.title = 'Hide navigation pane';
-    closeBtn.setAttribute('aria-label', 'Hide navigation pane');
+    // In multi-pane mode the × closes just this document's outline
+    // section (via `onClose`); in single-doc it hides the whole pane.
+    const closeLabel = this.onClose ? "Hide this document's outline" : 'Hide navigation pane';
+    closeBtn.title = closeLabel;
+    closeBtn.setAttribute('aria-label', closeLabel);
     closeBtn.addEventListener('click', () => {
-      settings.set('navPaneVisible', false);
+      if (this.onClose) this.onClose();
+      else settings.set('navPaneVisible', false);
     });
     header.appendChild(closeBtn);
 

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -8777,9 +8777,57 @@ body.pmd-multi-doc #word-count-btn {
   flex-direction: column;
   border-top: 1px solid var(--pmd-c-border-soft);
   overflow: hidden;
+  /* Anchor for the absolutely-positioned top-edge resize handle. */
+  position: relative;
 }
 .pmd-multi-nav-section:first-child {
   border-top: none;
+}
+
+/* Vertical resize handle straddling the border between two stacked
+ * outline sections. Absolutely positioned so it doesn't consume the
+ * section's flex height; hidden on the topmost visible section (set
+ * via the `hidden` attribute from reconcileNavRail). */
+.pmd-multi-nav-resize {
+  position: absolute;
+  /* Flush with the section's top edge — the section's `overflow:
+   * hidden` would clip a handle pulled above it, so it sits just
+   * inside, straddling the `border-top` visually on hover. */
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  cursor: row-resize;
+  z-index: 2;
+  background: transparent;
+  transition: background-color 0.1s ease;
+}
+.pmd-multi-nav-resize[hidden] {
+  display: none;
+}
+.pmd-multi-nav-resize:hover,
+body.pmd-nav-resize-vertical .pmd-multi-nav-resize {
+  background: var(--pmd-c-accent-soft);
+}
+/* While dragging a section divider: lock selection + row-resize cursor
+ * document-wide so a fast drag that outruns the handle keeps state. */
+body.pmd-nav-resize-vertical {
+  user-select: none;
+  cursor: row-resize !important;
+}
+
+/* Rail hidden because every open doc's outline was individually closed.
+ * Mirror the section's explicit UA-display restore so the class's
+ * `display: flex` doesn't beat `[hidden]`, and reclaim the rail's width
+ * the same way the global nav toggle does. */
+.pmd-multi-nav[hidden] {
+  display: none;
+}
+body.pmd-multi-nav-empty.pmd-multi-doc #app {
+  margin-left: 0;
+}
+body.pmd-multi-nav-empty.pmd-multi-doc #status-bar {
+  left: 0;
 }
 /* Class-selector specificity ties [hidden]'s UA `display: none`,
  * so the .pmd-multi-nav-section `display: flex` would otherwise win
@@ -9148,10 +9196,12 @@ body.pmd-multi-doc #word-count-btn {
 }
 .pmd-pane-focused .pmd-pane-chip-close,
 .pmd-pane-focused .pmd-pane-chip-stack,
+.pmd-pane-focused .pmd-pane-chip-nav,
 .pmd-pane-focused .pmd-pane-chip-expand {
   color: var(--pmd-c-text-on-accent);
 }
-.pmd-pane-focused .pmd-pane-chip-expand[aria-pressed="true"] {
+.pmd-pane-focused .pmd-pane-chip-expand[aria-pressed="true"],
+.pmd-pane-focused .pmd-pane-chip-nav[aria-pressed="true"] {
   /* Active-state accent reads as too-similar to the focused-pane
    * blue background; switch to white + a subtle box to flag the
    * pressed state instead. */
@@ -9261,6 +9311,22 @@ body.pmd-multi-doc #word-count-btn {
 }
 .pmd-pane-chip-expand:hover { color: var(--pmd-c-text-strong); }
 .pmd-pane-chip-expand[aria-pressed="true"] {
+  color: var(--pmd-c-accent);
+}
+.pmd-pane-chip-nav {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--pmd-c-text-muted);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+.pmd-pane-chip-nav:hover { color: var(--pmd-c-text-strong); }
+.pmd-pane-chip-nav[aria-pressed="true"] {
   color: var(--pmd-c-accent);
 }
 .pmd-pane-chip-close {


### PR DESCRIPTION
## What & why

In the multi-doc workspace the navigation rail stacks one outline section per open document. Two limitations made the per-document outlines hard to manage:

- **The section × closed the whole rail.** Each section's × called `settings.set('navPaneVisible', false)`, hiding every document's outline at once, there was no way to dismiss just one.
- **Sections were not resizable.** They were locked to `flex: 1 1 0`, so they always split the rail evenly with no way to give one document's outline more room.

## Changes

- **`NavigationPanel`** takes an optional `onClose` callback. In multi-doc the × routes to it (close just *this* document's outline); the single-doc panel keeps the old "hide the nav pane" behavior.
- **Per-document close** via a per-slot `navHidden` flag and a new `reconcileNavRail()` — the single source of truth for section visibility (expand mode → only the expanded slot; otherwise every populated slot, minus individually-closed ones), the resize handles, the flex weights, and whether the rail shows at all. When every open document's outline is closed, the rail drops and the panes reclaim the width (`pmd-multi-nav-empty` body class zeroes `#app`'s left margin, mirroring the global nav toggle).
- **Vertical resize** — each non-topmost section grows a top-edge `row-resize` handle. Dragging it trades flex weight between the section and its visible neighbour above (combined weight held constant, so the rest hold their size). Double-click resets to an even split; any composition change (open/close/hide/show) re-evens the split so a reopened section doesn't inherit a stale weight.
- **Reopen affordance** — each pane's title chip gains an outline-toggle (☰) button, pressed when the outline is shown; it hides/shows that document's outline and is the reopen path after the × closes a section.
- Docs: MANUAL "Per-document outlines" subsection, plus CHANGELOG + DETAILED_CHANGELOG entries.

## Testing

- `npm run typecheck` — clean (the two pre-existing `apps/desktop` electron-module errors are unrelated to this change and present on `main`).
- `npm run test` — 1474 passing, 1 skipped.
- `npm run build` — succeeds.
- Manual click-test in the multi-doc workspace recommended (per-document close, the chip outline toggle, divider drag/double-click) — not automated here.