### PR TITLE
Add Word-style image resize handles

### DIFF
--- a/src/editor/image-resize-nodeview.ts
+++ b/src/editor/image-resize-nodeview.ts
@@ -1,0 +1,243 @@
+/**
+ * Resizable image NodeView — gives editor images Word-style resize
+ * handles. The image node stays an inline atom whose size is carried
+ * by the existing `widthEmu` / `heightEmu` attrs (English Metric
+ * Units, 9525 EMU per CSS pixel), so a resize round-trips straight to
+ * the `.docx` `<wp:extent>` on export with no new metadata added to
+ * the schema.
+ *
+ * The inner element is rendered by the schema's own `toDOM` (an
+ * `<img>` for renderable formats, a placeholder `<span>` for EMF /
+ * WMF / TIFF), so this view adds only a thin wrapper plus handles.
+ * Handles are created lazily on selection and removed on deselect, so
+ * an unselected image costs one extra wrapper span and nothing more —
+ * keeping large multi-image documents light.
+ */
+
+import { DOMSerializer } from 'prosemirror-model';
+import type { Node as PMNode } from 'prosemirror-model';
+import type { EditorView, NodeView } from 'prosemirror-view';
+import { NodeSelection } from 'prosemirror-state';
+import { settings } from './settings.js';
+
+const EMU_PER_PX = 9525;
+const MIN_PX = 16;
+
+/**
+ * Eight Word-style handles: four corners resize proportionally
+ * (aspect-locked), four edges resize a single axis (aspect unlocked).
+ * For the edge handles to stay WYSIWYG, `renderInner` pins the image's
+ * width AND height to the stored EMU dimensions (overriding the
+ * schema's responsive `height: auto`), so what you drag is exactly what
+ * exports. Handles are created only while the image is selected, so
+ * unselected images carry no handle DOM.
+ */
+const HANDLE_DIRS = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'] as const;
+type Dir = (typeof HANDLE_DIRS)[number];
+
+/** Accumulated CSS `zoom` up the ancestor chain (editor panes zoom via
+ *  the `zoom` property). Lets us convert screen-space pointer deltas
+ *  into the element's own CSS pixels regardless of zoom level. */
+function zoomFactorOf(el: HTMLElement): number {
+  let z = 1;
+  let n: HTMLElement | null = el;
+  while (n) {
+    const cz = parseFloat(getComputedStyle(n).zoom);
+    if (Number.isFinite(cz) && cz > 0) z *= cz;
+    n = n.parentElement;
+  }
+  return z > 0 ? z : 1;
+}
+
+class ImageResizeView implements NodeView {
+  readonly dom: HTMLElement;
+  private inner!: HTMLElement;
+  private node: PMNode;
+  private readonly view: EditorView;
+  private readonly getPos: () => number | undefined;
+  private handles: HTMLElement[] = [];
+  private dragging = false;
+
+  constructor(node: PMNode, view: EditorView, getPos: () => number | undefined) {
+    this.node = node;
+    this.view = view;
+    this.getPos = getPos;
+
+    this.dom = document.createElement('span');
+    this.dom.className = 'pmd-image-wrap';
+    this.renderInner();
+  }
+
+  /** Render (or re-render) the schema's `<img>` / placeholder into the
+   *  wrapper, then pin its display size to the stored EMU dimensions so
+   *  an aspect-unlocked edge resize is WYSIWYG (the schema's default
+   *  `height: auto` would otherwise snap the image back to its natural
+   *  ratio, hiding a one-axis stretch). */
+  private renderInner(): void {
+    const spec = this.node.type.spec.toDOM?.(this.node);
+    if (!spec) return;
+    const { dom } = DOMSerializer.renderSpec(document, spec);
+    const el = dom as HTMLElement;
+    const widthEmu = Number(this.node.attrs['widthEmu'] ?? 0);
+    const heightEmu = Number(this.node.attrs['heightEmu'] ?? 0);
+    if (widthEmu > 0 && heightEmu > 0) {
+      el.style.width = `${Math.round(widthEmu / EMU_PER_PX)}px`;
+      el.style.height = `${Math.round(heightEmu / EMU_PER_PX)}px`;
+      // Honor the explicit height (don't let the schema's `height: auto`
+      // re-lock the aspect) and show the true set size like Word does.
+      el.style.maxWidth = 'none';
+    }
+    if (this.inner) this.inner.replaceWith(el);
+    else this.dom.appendChild(el);
+    this.inner = el;
+  }
+
+  update(node: PMNode): boolean {
+    if (node.type !== this.node.type) return false;
+    this.node = node;
+    // Skip re-render mid-drag: the live inline styles are authoritative
+    // until the drag commits the new EMU dimensions.
+    if (!this.dragging) this.renderInner();
+    return true;
+  }
+
+  selectNode(): void {
+    this.dom.classList.add('ProseMirror-selectednode');
+    if (settings.get('readMode') || !this.view.editable) return;
+    this.addHandles();
+  }
+
+  deselectNode(): void {
+    this.dom.classList.remove('ProseMirror-selectednode');
+    this.removeHandles();
+  }
+
+  private addHandles(): void {
+    if (this.handles.length) return;
+    for (const dir of HANDLE_DIRS) {
+      const h = document.createElement('span');
+      h.className = `pmd-image-handle pmd-image-handle-${dir}`;
+      h.addEventListener('pointerdown', (e) => this.startResize(e, dir));
+      this.dom.appendChild(h);
+      this.handles.push(h);
+    }
+  }
+
+  private removeHandles(): void {
+    for (const h of this.handles) h.remove();
+    this.handles = [];
+  }
+
+  private startResize(e: PointerEvent, dir: Dir): void {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const z = zoomFactorOf(this.inner);
+    const rect = this.inner.getBoundingClientRect();
+    const startW = rect.width / z;
+    const startH = rect.height / z;
+    if (startW < 1 || startH < 1) return;
+    const aspect = startW / startH;
+    const startX = e.clientX;
+    const startY = e.clientY;
+
+    this.dragging = true;
+    const prevMaxWidth = this.inner.style.maxWidth;
+    // Let the image grow past the container width while dragging.
+    this.inner.style.maxWidth = 'none';
+    const handle = e.currentTarget as HTMLElement;
+    try {
+      handle.setPointerCapture(e.pointerId);
+    } catch {
+      /* pointer capture is best-effort */
+    }
+
+    let w = startW;
+    let h = startH;
+    const west = dir === 'nw' || dir === 'w' || dir === 'sw';
+    const east = dir === 'ne' || dir === 'e' || dir === 'se';
+    const north = dir === 'nw' || dir === 'n' || dir === 'ne';
+    const south = dir === 'sw' || dir === 's' || dir === 'se';
+    const corner = (west || east) && (north || south);
+
+    const onMove = (ev: PointerEvent): void => {
+      const dx = (ev.clientX - startX) / z;
+      const dy = (ev.clientY - startY) / z;
+      if (corner) {
+        // Corner: aspect-locked. Drive width from horizontal motion and
+        // derive height so the image scales without distorting.
+        const nextW = east ? startW + dx : startW - dx;
+        w = Math.max(MIN_PX, nextW);
+        h = w / aspect;
+      } else {
+        // Edge: aspect unlocked — resize only the dragged axis.
+        if (east) w = Math.max(MIN_PX, startW + dx);
+        else if (west) w = Math.max(MIN_PX, startW - dx);
+        if (south) h = Math.max(MIN_PX, startH + dy);
+        else if (north) h = Math.max(MIN_PX, startH - dy);
+      }
+      this.inner.style.width = `${Math.round(w)}px`;
+      this.inner.style.height = `${Math.round(h)}px`;
+    };
+
+    const onUp = (): void => {
+      handle.removeEventListener('pointermove', onMove);
+      handle.removeEventListener('pointerup', onUp);
+      handle.removeEventListener('pointercancel', onUp);
+      this.dragging = false;
+      this.inner.style.maxWidth = prevMaxWidth;
+      this.commit(Math.round(w), Math.round(h));
+    };
+
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onUp);
+  }
+
+  /** Write the new pixel dimensions back to the node as EMU. */
+  private commit(wPx: number, hPx: number): void {
+    const pos = this.getPos();
+    if (pos == null) return;
+    const live = this.view.state.doc.nodeAt(pos);
+    if (!live || live.type.name !== 'image') return;
+    const widthEmu = Math.max(0, Math.round(wPx * EMU_PER_PX));
+    const heightEmu = Math.max(0, Math.round(hPx * EMU_PER_PX));
+    if (live.attrs['widthEmu'] === widthEmu && live.attrs['heightEmu'] === heightEmu) {
+      this.renderInner();
+      return;
+    }
+    const tr = this.view.state.tr.setNodeMarkup(pos, undefined, {
+      ...live.attrs,
+      widthEmu,
+      heightEmu,
+    });
+    // Keep the image selected after the resize so its handles stay up
+    // for a follow-up drag (Word keeps the selection too).
+    tr.setSelection(NodeSelection.create(tr.doc, pos));
+    this.view.dispatch(tr);
+  }
+
+  /** Keep PM out of the handle-drag gestures; ordinary clicks on the
+   *  image itself still fall through so it selects normally. */
+  stopEvent(e: Event): boolean {
+    const t = e.target as HTMLElement | null;
+    return !!t?.classList?.contains('pmd-image-handle');
+  }
+
+  ignoreMutation(): boolean {
+    return true;
+  }
+
+  destroy(): void {
+    this.removeHandles();
+  }
+}
+
+/** NodeView map shared by every editor surface (single-doc + panes). */
+export const editorNodeViews = {
+  image: (
+    node: PMNode,
+    view: EditorView,
+    getPos: () => number | undefined,
+  ): NodeView => new ImageResizeView(node, view, getPos),
+};

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -157,6 +157,7 @@ import { tableEditingPlugin, columnResizingPlugin } from './table-plugins.js';
 import { buildPastePlugin } from './paste-plugin.js';
 import { buildImageNodeFromBlob, insertImageNode } from './image-insert.js';
 import { imageContextMenuPlugin } from './image-context-menu-plugin.js';
+import { editorNodeViews } from './image-resize-nodeview.js';
 import { linkContextMenuPlugin } from './link-context-menu-plugin.js';
 import { wordSelectionPlugin } from './word-selection-plugin.js';
 import { typeOverBoundaryPlugin } from './type-over-boundary.js';
@@ -4153,6 +4154,7 @@ function mountView(doc: PMNode, threads: Thread[] = []): void {
   });
   view = new EditorView(editorEl, {
     state,
+    nodeViews: editorNodeViews,
     editable: () => !settings.get('readMode'),
     // Browser's built-in spellcheck stays OFF — `editorSpellcheck` is
     // served by the custom viewport checker (viewport-spellcheck.ts),

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -87,6 +87,7 @@ import {
   sendViewToDropzone,
 } from './index.js';
 import { sendViewToStarred } from './pairing/send-to-starred.js';
+import { editorNodeViews } from './image-resize-nodeview.js';
 import { coordinatorBlocks, flashLockedLeases } from './ai/edit-coordinator.js';
 import { icon, setIcon } from './icons';
 
@@ -2595,6 +2596,7 @@ function buildDocRecord(
   // changes.
   const view: EditorView = new EditorView(editorEl, {
     state,
+    nodeViews: editorNodeViews,
     // Browser's built-in spellcheck stays OFF — `editorSpellcheck` is
     // served by the custom viewport checker (viewport-spellcheck.ts).
     attributes: { spellcheck: 'false' },

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -2537,6 +2537,7 @@ code {
    placeholder also gets a tinted background since its
    selected-vs-unselected outline contrast is otherwise marginal. */
 img[data-pmd-image].ProseMirror-selectednode,
+.pmd-image-wrap.ProseMirror-selectednode,
 .pmd-image-placeholder.ProseMirror-selectednode {
   outline: 2px solid var(--pmd-c-accent);
   outline-offset: 2px;
@@ -2544,6 +2545,61 @@ img[data-pmd-image].ProseMirror-selectednode,
 .pmd-image-placeholder.ProseMirror-selectednode {
   background: var(--pmd-c-drop-soft);
 }
+
+/* Resizable-image wrapper NodeView. Inline-block so it flows with text
+   like the bare <img> it replaces; `position: relative` anchors the
+   eight resize handles. `line-height: 0` trims the descender gap the
+   wrapper would otherwise add below the image. */
+.pmd-image-wrap {
+  position: relative;
+  display: inline-block;
+  line-height: 0;
+  vertical-align: middle;
+}
+
+/* Word-style resize handles — created only while the image is
+   selected (see image-resize-nodeview.ts), so unselected images add no
+   handle DOM. Corners are white circles; edges are pill-shaped
+   rectangles. Both use a subtle grey outline. */
+.pmd-image-handle {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #9a9a9a;
+  box-sizing: border-box;
+  z-index: 6;
+}
+/* Corners: white circles. */
+.pmd-image-handle-nw,
+.pmd-image-handle-ne,
+.pmd-image-handle-se,
+.pmd-image-handle-sw {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+/* Edges: pill rectangles — corner radius = half the short side (the
+   rectangle's thickness), giving fully rounded ends. Horizontal edges
+   (n / s) are wide and thin; vertical edges (e / w) are tall and thin. */
+.pmd-image-handle-n,
+.pmd-image-handle-s {
+  width: 16px;
+  height: 6px;
+  border-radius: 3px;
+}
+.pmd-image-handle-e,
+.pmd-image-handle-w {
+  width: 6px;
+  height: 16px;
+  border-radius: 3px;
+}
+.pmd-image-handle-nw { top: -6px; left: -6px; cursor: nwse-resize; }
+.pmd-image-handle-n  { top: -3px; left: calc(50% - 8px); cursor: ns-resize; }
+.pmd-image-handle-ne { top: -6px; right: -6px; cursor: nesw-resize; }
+.pmd-image-handle-e  { top: calc(50% - 8px); right: -3px; cursor: ew-resize; }
+.pmd-image-handle-se { bottom: -6px; right: -6px; cursor: nwse-resize; }
+.pmd-image-handle-s  { bottom: -3px; left: calc(50% - 8px); cursor: ns-resize; }
+.pmd-image-handle-sw { bottom: -6px; left: -6px; cursor: nesw-resize; }
+.pmd-image-handle-w  { top: calc(50% - 8px); left: -3px; cursor: ew-resize; }
 
 /* Placeholder span shown in place of unsupported image formats
    (EMF / WMF / TIFF). Visual styling lives here so it can be
@@ -4265,6 +4321,7 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
 
 /* Images are never read-aloud content — hide them in read mode. */
 .pmd-read-mode img[data-pmd-image],
+.pmd-read-mode .pmd-image-wrap,
 .pmd-read-mode .pmd-image-placeholder { display: none; }
 
 /* Run-separator widget. The plugin inserts a `<span class="pmd-rm-


### PR DESCRIPTION
## Summary

Adds Word-style image resizing to the editor. Images are inline atoms with no in-editor way to resize them; this adds a ProseMirror `NodeView` that wraps each image and, on selection, shows eight resize handles.

## What it does

- **Eight resize handles** appear when an image is selected:
  - **Corners** (white circles) resize **proportionally** (aspect-locked).
  - **Edges** (rounded pills) resize a **single axis** (aspect unlocked), matching Word.
- Resizes write back to the existing `widthEmu` / `heightEmu` attrs, so they **round-trip straight to the `.docx` `<wp:extent>`** on export — no new schema metadata.
- The NodeView pins the image to its stored width **and** height (overriding the schema's responsive `height: auto`) so an edge stretch is WYSIWYG.
- The node selection is re-asserted after a resize, so handles stay up for a follow-up drag.
- Handles are created only while an image is selected, so unselected images add no handle DOM — keeping large multi-image documents light.
- Zoom-aware pointer math (editor panes zoom via CSS `zoom`).
- Wired into **both** the single-doc and multi-pane editor views via a shared `nodeViews` map.

## Files

- `src/editor/image-resize-nodeview.ts` (new) — the resizable-image NodeView.
- `src/editor/index.ts`, `src/editor/multi-pane-shell.ts` — pass the shared `nodeViews` map to each `EditorView`.
- `src/editor/style.css` — wrapper + handle styling, read-mode hiding, selection outline moved to the wrapper.

## Testing

- Verified in a live headless browser against a real Verbatim `.docx`: opening the file gives the image the resize NodeView, clicking shows 8 handles, corner drags scale proportionally, edge drags stretch one axis, and the new size persists.
- Confirmed a resize round-trips through `toDocx` → `fromDocx` with exact EMU dimensions preserved.
- `npm test` — 1575 passing (unchanged), `npm run typecheck` clean for the new code.
