### PR TITLE
Keep find bar within viewport on narrow windows

### DIFF
--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -6173,7 +6173,11 @@ body.pmd-steady-cursor .pmd-italic-caret,
   flex-direction: column;
   gap: 0.35rem;
   font-size: 0.85rem;
-  min-width: 360px;
+  /* Shrink to fit narrow windows instead of overflowing past the screen
+     edge. min() keeps the 360px target but caps it at the viewport width
+     so min-width never forces an overflow. */
+  min-width: min(360px, calc(100vw - 2rem));
+  max-width: calc(100vw - 2rem);
 }
 .pmd-find-bar[hidden] { display: none; }
 .pmd-find-row,
@@ -6181,6 +6185,9 @@ body.pmd-steady-cursor .pmd-italic-caret,
   display: flex;
   align-items: center;
   gap: 0.35rem;
+  /* When the row can't fit on one line (small windows), wrap the controls
+     onto additional lines rather than overflowing. */
+  flex-wrap: wrap;
 }
 .pmd-find-input {
   flex: 1 1 auto;


### PR DESCRIPTION
The find bar was fixed at min-width 360px with non-wrapping rows, so a window narrower than the bar pushed it off the left edge of the screen and out of reach.

<img width="549" height="189" alt="dyn-fe50d5c45f25efd9819b137dfddab7d7" src="https://github.com/user-attachments/assets/3144ff3f-6d25-4e03-b431-d149bf7c1dde" />

The min-width now clamps to the viewport, a matching max-width caps it, and the rows wrap so all controls are visible.

<img width="516" height="165" alt="dyn-3fb4f8aa49d19f857c06f77714e8f017" src="https://github.com/user-attachments/assets/7658c39d-7841-4d17-98ab-148184dc4b0a" />
