### PR TITLE
Visually denote unread text after a marker

### DIFF
--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -5851,6 +5851,7 @@ async function serializeForSave(
     includeUndertags: opts.includeUndertags,
     readMode: opts.readMode,
     markedCardsOnly: opts.markedCardsOnly ?? false,
+    markUnreadAfterMarker: settings.get('markUnreadAfterMarker'),
   });
   if (view) gcOrphanThreads(view);
   const baseThreads =
@@ -7513,6 +7514,7 @@ async function reserializeJournalAs(
     includeUndertags: true,
     readMode: false,
     markedCardsOnly: false,
+    markUnreadAfterMarker: settings.get('markUnreadAfterMarker'),
   });
   return toDocx(
     exportDoc,

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -136,6 +136,7 @@ import {
   readModeAwareUndo,
   readModeAwareRedo,
 } from './read-mode-plugin.js';
+import { markUnreadPlugin, MARK_UNREAD_TOGGLE } from './mark-unread-plugin.js';
 import { tagCollabTransaction, collabPluginSource, setCollabInviteJoiner, setCollabInviter } from './collab/collab-hooks.js';
 import { learnHighlightPlugin, flashcardRangeAt } from './learn-highlight-plugin.js';
 import { repairHighlightPlugin } from './repair-highlight-plugin.js';
@@ -2908,6 +2909,7 @@ let lastKeyboardMacros = settings.get('keyboardMacros');
 // make every settings change lag on big docs.
 let lastReadMode = settings.get('readMode');
 let lastReadModeBorders = settings.get('hideEmphasisBordersInReadMode');
+let lastMarkUnread = settings.get('markUnreadAfterMarker');
 
 /** Show/hide the chrome's optional clusters per their (default-off) settings:
  *  the dropzone pill and the Quick Cards button stack. Called from the settings
@@ -2955,6 +2957,12 @@ settings.subscribe((s) => {
     lastReadMode = s.readMode;
     lastReadModeBorders = s.hideEmphasisBordersInReadMode;
     applyReadMode(s.readMode);
+  }
+  // Nudge the mark-unread plugin to rebuild when its toggle flips (diff-gated
+  // because the rebuild is O(doc); the plugin re-reads the setting itself).
+  if (s.markUnreadAfterMarker !== lastMarkUnread) {
+    lastMarkUnread = s.markUnreadAfterMarker;
+    if (view) view.dispatch(view.state.tr.setMeta(MARK_UNREAD_TOGGLE, true));
   }
   applyNavPaneVisible(s.navPaneVisible);
   applyFormatNavPaneByType(s.formatNavPaneByType);
@@ -4339,6 +4347,7 @@ export function buildEditorPlugins(): Plugin[] {
     wordSelectionKeymap,
     keymap(baseKeymap),
     readModePlugin,
+    markUnreadPlugin,
     commentsPlugin,
     learnHighlightPlugin,
     repairHighlightPlugin,

--- a/src/editor/mark-unread-plugin.ts
+++ b/src/editor/mark-unread-plugin.ts
@@ -1,0 +1,87 @@
+/**
+ * "Unread after marker" decoration.
+ *
+ * A toggleable review aid (`markUnreadAfterMarker`): when on, every run of a
+ * card's body text that falls AFTER a reading-position marker (see
+ * `reading-marker.ts`) is tinted red, a visual record of the part of the card
+ * you didn't reach in a round. Bounded by the card: a marker only reddens the
+ * rest of ITS card, never the next one.
+ *
+ * Display-only, like read mode's hiding: it's a `Decoration` set, never a doc
+ * edit, so it round-trips to nothing and flips off cleanly. The red the
+ * marker text itself already carries (`font_color` FF0000) is left alone; this
+ * only colors the body that comes after it.
+ *
+ * Perf: the setting is OFF by default, so `build` bails before walking
+ * anything (zero cost for the common case). When on, it rebuilds the whole
+ * set on each doc change.
+ * ponytail: O(doc) full rebuild per doc-change while on. Fine, since "on" is a
+ * review posture (few edits). Upgrade to incremental (map + recompute the
+ * changed card, like read-mode-plugin) only if a big doc lags while on.
+ */
+
+import { Plugin } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+import type { Node as PMNode } from 'prosemirror-model';
+import { settings } from './settings.js';
+import { isMarkerText } from './reading-marker.js';
+
+/** Meta flag on the no-op transaction the settings watcher dispatches when
+ *  the toggle flips, so the plugin rebuilds on demand (mirrors read mode's
+ *  `PMD_READ_MODE_TOGGLE`). The value is unused; `build` re-reads the setting
+ *  itself, so the transaction is purely a rebuild nudge. */
+export const MARK_UNREAD_TOGGLE = 'pmdMarkUnreadToggle';
+
+/** The decorations for one doc, ignoring the toggle (the plugin gates on the
+ *  setting before calling this). Pure; exported for testing. */
+export function computeUnreadDecorations(doc: PMNode): Decoration[] {
+  const decos: Decoration[] = [];
+  doc.descendants((node, pos) => {
+    const name = node.type.name;
+    // Descend through structural containers (pocket/hat/block) to reach cards.
+    if (name !== 'card' && name !== 'analytic_unit') return true;
+    // Walk this card's text runs in doc order: find the first marker, then
+    // redden every following body run. Tags/cites are skipped, since the
+    // feature is about the *body* you didn't read.
+    let markerEnd = -1;
+    node.descendants((child, offset, parent) => {
+      if (!child.isText || !child.text) return true;
+      const from = pos + 1 + offset;
+      const to = from + child.nodeSize;
+      if (markerEnd < 0) {
+        if (isMarkerText(child)) markerEnd = to; // "after the marked location"
+        return true;
+      }
+      const inBody = parent?.type.name === 'card_body' || parent?.type.name === 'undertag';
+      if (inBody) decos.push(Decoration.inline(from, to, { class: 'pmd-unread' }));
+      return true;
+    });
+    return false; // cards don't nest
+  });
+  return decos;
+}
+
+function build(doc: PMNode): DecorationSet {
+  // OFF (the default) bails before any walk: zero cost for the common case.
+  if (!settings.get('markUnreadAfterMarker')) return DecorationSet.empty;
+  return DecorationSet.create(doc, computeUnreadDecorations(doc));
+}
+
+export const markUnreadPlugin: Plugin<DecorationSet> = new Plugin<DecorationSet>({
+  state: {
+    init(_config, state) {
+      return build(state.doc);
+    },
+    apply(tr, prev, _old, newState) {
+      // Rebuild on doc edits (a marker moved / body changed) and on the
+      // toggle nudge; otherwise (selection-only, unrelated meta) reuse prev.
+      if (tr.getMeta(MARK_UNREAD_TOGGLE) === undefined && !tr.docChanged) return prev;
+      return build(newState.doc);
+    },
+  },
+  props: {
+    decorations(state) {
+      return markUnreadPlugin.getState(state);
+    },
+  },
+});

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -32,6 +32,7 @@ import { Node as PMNode } from 'prosemirror-model';
 import { schema, newHeadingId } from '../schema/index.js';
 import { fromDocxFull, parseNative, serializeNativeAsync, NATIVE_FILE_EXTENSION } from '../index.js';
 import { settings } from './settings.js';
+import { MARK_UNREAD_TOGGLE } from './mark-unread-plugin.js';
 import { getHost, getElectronHost, isSameOpenHandle, type OpenedFile } from './host/index.js';
 import { isFileOpenInAnotherWindow } from './window-coordination.js';
 import { getCommentsState, loadThreads, type Thread } from './comments-plugin.js';
@@ -1100,6 +1101,10 @@ function closeOpenStackDropdown(): void {
   openStackDropdownEl = null;
 }
 
+/** Last-applied value of the global `markUnreadAfterMarker` toggle, so the
+ *  shell only rebuilds pane decorations when it actually flips. */
+let shellLastMarkUnread = settings.get('markUnreadAfterMarker');
+
 class MultiPaneShell {
   private slots: Record<SlotId, Slot>;
   private shellEl: HTMLElement;
@@ -1222,6 +1227,17 @@ class MultiPaneShell {
               'pmd-rm-no-emphasis-borders',
               hideEmphasisBorders,
             );
+          }
+        }
+      }
+      // The mark-unread toggle is settings-driven (a global display pref);
+      // when it flips, nudge every pane's plugin to rebuild. Diff-gated
+      // because the rebuild is O(doc): don't fire on unrelated settings changes.
+      if (s.markUnreadAfterMarker !== shellLastMarkUnread) {
+        shellLastMarkUnread = s.markUnreadAfterMarker;
+        for (const id of SLOT_IDS) {
+          for (const rec of this.slots[id].stack) {
+            rec.view.dispatch(rec.view.state.tr.setMeta(MARK_UNREAD_TOGGLE, true));
           }
         }
       }

--- a/src/editor/reading-marker.ts
+++ b/src/editor/reading-marker.ts
@@ -51,7 +51,8 @@ export function formatMarkerTime(d: Date): string {
   return `${h}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
-function isMarkerText(node: { isText: boolean; marks: readonly { type: { name: string }; attrs: Record<string, unknown> }[] }): boolean {
+/** True when a text node is a reading-position marker run (red `font_color`). */
+export function isMarkerText(node: { isText: boolean; marks: readonly { type: { name: string }; attrs: Record<string, unknown> }[] }): boolean {
   return (
     node.isText &&
     node.marks.some(

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -1670,9 +1670,9 @@ export const SETTING_METADATA: SettingMeta[] = [
   },
   {
     key: 'markUnreadAfterMarker',
-    label: 'Redden card text after a reading marker',
+    label: 'Turn text after a mark red',
     description:
-      "When on, every bit of a card's body text after a reading-position marker turns red, a visual record of the part you didn't reach in the round. Bounded per card: a marker only reddens the rest of its own card. Off by default. Display-only, so it never changes the document or its exports.",
+      "When on, all card body text after a mark turns red, which visually denotes portions you didn't read. This is bounded per card, and is preserved in exported versions of the document.",
     kind: 'toggle',
     category: 'general',
     section: 'Editor behavior',

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -624,6 +624,11 @@ export interface Settings {
    *  the ones around hidden text). Some users prefer the cleanest look
    *  in read mode regardless of what's emphasized. */
   hideEmphasisBordersInReadMode: boolean;
+  /** When true, tint every run of card body text that falls AFTER a
+   *  reading-position marker red, a visual record of what you didn't reach
+   *  in a round. Bounded per-card; display-only (a decoration, never a doc
+   *  edit). See `mark-unread-plugin.ts`. */
+  markUnreadAfterMarker: boolean;
   /** The body-text zoom (50–200%, step 10) any editor OPENS at. The live
    *  per-editor zoom is NOT a setting — it's transient per window / per pane and
    *  resets to this default on reload, so different documents can sit at
@@ -1333,6 +1338,7 @@ const DEFAULTS: Settings = {
   autosaveEnabled: false,
   readMode: false,
   hideEmphasisBordersInReadMode: false,
+  markUnreadAfterMarker: false,
   defaultZoomPct: 100,
   chromeScalePct: 100,
   gestureZoom: false,
@@ -1661,6 +1667,16 @@ export const SETTING_METADATA: SettingMeta[] = [
     kind: 'toggle',
     category: 'general',
     section: 'Editor behavior',
+  },
+  {
+    key: 'markUnreadAfterMarker',
+    label: 'Redden card text after a reading marker',
+    description:
+      "When on, every bit of a card's body text after a reading-position marker turns red, a visual record of the part you didn't reach in the round. Bounded per card: a marker only reddens the rest of its own card. Off by default. Display-only, so it never changes the document or its exports.",
+    kind: 'toggle',
+    category: 'general',
+    section: 'Editor behavior',
+    aliases: ['reading marker', 'unread', 'red text', 'marked'],
   },
   // ─── General ────────────────────────────────────────────────────
   {
@@ -3367,6 +3383,7 @@ function sanitize(s: Settings): Settings {
     autosaveEnabled: !!s.autosaveEnabled,
     readMode: !!s.readMode,
     hideEmphasisBordersInReadMode: !!s.hideEmphasisBordersInReadMode,
+    markUnreadAfterMarker: !!s.markUnreadAfterMarker,
     // A legacy persisted `zoomPct` is deliberately ignored — live body
     // zoom is transient; documents open at this default.
     defaultZoomPct: clamp(Math.round(s.defaultZoomPct / 10) * 10, 50, 200),

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -4382,6 +4382,15 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
 .pmd-read-mode .pmd-rm-hide { display: none; }
 .pmd-read-mode .pmd-rm-keep { display: inline; }
 
+/* "Redden card text after a reading marker" (settings.markUnreadAfterMarker).
+   The mark-unread plugin tags each body run after a marker with `.pmd-unread`.
+   `!important` on both the wrapper and its descendants forces red over any
+   per-run `font_color` inline `style="color:…"` (which is a normal-priority
+   author declaration `!important` beats) regardless of how PM nests the
+   decoration span vs. the mark span. */
+.pmd-unread,
+.pmd-unread * { color: #ff0000 !important; }
+
 /* Images are never read-aloud content — hide them in read mode. */
 .pmd-read-mode img[data-pmd-image],
 .pmd-read-mode .pmd-image-wrap,

--- a/src/export/transform-for-export.ts
+++ b/src/export/transform-for-export.ts
@@ -27,7 +27,9 @@
  */
 
 import type { Node as PMNode, Schema } from 'prosemirror-model';
-import { isReadingMarkerColor } from '../editor/reading-marker.js';
+import { Transform } from 'prosemirror-transform';
+import { isReadingMarkerColor, READING_MARKER_COLOR } from '../editor/reading-marker.js';
+import { computeUnreadDecorations } from '../editor/mark-unread-plugin.js';
 
 export interface ExportTransformOptions {
   includeComments: boolean;
@@ -38,22 +40,51 @@ export interface ExportTransformOptions {
    *  no analytics. Mutually exclusive with the other options (like readMode).
    *  Optional / defaults off so existing callers don't have to opt in. */
   markedCardsOnly?: boolean;
+  /** Bake the display-only "text after a reading marker is red"
+   *  (`markUnreadAfterMarker`) into real `font_color` runs, so the export
+   *  matches what's on screen. Mirror the live setting at the call site;
+   *  off by default so unrelated callers don't have to opt in. */
+  markUnreadAfterMarker?: boolean;
 }
 
 export function transformForExport(
   doc: PMNode,
   opts: ExportTransformOptions,
 ): PMNode {
-  if (opts.readMode) return applyReadModeTransform(doc);
-  if (opts.markedCardsOnly) return extractMarkedCards(doc);
-
-  let out = doc;
-  if (!opts.includeAnalytics) out = stripAnalytics(out);
-  if (!opts.includeUndertags) out = stripUndertags(out);
-  // includeComments needs no doc transform here: the export call site
-  // gates it by withholding the doc's comment threads from the
-  // exporter when off (notes / AI threads have their own flags there).
+  let out: PMNode;
+  if (opts.readMode) out = applyReadModeTransform(doc);
+  else if (opts.markedCardsOnly) out = extractMarkedCards(doc);
+  else {
+    out = doc;
+    if (!opts.includeAnalytics) out = stripAnalytics(out);
+    if (!opts.includeUndertags) out = stripUndertags(out);
+    // includeComments needs no doc transform here: the export call site
+    // gates it by withholding the doc's comment threads from the
+    // exporter when off (notes / AI threads have their own flags there).
+  }
+  // Last, so it colors whatever survived the transforms above.
+  if (opts.markUnreadAfterMarker) out = bakeUnreadRed(out);
   return out;
+}
+
+// ------------------- unread-after-marker red -------------------
+//
+// The `markUnreadAfterMarker` review aid tints body text after a reading
+// marker red via a display-only `.pmd-unread` decoration (see
+// `mark-unread-plugin.ts`) — it never touches the doc, so the exporter can't
+// see it. To make red-on-screen stay red in Word, reuse the plugin's exact
+// walk to get the same ranges, then bake them into real `font_color` FF0000
+// runs. Reused (not re-implemented) so the two can't drift.
+
+function bakeUnreadRed(doc: PMNode): PMNode {
+  const fontColor = doc.type.schema.marks['font_color'];
+  if (!fontColor) return doc;
+  const decos = computeUnreadDecorations(doc);
+  if (decos.length === 0) return doc;
+  const tr = new Transform(doc);
+  const mark = fontColor.create({ color: READING_MARKER_COLOR });
+  for (const d of decos) tr.addMark(d.from, d.to, mark);
+  return tr.doc;
 }
 
 // --------------------------- read mode ---------------------------

--- a/tests/editor/mark-unread-plugin.test.ts
+++ b/tests/editor/mark-unread-plugin.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { schema, newHeadingId } from '../../src/schema/index.js';
+import { READING_MARKER_COLOR } from '../../src/editor/reading-marker.js';
+import { computeUnreadDecorations } from '../../src/editor/mark-unread-plugin.js';
+import type { Node as PMNode } from 'prosemirror-model';
+
+function tag(text: string) {
+  return schema.nodes['tag']!.create({ id: newHeadingId() }, schema.text(text));
+}
+function cardBody(...inline: PMNode[]) {
+  return schema.nodes['card_body']!.create(null, inline);
+}
+function marker() {
+  return schema.text('Marked 7:32', [schema.marks['font_color']!.create({ color: READING_MARKER_COLOR })]);
+}
+function card(...c: PMNode[]) { return schema.nodes['card']!.createChecked(null, c); }
+function makeDoc(...c: PMNode[]) { return schema.nodes['doc']!.createChecked(null, c); }
+
+/** The text each decoration covers, in doc order: the observable behavior. */
+function decoratedText(doc: PMNode): string[] {
+  return computeUnreadDecorations(doc)
+    .sort((a, b) => a.from - b.from)
+    .map((d) => doc.textBetween(d.from, d.to));
+}
+
+describe('computeUnreadDecorations', () => {
+  it('reddens body text after the marker, across paragraphs, within the card', () => {
+    const doc = makeDoc(
+      card(
+        tag('nuclear war causes extinction'),
+        cardBody(schema.text('sentence 1. '), marker(), schema.text(' ')),
+        cardBody(schema.text('sentence 2.')),
+        cardBody(schema.text('sentence 3.')),
+      ),
+    );
+    // "sentence 1." (before the marker) stays; the trailing run of the
+    // marker's paragraph and both following paragraphs go red.
+    expect(decoratedText(doc)).toEqual([' ', 'sentence 2.', 'sentence 3.']);
+  });
+
+  it('does nothing to a card with no marker', () => {
+    const doc = makeDoc(card(tag('T'), cardBody(schema.text('unread but unmarked'))));
+    expect(computeUnreadDecorations(doc)).toEqual([]);
+  });
+
+  it('is bounded per card: a marker in one card never reddens the next', () => {
+    const doc = makeDoc(
+      card(tag('A'), cardBody(schema.text('a1. '), marker()), cardBody(schema.text('a2.'))),
+      card(tag('B'), cardBody(schema.text('b1.')), cardBody(schema.text('b2.'))),
+    );
+    expect(decoratedText(doc)).toEqual(['a2.']);
+  });
+
+  it('leaves the tag and text before the marker uncolored', () => {
+    const doc = makeDoc(
+      card(tag('TAG'), cardBody(schema.text('before '), marker(), schema.text(' after'))),
+    );
+    expect(decoratedText(doc)).toEqual([' after']);
+  });
+});

--- a/tests/export/transform-for-export.test.ts
+++ b/tests/export/transform-for-export.test.ts
@@ -357,3 +357,42 @@ describe('markedCardsOnly transform', () => {
     expect(transformForExport(doc, MARKED).childCount).toBe(0);
   });
 });
+
+// ---- unread-after-marker red bake ---------------------------------
+
+describe('markUnreadAfterMarker bake', () => {
+  const marker = (s: string) =>
+    schema.text(s, [schema.marks['font_color']!.create({ color: 'FF0000' })]);
+
+  /** Which text runs carry a red font_color mark after the transform. */
+  function redRuns(doc: ReturnType<typeof makeDoc>): string[] {
+    const red: string[] = [];
+    doc.descendants((n) => {
+      if (
+        n.isText &&
+        n.marks.some((m) => m.type.name === 'font_color' && (m.attrs['color'] as string).toUpperCase() === 'FF0000')
+      ) {
+        red.push(n.text ?? '');
+      }
+      return true;
+    });
+    return red;
+  }
+
+  const doc = makeDoc(
+    card(tag('T'), cardBody(txt('before. '), marker('Marked 7:32'), txt(' after one.')), cardBody(txt('after two.'))),
+  );
+
+  it('bakes body after the marker into real red runs when on', () => {
+    const out = transformForExport(doc, { ...ALL_ON, markUnreadAfterMarker: true });
+    // Everything from the marker onward is red. The marker run and the body
+    // that follows it in the same paragraph coalesce (identical mark); the
+    // next paragraph's body is its own red run.
+    expect(redRuns(out)).toEqual(['Marked 7:32 after one.', 'after two.']);
+  });
+
+  it('leaves the doc untouched when off (only the marker stays red)', () => {
+    const out = transformForExport(doc, { ...ALL_ON, markUnreadAfterMarker: false });
+    expect(redRuns(out)).toEqual(['Marked 7:32']);
+  });
+});


### PR DESCRIPTION
Adds a togglable setting that visually denotes text after any marker as not being read in a round by changing the text's body color to red. Default is off, and can be accessed in Settings > General > Editor Behavior. 

This hooks in to the existing `isMarkerText` feature, and doesn't add any computational overhead when turned off.

The visual change is preserved on export to .docx.

Tested on web and Mac ARM versions.

<img width="525" height="721" alt="image" src="https://github.com/user-attachments/assets/f99e7714-8a92-4d50-8f93-dd3e5d56a31d" />
