### PR TITLE
Fix: Cmd+Q now actually quits the app on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ changes in each release, written for users of the editor. For
 in-depth rationale and implementation context behind each entry,
 see `DETAILED_CHANGELOG.md`.
 
+## Unreleased
+
+### Fixed
+
+- **⌘Q now actually quits on macOS.** Pressing ⌘Q — or choosing Quit from the
+  app menu — closed CardMirror's windows but left the app running in the dock
+  instead of quitting. It now exits fully once any unsaved-changes prompts are
+  handled. Backing out of a quit (Cancel, or a save that fails) still leaves
+  the app running, the way macOS expects.
+
 ## 0.1.0-beta.10 — 2026-07-07
 
 ### Added

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -5,6 +5,22 @@ behavior, rationale, and (where useful) the implementation context
 behind a change. For a shorter, jargon-free summary of what's new
 in each release, see `CHANGELOG.md`.
 
+## Unreleased
+
+- **⌘Q now quits on macOS** (`apps/desktop/src/main.ts`,
+  `apps/desktop/src/preload.ts`, `src/editor/host/electron-host.ts`,
+  `src/editor/index.ts`). The per-window `close` interception always
+  `preventDefault()`s so the renderer can confirm unsaved work — which aborts
+  the `app.quit()` that ⌘Q (and the app-menu Quit) triggers. The windows then
+  close via `host:close-self`, but `window-all-closed` deliberately no-ops on
+  darwin, leaving the app alive with no windows so ⌘Q appeared to do nothing. A
+  `quitInitiated` flag, set in `before-quit`, now lets `window-all-closed`
+  finish the quit once every window has confirmed. A new `host:close-cancelled`
+  IPC — called from the renderer when a close-request resolves WITHOUT closing
+  (Cancel, or a failed Save / Save As) — clears the flag, so a later ordinary
+  window close still keeps the app in the dock per macOS convention rather than
+  terminating it.
+
 ## 0.1.0-beta.10 — 2026-07-07
 
 - **Live zones (transclusion)** (`schema/nodes.ts`, `transclusion.ts` NEW,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -283,6 +283,20 @@ async function openExternalFile(filePath: string): Promise<void> {
  *  back to the renderer. Cleared whenever a window is gone. */
 const skipCloseConfirm = new Set<number>();
 
+/** True once a genuine app-quit has been initiated (Cmd+Q, the
+ *  app-menu Quit, or the OS asking us to shut down). The window
+ *  `close` interception aborts every quit by design — it always
+ *  `preventDefault()`s so the renderer can confirm unsaved work —
+ *  so on macOS the resulting `window-all-closed` would otherwise
+ *  leave the app alive in the dock with no windows, and Cmd+Q
+ *  would appear to do nothing. We set this in `before-quit` and
+ *  honour it in `window-all-closed` to finish the quit once every
+ *  window has confirmed. Reset when the confirmation flow ends
+ *  WITHOUT closing (Cancel, or a failed Save) via
+ *  `host:close-cancelled`, so a later ordinary window close keeps
+ *  the app running the way macOS expects. */
+let quitInitiated = false;
+
 function createWindow(initialDoc?: InitialDocPayload): BrowserWindow {
   const win = new BrowserWindow({
     width: 1400,
@@ -1487,6 +1501,16 @@ ipcMain.handle('host:close-self', async (event) => {
   }
 });
 
+// The renderer resolved a close-request WITHOUT closing (the user
+// hit Cancel, or a Save/Save As failed). If that close-request was
+// part of a quit, the window is staying open, so the quit is off —
+// clear the intent flag. Otherwise a later ordinary window close
+// would wrongly terminate the app on macOS instead of leaving it
+// alive in the dock.
+ipcMain.handle('host:close-cancelled', () => {
+  quitInitiated = false;
+});
+
 ipcMain.handle(
   'host:mode-switch-journaled',
   (_event, docs: Array<{ uid: string; dirty: boolean }>) => {
@@ -2563,7 +2587,12 @@ void app.whenReady().then(() => {
 });
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit();
+  // Non-darwin: closing the last window quits, as usual. macOS
+  // keeps the app alive when the user merely closes windows —
+  // EXCEPT when a real quit is underway, where the close
+  // interception aborted `app.quit()` and it now falls to us to
+  // finish the job once every window has confirmed and gone.
+  if (process.platform !== 'darwin' || quitInitiated) app.quit();
 });
 
 // Tear down the Fast Debate Paste bridge before the app exits so
@@ -2571,5 +2600,11 @@ app.on('window-all-closed', () => {
 // designed in, but cleaning up our own state means the next launch
 // starts from a known-empty state).
 app.on('before-quit', () => {
+  // Remember that a genuine quit was asked for. The per-window
+  // `close` handlers will `preventDefault()` this quit to confirm
+  // unsaved work; `window-all-closed` reads this flag to actually
+  // exit once the confirmations resolve. Cleared by
+  // `host:close-cancelled` if the user backs out.
+  quitInitiated = true;
   void stopFastPasteBridge();
 });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -353,6 +353,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
    *  please-close handler after journaling. */
   closeSelf: () => ipcRenderer.invoke('host:close-self'),
 
+  /** Tell main that a close-request was resolved WITHOUT closing
+   *  (Cancel, or a failed Save). Lets main drop any pending quit
+   *  intent so a subsequent ordinary window close doesn't quit the
+   *  app on macOS. No-op close-wise; safe to call redundantly. */
+  cancelClose: () => ipcRenderer.invoke('host:close-cancelled'),
+
   /** Mode-switch helper: report the docs this window journaled in
    *  response to a please-close. Main accumulates them so the
    *  surviving window can scope its post-reload auto-recovery to

--- a/src/editor/host/electron-host.ts
+++ b/src/editor/host/electron-host.ts
@@ -236,6 +236,10 @@ interface ElectronAPI {
   onExternalOpen(handler: (payload: { path: string }) => void): () => void;
   journalAndCloseOtherWindows(): Promise<void>;
   closeSelf(): Promise<void>;
+  /** Report that a close-request ended without closing (Cancel or a
+   *  failed Save) so main can drop any pending quit intent. Optional
+   *  so an older preload without the channel is tolerated. */
+  cancelClose?(): Promise<void>;
   /** Optional so an older preload tolerates the mode-switch
    *  doc-list channel being absent. */
   reportModeSwitchJournaled?(docs: Array<{ uid: string; dirty: boolean }>): Promise<void>;
@@ -711,6 +715,12 @@ export class ElectronHost implements Host {
    *  handler after the renderer finishes journaling. */
   async closeSelf(): Promise<void> {
     await api().closeSelf();
+  }
+
+  /** Tell main a close-request was resolved without closing (Cancel
+   *  or a failed Save) so it can drop any pending quit intent. */
+  async cancelClose(): Promise<void> {
+    await api().cancelClose?.();
   }
 
   /** Mode-switch helper: report the docs this window journaled in

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -6640,11 +6640,15 @@ async function handleUserCloseRequest(): Promise<void> {
     case 'save': {
       const ok = await runSaveFlow();
       if (ok) await electronHost.closeSelf();
+      // Save failed — the window stays open, so a quit that was
+      // waiting on this confirmation is off. Let main know.
+      else await electronHost.cancelClose?.();
       return;
     }
     case 'saveAs': {
       const ok = await runSaveAsFlow();
       if (ok) await electronHost.closeSelf();
+      else await electronHost.cancelClose?.();
       return;
     }
     case 'discard': {
@@ -6658,7 +6662,9 @@ async function handleUserCloseRequest(): Promise<void> {
       return;
     }
     case 'cancel':
-      // Window stays open.
+      // Window stays open — cancel any pending app quit so a later
+      // ordinary close doesn't terminate the app on macOS.
+      await electronHost.cancelClose?.();
       return;
   }
 }


### PR DESCRIPTION
## Problem

Pressing ⌘Q (or app-menu → Quit) closed all windows but left CardMirror running in the dock. Root cause: ⌘Q calls `app.quit()`, which tries to close each window, but every window's `close` handler unconditionally `preventDefault()`s to route unsaved-changes confirmation through the renderer — aborting the quit. The renderer confirms and closes via `host:close-self`, then `window-all-closed` deliberately no-ops on darwin, so the app survives with no windows.

## Fix

- `quitInitiated` flag set in `before-quit`; `window-all-closed` now finishes the quit when it's set, in addition to the existing non-darwin case.
- New `host:close-cancelled` IPC clears the flag when a close-request resolves *without* closing (Cancel, or a failed Save/Save As), so a later ordinary window close still keeps the app alive per macOS convention.
- Wired `cancelClose` through preload → electron-host → renderer (`handleUserCloseRequest`), as an optional method so an older preload is tolerated.

## Files

`apps/desktop/src/main.ts`, `apps/desktop/src/preload.ts`, `src/editor/host/electron-host.ts`, `src/editor/index.ts` (+ changelogs)

## Test plan

- ⌘Q, clean doc → app quits
- ⌘Q, dirty doc → Save / Discard → app quits
- ⌘Q, dirty doc → Cancel (or Save fails) → window stays, app stays; later ⌘W closes the window but leaves the app in the dock
- ⌘W on a clean window (no quit) → window closes, app stays in dock (unchanged)
