### PR TITLE
Feat: Add openrouter AI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ see `DETAILED_CHANGELOG.md`.
 Co-editing bug-fix release, focused on the three-pane workspace. (Co-editing
 remains **experimental** — keep your own saved copies.)
 
+### Added
+
+- **AI features can now use OpenRouter** as an inference provider, alongside the
+  Anthropic API. Pick the provider under **Settings → Comments & AI → AI
+  provider**. OpenRouter needs its own API key and a model id (for example
+  `anthropic/claude-sonnet-4.6`); there is no built-in default, so set the model
+  before using AI features.
+
 ### Changed
 
 - **Switching between single-pane and three-pane now closes co-editing

--- a/src/editor/ai/cite-creator.ts
+++ b/src/editor/ai/cite-creator.ts
@@ -28,7 +28,7 @@ import { Selection, TextSelection } from 'prosemirror-state';
 import type { EditorState, Transaction } from 'prosemirror-state';
 import { schema } from '../../schema/index.js';
 import { settings } from '../settings.js';
-import { callAnthropic, AnthropicError } from './anthropic.js';
+import { callLlm, LlmError } from './llm.js';
 import { AiActivity } from './ai-activity.js';
 import { claimRegion } from './edit-coordinator.js';
 import { showToast } from '../toast.js';
@@ -399,7 +399,7 @@ export function runAiCreateCite(view: EditorView): void {
 
   void (async () => {
     try {
-      const reply = await callAnthropic({
+      const reply = await callLlm({
         apiKey,
         system: systemPrompt,
         messages: [{ role: 'user', content: raw }],
@@ -415,7 +415,7 @@ export function runAiCreateCite(view: EditorView): void {
       }
       applyCiteToSelection(view, region.from, region.to, parsed, (tr) => lease.apply(tr));
     } catch (e) {
-      if (e instanceof AnthropicError) {
+      if (e instanceof LlmError) {
         showToast(`Cite: ${e.message}`);
       } else {
         showToast(`Cite: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/editor/ai/cite-creator.ts
+++ b/src/editor/ai/cite-creator.ts
@@ -366,7 +366,7 @@ export function runAiCreateCite(view: EditorView): void {
   }
   const apiKey = activeApiKey();
   if (!apiKey) {
-    showToast('Set an Anthropic API key in Settings to use AI features.');
+    showToast('Set an API key in Settings to use AI features.');
     return;
   }
   const { state } = view;

--- a/src/editor/ai/cite-creator.ts
+++ b/src/editor/ai/cite-creator.ts
@@ -28,7 +28,7 @@ import { Selection, TextSelection } from 'prosemirror-state';
 import type { EditorState, Transaction } from 'prosemirror-state';
 import { schema } from '../../schema/index.js';
 import { settings } from '../settings.js';
-import { callLlm, LlmError } from './llm.js';
+import { callLlm, LlmError, activeApiKey } from './llm.js';
 import { AiActivity } from './ai-activity.js';
 import { claimRegion } from './edit-coordinator.js';
 import { showToast } from '../toast.js';
@@ -364,7 +364,7 @@ export function runAiCreateCite(view: EditorView): void {
     showToast('AI features are disabled — enable them in Settings.');
     return;
   }
-  const apiKey = settings.get('anthropicApiKey').trim();
+  const apiKey = activeApiKey();
   if (!apiKey) {
     showToast('Set an Anthropic API key in Settings to use AI features.');
     return;

--- a/src/editor/ai/explain-context.ts
+++ b/src/editor/ai/explain-context.ts
@@ -10,7 +10,7 @@
 
 import type { EditorState } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
-import { VISION_MEDIA_TYPES, type AnthropicContentBlock } from './anthropic.js';
+import { VISION_MEDIA_TYPES, type LlmContentBlock } from './llm.js';
 
 /** Max images sent to the model per request, to bound vision-token cost
  *  on large selections. */
@@ -208,10 +208,10 @@ export function formatExplainPrompt(
 export function formatExplainFirstTurn(
   question: string,
   ctx: ExplainContext,
-): string | AnthropicContentBlock[] {
+): string | LlmContentBlock[] {
   const text = formatExplainPrompt(question, ctx);
   if (ctx.images.length === 0) return text;
-  const blocks: AnthropicContentBlock[] = ctx.images.map((img) => ({
+  const blocks: LlmContentBlock[] = ctx.images.map((img) => ({
     type: 'image',
     source: { type: 'base64', media_type: img.mediaType, data: img.data },
   }));

--- a/src/editor/ai/flashcard-gen.ts
+++ b/src/editor/ai/flashcard-gen.ts
@@ -23,7 +23,7 @@
  *     concise; Q&A over cloze by default).
  */
 
-import { callAnthropic, AnthropicError } from './anthropic.js';
+import { callLlm, LlmError } from './llm.js';
 import type { ExplainContext } from './explain-context.js';
 import type { NewCardDef } from '../learn-create-ui.js';
 
@@ -162,21 +162,21 @@ export function parseFlashcardReply(text: string): NewCardDef | null {
   return { type, front, back };
 }
 
-/** Request one flashcard for an AI thread. Throws `AnthropicError` on a
+/** Request one flashcard for an AI thread. Throws `LlmError` on a
  *  failed call or an unparseable reply. */
 export async function requestFlashcard(
   apiKey: string,
   ctx: ExplainContext,
   turns: FlashcardTurn[],
 ): Promise<NewCardDef> {
-  const reply = await callAnthropic({
+  const reply = await callLlm({
     apiKey,
     system: FLASHCARD_SYSTEM_PROMPT,
     messages: [{ role: 'user', content: formatFlashcardPrompt(ctx, turns) }],
   });
   const card = parseFlashcardReply(reply.text);
   if (!card) {
-    throw new AnthropicError("Couldn't read a flashcard from the AI's reply.", null, 'parse');
+    throw new LlmError("Couldn't read a flashcard from the AI's reply.", null, 'parse');
   }
   return card;
 }

--- a/src/editor/ai/image-ai.ts
+++ b/src/editor/ai/image-ai.ts
@@ -30,11 +30,11 @@ import {
 import { showToast } from '../toast.js';
 import { promptForChoice } from '../text-prompt.js';
 import {
-  AnthropicError,
-  callAnthropic,
+  LlmError,
+  callLlm,
   VISION_MEDIA_TYPES,
-  type AnthropicContentBlock,
-} from './anthropic.js';
+  type LlmContentBlock,
+} from './llm.js';
 import { AiActivity } from './ai-activity.js';
 import { claimRegion } from './edit-coordinator.js';
 
@@ -299,14 +299,14 @@ function runAiAltTextRequest(
 
   void (async () => {
     try {
-      const userContent: AnthropicContentBlock[] = [];
+      const userContent: LlmContentBlock[] = [];
       if (contextText) userContent.push({ type: 'text', text: contextText });
       userContent.push({
         type: 'image',
         source: { type: 'base64', media_type: contentType, data },
       });
       userContent.push({ type: 'text', text: 'Write the alt text for this image.' });
-      const reply = await callAnthropic({
+      const reply = await callLlm({
         apiKey,
         system: ALT_TEXT_SYSTEM_PROMPT,
         messages: [{ role: 'user', content: userContent }],
@@ -330,7 +330,7 @@ function runAiAltTextRequest(
       }
       applyAltTextResult(view, region.from, altText, { writeAttribute: true }, (tr) => lease.apply(tr));
     } catch (err) {
-      if (err instanceof AnthropicError) {
+      if (err instanceof LlmError) {
         showToast(`Alt text: ${err.message}`);
       } else {
         showToast(`Alt text: ${err instanceof Error ? err.message : String(err)}`);
@@ -507,7 +507,7 @@ export function runGenerateTable(
 
   void (async () => {
     try {
-      const reply = await callAnthropic({
+      const reply = await callLlm({
         apiKey,
         system: TABLE_SYSTEM_PROMPT,
         // Big headroom — a large table is a lot of JSON, and a low
@@ -538,7 +538,7 @@ export function runGenerateTable(
         // Hand the broken output to a second pass to reformat into the
         // schema — a text-only call (no image), purely a formatting fix.
         // The "Thinking…" tooltip stays up across both calls.
-        const repair = await callAnthropic({
+        const repair = await callLlm({
           apiKey,
           system: TABLE_REPAIR_SYSTEM_PROMPT,
           maxTokens: 16384,
@@ -576,7 +576,7 @@ export function runGenerateTable(
       const tr = view.state.tr.insert(target.insertPos, tableNode);
       lease.apply(tr.scrollIntoView());
     } catch (err) {
-      if (err instanceof AnthropicError) {
+      if (err instanceof LlmError) {
         showToast(`Table: ${err.message}`);
       } else {
         showToast(`Table: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/editor/ai/image-ai.ts
+++ b/src/editor/ai/image-ai.ts
@@ -34,6 +34,7 @@ import {
   callLlm,
   VISION_MEDIA_TYPES,
   type LlmContentBlock,
+  activeApiKey,
 } from './llm.js';
 import { AiActivity } from './ai-activity.js';
 import { claimRegion } from './edit-coordinator.js';
@@ -60,7 +61,7 @@ function preflight(): string | null {
     showToast('AI features are disabled — enable them in Settings.');
     return null;
   }
-  const apiKey = settings.get('anthropicApiKey').trim();
+  const apiKey = activeApiKey();
   if (!apiKey) {
     showToast('Set an Anthropic API key in Settings to use AI features.');
     return null;

--- a/src/editor/ai/image-ai.ts
+++ b/src/editor/ai/image-ai.ts
@@ -63,7 +63,7 @@ function preflight(): string | null {
   }
   const apiKey = activeApiKey();
   if (!apiKey) {
-    showToast('Set an Anthropic API key in Settings to use AI features.');
+    showToast('Set an API key in Settings to use AI features.');
     return null;
   }
   return apiKey;

--- a/src/editor/ai/llm.ts
+++ b/src/editor/ai/llm.ts
@@ -112,6 +112,58 @@ export class LlmError extends Error {
   }
 }
 
+type OpenRouterBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } };
+
+interface OpenRouterMessage {
+  role: string;
+  content: string | OpenRouterBlock[];
+}
+
+function toOpenRouterContent(content: string | LlmContentBlock[]): string | OpenRouterBlock[] {
+  if (typeof content === 'string') return content;
+  return content.map((b): OpenRouterBlock =>
+    b.type === 'text'
+      ? { type: 'text', text: b.text }
+      : {
+          type: 'image_url',
+          image_url: { url: `data:${b.source.media_type};base64,${b.source.data}` },
+        },
+  );
+}
+
+/** Translate an Anthropic-shaped request's system + messages into the
+ *  OpenRouter (OpenAI-chat) message array: the top-level `system` field
+ *  becomes a leading `system` message, image blocks become `image_url`
+ *  data URLs. Exported for testing. */
+export function toOpenRouterMessages(req: LlmRequest): OpenRouterMessage[] {
+  const msgs: OpenRouterMessage[] = [];
+  if (req.system) msgs.push({ role: 'system', content: req.system });
+  for (const m of req.messages) {
+    msgs.push({ role: m.role, content: toOpenRouterContent(m.content) });
+  }
+  return msgs;
+}
+
+/** Parse an OpenRouter chat-completions response into `LlmReply`.
+ *  Maps `finish_reason: 'length'` to `'max_tokens'` so callers' truncation
+ *  checks (`stopReason === 'max_tokens'`) keep working. Exported for testing. */
+export function parseOpenRouterReply(json: unknown): LlmReply {
+  const choice = (
+    json as {
+      choices?: Array<{ message?: { content?: string }; finish_reason?: string }>;
+    }
+  )?.choices?.[0];
+  const text = choice?.message?.content ?? '';
+  if (!text) {
+    throw new LlmError('OpenRouter returned an empty response.', null, 'parse');
+  }
+  const fr = choice?.finish_reason;
+  const stopReason = fr === 'length' ? 'max_tokens' : fr;
+  return { text, stopReason };
+}
+
 export async function callLlm(req: LlmRequest): Promise<LlmReply> {
   if (!req.apiKey || !req.apiKey.trim()) {
     throw new LlmError(

--- a/src/editor/ai/llm.ts
+++ b/src/editor/ai/llm.ts
@@ -1,6 +1,6 @@
 /**
- * Minimal Anthropic Messages API client.
- *
+ * LLM client. Dispatches on the `aiProvider` setting between the
+ * Anthropic Messages API and OpenRouter (OpenAI-chat-compatible).
  * Browser-direct calls — the user's API key lives in local settings
  * and is sent on every request from the client. Documented as a
  * security tradeoff in PROJECT.md; users opt in by enabling AI
@@ -14,7 +14,7 @@ import { settings } from '../settings.js';
  *  block-array form: `[{ type: 'text', text }, { type: 'image', ... }]`.
  *  Block ordering matters — Anthropic recommends placing images
  *  before the text instruction in multimodal prompts. */
-export type AnthropicContentBlock =
+export type LlmContentBlock =
   | { type: 'text'; text: string }
   | {
       type: 'image';
@@ -39,12 +39,12 @@ export const VISION_MEDIA_TYPES: ReadonlySet<string> = new Set([
   'image/webp',
 ]);
 
-export interface AnthropicMessage {
+export interface LlmMessage {
   role: 'user' | 'assistant';
-  content: string | AnthropicContentBlock[];
+  content: string | LlmContentBlock[];
 }
 
-export interface AnthropicRequest {
+export interface LlmRequest {
   apiKey: string;
   /** Default `claude-sonnet-4-6`; callers can override. */
   model?: string;
@@ -55,10 +55,10 @@ export interface AnthropicRequest {
   temperature?: number;
   /** System prompt. Falls back to the explainer-flavored default. */
   system?: string;
-  messages: AnthropicMessage[];
+  messages: LlmMessage[];
 }
 
-export interface AnthropicReply {
+export interface LlmReply {
   text: string;
   /** The API's `stop_reason` — `'max_tokens'` means the output was
    *  truncated by the token limit (i.e. likely invalid/cut-off JSON). */
@@ -93,7 +93,7 @@ export function resolveAiModel(): string {
 /** Custom error so callers can branch on AI-specific failures
  *  (missing key, auth error, rate limit, retired model, generic network)
  *  without parsing string messages. */
-export class AnthropicError extends Error {
+export class LlmError extends Error {
   constructor(
     message: string,
     /** HTTP status when the call reached the server, else `null`. */
@@ -108,13 +108,13 @@ export class AnthropicError extends Error {
       | 'model',
   ) {
     super(message);
-    this.name = 'AnthropicError';
+    this.name = 'LlmError';
   }
 }
 
-export async function callAnthropic(req: AnthropicRequest): Promise<AnthropicReply> {
+export async function callLlm(req: LlmRequest): Promise<LlmReply> {
   if (!req.apiKey || !req.apiKey.trim()) {
-    throw new AnthropicError(
+    throw new LlmError(
       'Anthropic API key is not set — open Settings to add one.',
       null,
       'no-key',
@@ -145,7 +145,7 @@ export async function callAnthropic(req: AnthropicRequest): Promise<AnthropicRep
       body: JSON.stringify(body),
     });
   } catch (e) {
-    throw new AnthropicError(
+    throw new LlmError(
       `Network error contacting Anthropic: ${e instanceof Error ? e.message : String(e)}`,
       null,
       'network',
@@ -170,7 +170,7 @@ export async function callAnthropic(req: AnthropicRequest): Promise<AnthropicRep
       res.status === 404 ||
       (res.status >= 400 && res.status < 500 && /\bmodel\b/i.test(detail));
     if (looksLikeModelError) {
-      throw new AnthropicError(
+      throw new LlmError(
         `The AI model "${requestedModel}" was rejected by Anthropic — it may have been retired. ` +
           `Update CardMirror to the latest version, or, if you'd rather not update the whole app, ` +
           `set a newer model under Settings → Comments & AI → AI model.`,
@@ -178,9 +178,9 @@ export async function callAnthropic(req: AnthropicRequest): Promise<AnthropicRep
         'model',
       );
     }
-    const kind: AnthropicError['kind'] =
+    const kind: LlmError['kind'] =
       res.status === 401 ? 'auth' : res.status === 429 ? 'rate-limit' : 'server';
-    throw new AnthropicError(
+    throw new LlmError(
       `Anthropic API returned ${res.status}${detail ? `: ${detail}` : ''}`,
       res.status,
       kind,
@@ -191,7 +191,7 @@ export async function callAnthropic(req: AnthropicRequest): Promise<AnthropicRep
   try {
     json = await res.json();
   } catch (e) {
-    throw new AnthropicError(
+    throw new LlmError(
       `Failed to parse Anthropic response: ${e instanceof Error ? e.message : String(e)}`,
       res.status,
       'parse',
@@ -209,7 +209,7 @@ export async function callAnthropic(req: AnthropicRequest): Promise<AnthropicRep
     .map((c) => c.text ?? '')
     .join('');
   if (!text) {
-    throw new AnthropicError('Anthropic returned an empty response.', res.status, 'parse');
+    throw new LlmError('Anthropic returned an empty response.', res.status, 'parse');
   }
   const stopReason = (json as { stop_reason?: string })?.stop_reason;
   return { text, stopReason };

--- a/src/editor/ai/llm.ts
+++ b/src/editor/ai/llm.ts
@@ -82,12 +82,35 @@ function isPlausibleModelId(s: string): boolean {
   return /^[A-Za-z0-9][A-Za-z0-9._-]{2,}$/.test(s);
 }
 
-/** The model the app should use: the user's `aiModelOverride` when it
- *  looks valid, otherwise `DEFAULT_MODEL`. Single resolver so every AI
+/** The model the app should use: for OpenRouter, the user's configured
+ *  `openrouterModel` verbatim; for Anthropic, the `aiModelOverride` when
+ *  it looks valid, otherwise `DEFAULT_MODEL`. Single resolver so every AI
  *  feature (cite, explain, translate, flashcards, image) stays in sync. */
 export function resolveAiModel(): string {
+  if (settings.get('aiProvider') === 'openrouter') {
+    return settings.get('openrouterModel').trim();
+  }
   const override = (settings.get('aiModelOverride') || '').trim();
   return isPlausibleModelId(override) ? override : DEFAULT_MODEL;
+}
+
+/** The API key for the currently selected provider, trimmed. Single
+ *  source so every AI feature reads the right key when the provider
+ *  changes. */
+export function activeApiKey(): string {
+  const key =
+    settings.get('aiProvider') === 'openrouter'
+      ? settings.get('openrouterApiKey')
+      : settings.get('anthropicApiKey');
+  return key.trim();
+}
+
+/** Whether AI features are usable right now: master switch on AND the
+ *  active provider has a key. (An OpenRouter key with no model still
+ *  reads as configured; the missing model surfaces as a friendly error
+ *  on use, mirroring how a retired Claude id already behaves.) */
+export function aiConfigured(): boolean {
+  return settings.get('aiFeaturesEnabled') && activeApiKey() !== '';
 }
 
 /** Custom error so callers can branch on AI-specific failures
@@ -164,15 +187,7 @@ export function parseOpenRouterReply(json: unknown): LlmReply {
   return { text, stopReason };
 }
 
-export async function callLlm(req: LlmRequest): Promise<LlmReply> {
-  if (!req.apiKey || !req.apiKey.trim()) {
-    throw new LlmError(
-      'Anthropic API key is not set — open Settings to add one.',
-      null,
-      'no-key',
-    );
-  }
-
+async function callAnthropicApi(req: LlmRequest): Promise<LlmReply> {
   const requestedModel = req.model ?? resolveAiModel();
   const body = {
     model: requestedModel,
@@ -265,4 +280,88 @@ export async function callLlm(req: LlmRequest): Promise<LlmReply> {
   }
   const stopReason = (json as { stop_reason?: string })?.stop_reason;
   return { text, stopReason };
+}
+
+async function callOpenRouter(req: LlmRequest): Promise<LlmReply> {
+  const model = req.model ?? resolveAiModel();
+  if (!model) {
+    throw new LlmError(
+      'No OpenRouter model is set - add one under Settings -> Comments & AI -> ' +
+        'OpenRouter model (e.g. anthropic/claude-sonnet-4.6).',
+      null,
+      'model',
+    );
+  }
+  const body = {
+    model,
+    max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
+    ...(req.temperature != null ? { temperature: req.temperature } : {}),
+    messages: toOpenRouterMessages(req),
+  };
+
+  let res: Response;
+  try {
+    res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${req.apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    throw new LlmError(
+      `Network error contacting OpenRouter: ${e instanceof Error ? e.message : String(e)}`,
+      null,
+      'network',
+    );
+  }
+
+  if (!res.ok) {
+    let detail = '';
+    try {
+      const payload = (await res.json()) as { error?: { message?: string } };
+      detail = payload?.error?.message ?? '';
+    } catch {
+      // Body wasn't JSON. Fall back to status.
+    }
+    const looksLikeModelError =
+      res.status === 404 || (res.status >= 400 && res.status < 500 && /\bmodel\b/i.test(detail));
+    if (looksLikeModelError) {
+      throw new LlmError(
+        `The AI model "${model}" was rejected by OpenRouter - check the model id under ` +
+          `Settings -> Comments & AI -> OpenRouter model.`,
+        res.status,
+        'model',
+      );
+    }
+    const kind: LlmError['kind'] =
+      res.status === 401 ? 'auth' : res.status === 429 ? 'rate-limit' : 'server';
+    throw new LlmError(
+      `OpenRouter API returned ${res.status}${detail ? `: ${detail}` : ''}`,
+      res.status,
+      kind,
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch (e) {
+    throw new LlmError(
+      `Failed to parse OpenRouter response: ${e instanceof Error ? e.message : String(e)}`,
+      res.status,
+      'parse',
+    );
+  }
+  return parseOpenRouterReply(json);
+}
+
+export async function callLlm(req: LlmRequest): Promise<LlmReply> {
+  if (!req.apiKey || !req.apiKey.trim()) {
+    throw new LlmError('API key is not set - open Settings to add one.', null, 'no-key');
+  }
+  return settings.get('aiProvider') === 'openrouter'
+    ? callOpenRouter(req)
+    : callAnthropicApi(req);
 }

--- a/src/editor/ai/llm.ts
+++ b/src/editor/ai/llm.ts
@@ -71,8 +71,20 @@ export interface LlmReply {
  *  it usually needs no change. Users can also override per-install via
  *  the `aiModelOverride` setting (see `resolveAiModel`). */
 export const DEFAULT_MODEL = 'claude-sonnet-4-6';
-const DEFAULT_MAX_TOKENS = 1024;
+/** Floor for the user-configurable output budget. Reasoning models
+ *  count hidden thinking tokens against `max_tokens`, so anything below
+ *  this can leave no room for the actual reply (empty content, a
+ *  `finish_reason: length` cut-off). */
+const MIN_MAX_TOKENS = 1024;
 const ANTHROPIC_VERSION = '2023-06-01';
+
+/** The output-token ceiling for calls that don't set their own, from the
+ *  `aiMaxTokens` setting and never below the floor. Shared by both
+ *  providers so cite/explain/flashcards/image-alt behave the same. */
+function defaultMaxTokens(): number {
+  const n = Math.round(settings.get('aiMaxTokens'));
+  return Number.isFinite(n) ? Math.max(MIN_MAX_TOKENS, n) : MIN_MAX_TOKENS;
+}
 
 /** Loosely validate a model id before trusting a user override: no
  *  whitespace, a plausible length, and only the characters model ids use.
@@ -179,10 +191,22 @@ export function parseOpenRouterReply(json: unknown): LlmReply {
     }
   )?.choices?.[0];
   const text = choice?.message?.content ?? '';
+  const fr = choice?.finish_reason;
   if (!text) {
+    // A reasoning model can spend the entire token budget on hidden
+    // thinking and return empty content with finish_reason: 'length'.
+    // Point the user at the fix rather than a bare "empty response".
+    if (fr === 'length') {
+      throw new LlmError(
+        'The model used its whole token budget on reasoning and returned no text. ' +
+          'Raise "Max output tokens" under Settings -> Comments & AI (reasoning ' +
+          'models need a higher value), or pick a non-reasoning model.',
+        null,
+        'parse',
+      );
+    }
     throw new LlmError('OpenRouter returned an empty response.', null, 'parse');
   }
-  const fr = choice?.finish_reason;
   const stopReason = fr === 'length' ? 'max_tokens' : fr;
   return { text, stopReason };
 }
@@ -191,7 +215,7 @@ async function callAnthropicApi(req: LlmRequest): Promise<LlmReply> {
   const requestedModel = req.model ?? resolveAiModel();
   const body = {
     model: requestedModel,
-    max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
+    max_tokens: req.maxTokens ?? defaultMaxTokens(),
     ...(req.temperature != null ? { temperature: req.temperature } : {}),
     ...(req.system ? { system: req.system } : {}),
     messages: req.messages,
@@ -294,7 +318,7 @@ async function callOpenRouter(req: LlmRequest): Promise<LlmReply> {
   }
   const body = {
     model,
-    max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
+    max_tokens: req.maxTokens ?? defaultMaxTokens(),
     ...(req.temperature != null ? { temperature: req.temperature } : {}),
     messages: toOpenRouterMessages(req),
   };

--- a/src/editor/ai/repair-formatting.ts
+++ b/src/editor/ai/repair-formatting.ts
@@ -30,7 +30,7 @@ import type { EditorState, Transaction } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
 import { schema } from '../../schema/index.js';
 import { settings } from '../settings.js';
-import { callAnthropic, AnthropicError } from './anthropic.js';
+import { callLlm, LlmError } from './llm.js';
 import { salvageJson, extractJsonObjects } from './repair-text.js';
 import { showToast } from '../toast.js';
 import { AiActivity } from './ai-activity.js';
@@ -620,7 +620,7 @@ export function runRepairFormatting(view: EditorView): void {
               s.samples.map((x) => JSON.stringify(x)).join(', '),
           );
         }
-        const reply = await callAnthropic({
+        const reply = await callLlm({
           apiKey,
           system: DEFAULT_FORMAT_REPAIR_PROMPT,
           messages: [{ role: 'user', content: buildCardRequest(analysis) }],
@@ -684,7 +684,7 @@ export function runRepairFormatting(view: EditorView): void {
       );
     } catch (e) {
       console.warn(`[repair-fmt] error: ${e instanceof Error ? e.message : String(e)}`);
-      if (e instanceof AnthropicError) showToast(`Repair formatting: ${e.message}`);
+      if (e instanceof LlmError) showToast(`Repair formatting: ${e.message}`);
       else showToast(`Repair formatting: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       activity.stop();

--- a/src/editor/ai/repair-formatting.ts
+++ b/src/editor/ai/repair-formatting.ts
@@ -577,7 +577,7 @@ export function runRepairFormatting(view: EditorView): void {
   }
   const apiKey = activeApiKey();
   if (!apiKey) {
-    showToast('Set an Anthropic API key in Settings to use AI features.');
+    showToast('Set an API key in Settings to use AI features.');
     return;
   }
   const sel = view.state.selection;

--- a/src/editor/ai/repair-formatting.ts
+++ b/src/editor/ai/repair-formatting.ts
@@ -30,7 +30,7 @@ import type { EditorState, Transaction } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
 import { schema } from '../../schema/index.js';
 import { settings } from '../settings.js';
-import { callLlm, LlmError } from './llm.js';
+import { callLlm, LlmError, activeApiKey } from './llm.js';
 import { salvageJson, extractJsonObjects } from './repair-text.js';
 import { showToast } from '../toast.js';
 import { AiActivity } from './ai-activity.js';
@@ -575,7 +575,7 @@ export function runRepairFormatting(view: EditorView): void {
     showToast('AI features are disabled — enable them in Settings.');
     return;
   }
-  const apiKey = settings.get('anthropicApiKey').trim();
+  const apiKey = activeApiKey();
   if (!apiKey) {
     showToast('Set an Anthropic API key in Settings to use AI features.');
     return;

--- a/src/editor/ai/repair-text.ts
+++ b/src/editor/ai/repair-text.ts
@@ -22,7 +22,7 @@ import { Selection } from 'prosemirror-state';
 import type { EditorState, Transaction } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
 import { settings } from '../settings.js';
-import { callAnthropic, AnthropicError } from './anthropic.js';
+import { callLlm, LlmError } from './llm.js';
 import { showToast } from '../toast.js';
 import { AiActivity } from './ai-activity.js';
 import { claimRegion, type EditLease } from './edit-coordinator.js';
@@ -612,7 +612,7 @@ async function fetchFixes(
 ): Promise<{ fixesReturned: number; located: LocatedFix[]; skipped: number }> {
   const flat = flattenSelection(view.state.doc, from, to);
   if (!flat.text.trim()) return { fixesReturned: 0, located: [], skipped: 0 };
-  const reply = await callAnthropic({
+  const reply = await callLlm({
     apiKey,
     system: DEFAULT_REPAIR_PROMPT,
     messages: [{ role: 'user', content: flat.text }],
@@ -799,7 +799,7 @@ export function runRepairText(view: EditorView): void {
       // Mirror the failure to the console (forwarded to the dev log) —
       // the toast is transient and otherwise leaves no trace to debug.
       console.warn(`[repair] error: ${e instanceof Error ? e.message : String(e)}`);
-      if (e instanceof AnthropicError) showToast(`Repair: ${e.message}`);
+      if (e instanceof LlmError) showToast(`Repair: ${e.message}`);
       else showToast(`Repair: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
       activity.stop();

--- a/src/editor/ai/repair-text.ts
+++ b/src/editor/ai/repair-text.ts
@@ -22,7 +22,7 @@ import { Selection } from 'prosemirror-state';
 import type { EditorState, Transaction } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
 import { settings } from '../settings.js';
-import { callLlm, LlmError } from './llm.js';
+import { callLlm, LlmError, activeApiKey } from './llm.js';
 import { showToast } from '../toast.js';
 import { AiActivity } from './ai-activity.js';
 import { claimRegion, type EditLease } from './edit-coordinator.js';
@@ -702,7 +702,7 @@ export function runRepairText(view: EditorView): void {
     showToast('AI features are disabled — enable them in Settings.');
     return;
   }
-  const apiKey = settings.get('anthropicApiKey').trim();
+  const apiKey = activeApiKey();
   if (!apiKey) {
     showToast('Set an Anthropic API key in Settings to use AI features.');
     return;

--- a/src/editor/ai/repair-text.ts
+++ b/src/editor/ai/repair-text.ts
@@ -704,7 +704,7 @@ export function runRepairText(view: EditorView): void {
   }
   const apiKey = activeApiKey();
   if (!apiKey) {
-    showToast('Set an Anthropic API key in Settings to use AI features.');
+    showToast('Set an API key in Settings to use AI features.');
     return;
   }
   const sel = view.state.selection;

--- a/src/editor/card-cutter-port.ts
+++ b/src/editor/card-cutter-port.ts
@@ -7,7 +7,7 @@
  *
  * Responsibilities, all app-side:
  *  - hold whatever engine registered (registry),
- *  - inject an LlmCaller wrapping the app's browser-direct callAnthropic,
+ *  - inject an LlmCaller wrapping the app's browser-direct callLlm,
  *  - extract tag / cite / body text from the focused card,
  *  - translate the engine's returned mark spans into ONE ProseMirror
  *    transaction (underline / emphasis / highlight), with the highlight
@@ -24,8 +24,8 @@ import type { Node as PMNode } from 'prosemirror-model';
 import { schema } from '../schema/index.js';
 import { settings } from './settings.js';
 import { compileShrinkProtections, findProtectedRanges } from './ribbon-commands.js';
-import { callAnthropic } from './ai/anthropic.js';
-import { resolveAiModel } from './ai/anthropic.js';
+import { callLlm } from './ai/llm.js';
+import { resolveAiModel } from './ai/llm.js';
 import { showToast } from './toast.js';
 import { AiActivity } from './ai/ai-activity.js';
 import { claimRegion, type EditLease } from './ai/edit-coordinator.js';
@@ -215,7 +215,7 @@ export async function tryLoadCardCutterEngine(): Promise<boolean> {
 
 function makeLlm(): LlmCaller {
   return async (system, user, model) => {
-    const reply = await callAnthropic({
+    const reply = await callLlm({
       apiKey: settings.get('anthropicApiKey').trim(),
       model,
       system,

--- a/src/editor/card-cutter-port.ts
+++ b/src/editor/card-cutter-port.ts
@@ -493,7 +493,7 @@ export async function cutFocusedCard(
   }
   const api = engine!;
   if (!activeApiKey()) {
-    showToast('Set an Anthropic API key in Settings to use the card cutter.');
+    showToast('Set an API key in Settings to use the card cutter.');
     return null;
   }
   const focused = focusedPlainCard(view);
@@ -742,7 +742,7 @@ export async function refineHighlightFocusedCard(
     return;
   }
   if (!activeApiKey()) {
-    showToast('Set an Anthropic API key in Settings to use the card cutter.');
+    showToast('Set an API key in Settings to use the card cutter.');
     return;
   }
   const feedback = inv.feedback?.trim() || undefined;
@@ -849,7 +849,7 @@ export async function addHighlightFocusedCard(view: EditorView): Promise<void> {
     return;
   }
   if (!activeApiKey()) {
-    showToast('Set an Anthropic API key in Settings to use the card cutter.');
+    showToast('Set an API key in Settings to use the card cutter.');
     return;
   }
   const focused = focusedPlainCard(view);

--- a/src/editor/card-cutter-port.ts
+++ b/src/editor/card-cutter-port.ts
@@ -24,7 +24,7 @@ import type { Node as PMNode } from 'prosemirror-model';
 import { schema } from '../schema/index.js';
 import { settings } from './settings.js';
 import { compileShrinkProtections, findProtectedRanges } from './ribbon-commands.js';
-import { callLlm } from './ai/llm.js';
+import { callLlm, activeApiKey } from './ai/llm.js';
 import { resolveAiModel } from './ai/llm.js';
 import { showToast } from './toast.js';
 import { AiActivity } from './ai/ai-activity.js';
@@ -216,7 +216,7 @@ export async function tryLoadCardCutterEngine(): Promise<boolean> {
 function makeLlm(): LlmCaller {
   return async (system, user, model) => {
     const reply = await callLlm({
-      apiKey: settings.get('anthropicApiKey').trim(),
+      apiKey: activeApiKey(),
       model,
       system,
       maxTokens: 8000,
@@ -492,7 +492,7 @@ export async function cutFocusedCard(
     }
   }
   const api = engine!;
-  if (!settings.get('anthropicApiKey').trim()) {
+  if (!activeApiKey()) {
     showToast('Set an Anthropic API key in Settings to use the card cutter.');
     return null;
   }
@@ -741,7 +741,7 @@ export async function refineHighlightFocusedCard(
     showToast('Card-cutter engine not loaded.');
     return;
   }
-  if (!settings.get('anthropicApiKey').trim()) {
+  if (!activeApiKey()) {
     showToast('Set an Anthropic API key in Settings to use the card cutter.');
     return;
   }
@@ -848,7 +848,7 @@ export async function addHighlightFocusedCard(view: EditorView): Promise<void> {
     showToast('Card-cutter engine not loaded.');
     return;
   }
-  if (!settings.get('anthropicApiKey').trim()) {
+  if (!activeApiKey()) {
     showToast('Set an Anthropic API key in Settings to use the card cutter.');
     return;
   }

--- a/src/editor/card-cutter-port.ts
+++ b/src/editor/card-cutter-port.ts
@@ -213,6 +213,10 @@ export async function tryLoadCardCutterEngine(): Promise<boolean> {
 
 // ─── LLM injection ────────────────────────────────────────────────
 
+// ponytail: card-cutter forwards bare Anthropic model ids (claude-…) from its
+// engine, so it is effectively Anthropic-only under OpenRouter (OpenRouter needs
+// the "anthropic/…" prefix). Make model selection provider-aware here if the
+// card cutter needs OpenRouter support.
 function makeLlm(): LlmCaller {
   return async (system, user, model) => {
     const reply = await callLlm({

--- a/src/editor/comments-ui.ts
+++ b/src/editor/comments-ui.ts
@@ -20,7 +20,7 @@ import type { EditorView } from 'prosemirror-view';
 import type { Node as PMNode } from 'prosemirror-model';
 import { schema } from '../schema/index.js';
 import { settings } from './settings.js';
-import { callAnthropic, AnthropicError, type AnthropicMessage } from './ai/anthropic.js';
+import { callLlm, LlmError, type LlmMessage } from './ai/llm.js';
 import {
   buildExplainContext,
   formatExplainFirstTurn,
@@ -1396,7 +1396,7 @@ export class CommentsColumn {
     const promptCtx = ctx;
     this.aiContextByThread.set(id, promptCtx);
 
-    const messages = item.comments.flatMap((c, i): AnthropicMessage[] => {
+    const messages = item.comments.flatMap((c, i): LlmMessage[] => {
       if (!c.text.trim()) return [];
       if (c.ai) return [{ role: 'assistant', content: c.text }];
       const isFirstUserTurn = !item.comments.slice(0, i).some((p) => !p.ai && p.text.trim());
@@ -1415,7 +1415,7 @@ export class CommentsColumn {
 
     void (async () => {
       try {
-        const reply = await callAnthropic({ apiKey, system: EXPLAIN_SYSTEM_PROMPT, messages });
+        const reply = await callLlm({ apiKey, system: EXPLAIN_SYSTEM_PROMPT, messages });
         // Drop the in-flight flag BEFORE appending so the store-driven
         // re-render shows the reply without the Thinking… placeholder.
         this.aiInFlight.delete(id);
@@ -1429,7 +1429,7 @@ export class CommentsColumn {
         if (kind === 'ai') learnStore.appendAiComment(id, aiTurn);
         else learnStore.appendNoteComment(id, aiTurn);
       } catch (e) {
-        if (e instanceof AnthropicError) showToast(`AI: ${e.message}`);
+        if (e instanceof LlmError) showToast(`AI: ${e.message}`);
         else showToast(`AI error: ${e instanceof Error ? e.message : String(e)}`);
       } finally {
         this.aiInFlight.delete(id);
@@ -1517,7 +1517,7 @@ export class CommentsColumn {
     try {
       card = await requestFlashcard(apiKey, ctx, turns);
     } catch (e) {
-      if (e instanceof AnthropicError) showToast(`AI: ${e.message}`);
+      if (e instanceof LlmError) showToast(`AI: ${e.message}`);
       else showToast(`AI error: ${e instanceof Error ? e.message : String(e)}`);
       btn.disabled = false;
       btn.textContent = 'Convert to Flashcard';
@@ -2250,7 +2250,7 @@ export class CommentsColumn {
     // the formatted prompt with the surrounding context; later
     // turns are plain. Skip empty bodies defensively (e.g. an
     // empty-root thread that was opened then closed).
-    const messages = thread.comments.flatMap((c, i): AnthropicMessage[] => {
+    const messages = thread.comments.flatMap((c, i): LlmMessage[] => {
       if (!c.text.trim()) return [];
       if (isAiComment(c)) {
         return [{ role: 'assistant', content: c.text }];
@@ -2291,7 +2291,7 @@ export class CommentsColumn {
 
     void (async () => {
       try {
-        const reply = await callAnthropic({
+        const reply = await callLlm({
           apiKey,
           system: EXPLAIN_SYSTEM_PROMPT,
           messages,
@@ -2314,7 +2314,7 @@ export class CommentsColumn {
         if (!getCommentsState(v2.state).threads.has(threadId)) return;
         v2.dispatch(v2.state.tr.setMeta(commentsKey, addReplyMeta(threadId, aiComment)));
       } catch (e) {
-        if (e instanceof AnthropicError) {
+        if (e instanceof LlmError) {
           showToast(`AI: ${e.message}`);
         } else {
           showToast(`AI error: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/editor/comments-ui.ts
+++ b/src/editor/comments-ui.ts
@@ -1381,7 +1381,7 @@ export class CommentsColumn {
     }
     const apiKey = activeApiKey();
     if (!apiKey) {
-      showToast('Set an Anthropic API key in Settings to use AI features.');
+      showToast('Set an API key in Settings to use AI features.');
       return;
     }
     const item = kind === 'ai' ? learnStore.getAiThread(id) : learnStore.getNote(id);
@@ -1493,7 +1493,7 @@ export class CommentsColumn {
     }
     const apiKey = activeApiKey();
     if (!apiKey) {
-      showToast('Set an Anthropic API key in Settings to use AI features.');
+      showToast('Set an API key in Settings to use AI features.');
       return;
     }
     const thread = learnStore.getAiThread(threadId);
@@ -2228,7 +2228,7 @@ export class CommentsColumn {
     }
     const apiKey = activeApiKey();
     if (!apiKey) {
-      showToast('Set an Anthropic API key in Settings to use AI features.');
+      showToast('Set an API key in Settings to use AI features.');
       return;
     }
     const thread = getCommentsState(view.state).threads.get(threadId);

--- a/src/editor/comments-ui.ts
+++ b/src/editor/comments-ui.ts
@@ -20,7 +20,7 @@ import type { EditorView } from 'prosemirror-view';
 import type { Node as PMNode } from 'prosemirror-model';
 import { schema } from '../schema/index.js';
 import { settings } from './settings.js';
-import { callLlm, LlmError, type LlmMessage } from './ai/llm.js';
+import { callLlm, LlmError, type LlmMessage, activeApiKey } from './ai/llm.js';
 import {
   buildExplainContext,
   formatExplainFirstTurn,
@@ -1379,7 +1379,7 @@ export class CommentsColumn {
       showToast('AI features are disabled — enable them in Settings.');
       return;
     }
-    const apiKey = settings.get('anthropicApiKey').trim();
+    const apiKey = activeApiKey();
     if (!apiKey) {
       showToast('Set an Anthropic API key in Settings to use AI features.');
       return;
@@ -1491,7 +1491,7 @@ export class CommentsColumn {
       showToast('AI features are disabled — enable them in Settings.');
       return;
     }
-    const apiKey = settings.get('anthropicApiKey').trim();
+    const apiKey = activeApiKey();
     if (!apiKey) {
       showToast('Set an Anthropic API key in Settings to use AI features.');
       return;
@@ -2226,7 +2226,7 @@ export class CommentsColumn {
       showToast('AI features are disabled — enable them in Settings.');
       return;
     }
-    const apiKey = settings.get('anthropicApiKey').trim();
+    const apiKey = activeApiKey();
     if (!apiKey) {
       showToast('Set an Anthropic API key in Settings to use AI features.');
       return;

--- a/src/editor/image-context-menu-plugin.ts
+++ b/src/editor/image-context-menu-plugin.ts
@@ -80,7 +80,7 @@ function showImageContextMenu(
   const hasKey = activeApiKey() !== '';
   const aiBlockedReason =
     !aiOn ? 'AI features are disabled — enable them in Settings.'
-    : !hasKey ? 'Set an Anthropic API key in Settings to use AI features.'
+    : !hasKey ? 'Set an API key in Settings to use AI features.'
     : null;
 
   const items: MenuItem[] = [

--- a/src/editor/image-context-menu-plugin.ts
+++ b/src/editor/image-context-menu-plugin.ts
@@ -17,6 +17,7 @@ import type { EditorView } from 'prosemirror-view';
 import type { Node as PMNode } from 'prosemirror-model';
 import { settings } from './settings.js';
 import { runGenerateAltText, runGenerateTable } from './ai/image-ai.js';
+import { activeApiKey } from './ai/llm.js';
 import { promptForText } from './text-prompt.js';
 
 /** PM plugin. Installed via `buildEditorPlugins` so every editor
@@ -76,7 +77,7 @@ function showImageContextMenu(
   closeImageContextMenu();
 
   const aiOn = settings.get('aiFeaturesEnabled');
-  const hasKey = settings.get('anthropicApiKey').trim().length > 0;
+  const hasKey = activeApiKey() !== '';
   const aiBlockedReason =
     !aiOn ? 'AI features are disabled — enable them in Settings.'
     : !hasKey ? 'Set an Anthropic API key in Settings to use AI features.'

--- a/src/editor/mobile-settings-ui.ts
+++ b/src/editor/mobile-settings-ui.ts
@@ -19,6 +19,7 @@ import { confirmDialog } from './text-prompt.js';
 import {
   settings,
   SETTING_METADATA,
+  evalDependsOn,
   type SettingMeta,
   type Settings,
   type SettingsCategory,
@@ -132,7 +133,7 @@ function buildRow(meta: SettingMeta): HTMLElement {
   // dependsOn greying, live (e.g. API-key row follows the AI toggle).
   if (meta.dependsOn) {
     const sync = (): void => {
-      row.classList.toggle('pmd-msettings-disabled', !settings.get(meta.dependsOn!));
+      row.classList.toggle('pmd-msettings-disabled', !evalDependsOn(meta.dependsOn));
     };
     sync();
     pageSubscribe(sync);
@@ -155,6 +156,11 @@ function buildEditor(meta: SettingMeta): HTMLElement {
       return buildSegment(meta.key, ['system', 'on', 'off']);
     case 'saveFormat':
       return buildSegment(meta.key, ['cmir', 'docx'], { cmir: '.cmir', docx: '.docx' });
+    case 'aiProvider':
+      return buildSegment(meta.key, ['anthropic', 'openrouter'], {
+        anthropic: 'Anthropic',
+        openrouter: 'OpenRouter',
+      });
     case 'mobileLayout':
       return buildMobileLayoutSegment();
     case 'displaySizes':

--- a/src/editor/mobile-shell.ts
+++ b/src/editor/mobile-shell.ts
@@ -38,6 +38,7 @@ import {
   type UnitRange,
 } from './structural-move.js';
 import { preciseScrollIntoView } from './precise-scroll.js';
+import { aiConfigured } from './ai/llm.js';
 import { showToast } from './toast.js';
 
 const ZOOM_MIN = ZOOM_MIN_PCT;
@@ -525,7 +526,7 @@ function buildRepairSheet(): HTMLElement {
 }
 
 function aiReady(): boolean {
-  return settings.get('aiFeaturesEnabled') && settings.get('anthropicApiKey').trim() !== '';
+  return aiConfigured();
 }
 
 function showRepairSheet(unit: UnitRange): void {

--- a/src/editor/mobile-shell.ts
+++ b/src/editor/mobile-shell.ts
@@ -543,7 +543,7 @@ function showRepairSheet(unit: UnitRange): void {
   if (!aiReady()) {
     const note = document.createElement('div');
     note.className = 'pmd-mobile-movesheet-label';
-    note.textContent = 'AI repair needs AI features enabled and an Anthropic API key.';
+    note.textContent = 'AI repair needs AI features enabled and an API key.';
     body.appendChild(note);
     const open = document.createElement('button');
     open.type = 'button';

--- a/src/editor/settings-ui.ts
+++ b/src/editor/settings-ui.ts
@@ -20,6 +20,8 @@ import {
   type SettingMeta,
   type SettingsCategory,
   type Settings,
+  type SettingCondition,
+  evalDependsOn,
   type ReaderConfig,
   type DisplaySizes,
   DEFAULT_PARAGRAPH_SPACING,
@@ -208,10 +210,13 @@ class SettingsModal {
    *  when it's the topmost (a dialog opened from here — e.g. the AI
    *  cite-prompt editor — handles its own Escape first). */
   private overlayToken: symbol | null = null;
-  /** Rows whose enabled state is gated on another boolean setting,
-   *  keyed by the setting that drives them. Refilled each open()
-   *  via renderEntry bookkeeping; consumed by `refreshDependents`. */
-  private dependentRows: Map<keyof Settings, HTMLElement[]> = new Map();
+  /** Rows whose enabled state is gated on a `dependsOn` condition.
+   *  Refilled each open() via renderEntry bookkeeping; consumed by
+   *  `refreshDependents`. */
+  private dependentRows: Array<{
+    row: HTMLElement;
+    dependsOn: SettingCondition | readonly SettingCondition[];
+  }> = [];
   /** Unsubscribe handle returned by `settings.subscribe` while the
    *  dialog is open. Cleared on close. */
   private settingsUnsubscribe: (() => void) | null = null;
@@ -432,7 +437,7 @@ class SettingsModal {
     // Panels — one per category. Only the active panel is visible
     // (set via `hidden`); we build all of them up-front so the
     // refreshDependents pass can find rows under inactive tabs too.
-    this.dependentRows.clear();
+    this.dependentRows = [];
     const panels: Partial<Record<SettingsCategory, HTMLDivElement>> = {};
     for (const { id } of visibleCategoryTabs()) {
       const panel = document.createElement('div');
@@ -461,9 +466,7 @@ class SettingsModal {
         lastSection = meta.section;
         const row = this.renderEntry(meta);
         if (meta.dependsOn) {
-          const bucket = this.dependentRows.get(meta.dependsOn) ?? [];
-          bucket.push(row);
-          this.dependentRows.set(meta.dependsOn, bucket);
+          this.dependentRows.push({ row, dependsOn: meta.dependsOn });
         }
         panel.appendChild(row);
       }
@@ -604,15 +607,13 @@ class SettingsModal {
    *  disables every input / button inside those rows so the controls
    *  don't fire events while the row reads as "off". */
   private refreshDependents(): void {
-    for (const [parentKey, rows] of this.dependentRows) {
-      const enabled = Boolean(settings.get(parentKey));
-      for (const row of rows) {
-        row.classList.toggle('pmd-settings-row-disabled', !enabled);
-        const controls = row.querySelectorAll<HTMLInputElement | HTMLButtonElement | HTMLTextAreaElement | HTMLSelectElement>(
-          'input, button, textarea, select',
-        );
-        for (const c of controls) c.disabled = !enabled;
-      }
+    for (const { row, dependsOn } of this.dependentRows) {
+      const enabled = evalDependsOn(dependsOn);
+      row.classList.toggle('pmd-settings-row-disabled', !enabled);
+      const controls = row.querySelectorAll<
+        HTMLInputElement | HTMLButtonElement | HTMLTextAreaElement | HTMLSelectElement
+      >('input, button, textarea, select');
+      for (const c of controls) c.disabled = !enabled;
     }
   }
 
@@ -786,6 +787,10 @@ class SettingsModal {
     } else if (meta.kind === 'saveFormat') {
       row.appendChild(text);
       row.appendChild(buildSaveFormatEditor());
+      return row;
+    } else if (meta.kind === 'aiProvider') {
+      row.appendChild(text);
+      row.appendChild(buildAiProviderEditor());
       return row;
     } else if (meta.kind === 'formattingGapClass') {
       row.appendChild(text);
@@ -4521,6 +4526,35 @@ function buildSaveFormatEditor(): HTMLElement {
     labelText.textContent = o.label;
     row.appendChild(labelText);
     wrap.appendChild(row);
+  }
+  return wrap;
+}
+
+function buildAiProviderEditor(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'pmd-multi-doc-layout-mode-editor';
+  const options: { value: 'anthropic' | 'openrouter'; label: string }[] = [
+    { value: 'anthropic', label: 'Anthropic (api.anthropic.com)' },
+    { value: 'openrouter', label: 'OpenRouter (openrouter.ai, OpenAI-compatible)' },
+  ];
+  const groupName = `pmd-ai-provider-${Math.random().toString(36).slice(2, 8)}`;
+  for (const o of options) {
+    const optRow = document.createElement('label');
+    optRow.className = 'pmd-multi-doc-layout-mode-row';
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = groupName;
+    input.value = o.value;
+    input.checked = o.value === settings.get('aiProvider');
+    input.addEventListener('change', () => {
+      if (input.checked) settings.set('aiProvider', o.value);
+    });
+    optRow.appendChild(input);
+    const labelText = document.createElement('span');
+    labelText.className = 'pmd-multi-doc-layout-mode-row-label';
+    labelText.textContent = o.label;
+    optRow.appendChild(labelText);
+    wrap.appendChild(optRow);
   }
   return wrap;
 }

--- a/src/editor/settings-ui.ts
+++ b/src/editor/settings-ui.ts
@@ -758,7 +758,7 @@ class SettingsModal {
       return row;
     } else if (meta.kind === 'number') {
       row.appendChild(text);
-      row.appendChild(buildNumberEditor(meta.key as keyof Settings));
+      row.appendChild(buildNumberEditor(meta.key as keyof Settings, meta.min));
       return row;
     } else if (meta.kind === 'defaultZoomPct') {
       row.appendChild(text);
@@ -3142,15 +3142,15 @@ function buildDefaultZoomEditor(): HTMLElement {
   return input;
 }
 
-function buildNumberEditor(key: keyof Settings): HTMLElement {
+function buildNumberEditor(key: keyof Settings, min = 0): HTMLElement {
   const input = document.createElement('input');
   input.type = 'number';
   input.className = 'pmd-line-height-input';
-  input.min = '0';
+  input.min = String(min);
   input.step = '1';
   input.value = String(settings.get(key));
   input.addEventListener('change', () => {
-    const v = Math.max(0, Math.round(parseFloat(input.value)));
+    const v = Math.max(min, Math.round(parseFloat(input.value)));
     if (!Number.isFinite(v)) {
       input.value = String(settings.get(key));
       return;

--- a/src/editor/settings-ui.ts
+++ b/src/editor/settings-ui.ts
@@ -757,9 +757,10 @@ class SettingsModal {
       row.appendChild(btn);
       return row;
     } else if (meta.kind === 'number') {
-      row.appendChild(text);
-      row.appendChild(buildNumberEditor(meta.key as keyof Settings, meta.min));
-      return row;
+      // Inline: the numeric input sits on the right of the label, like
+      // toggles / text inputs. Falls through to `row.appendChild(label)`
+      // so the description stays width-limited inside the flex row.
+      label.appendChild(buildNumberEditor(meta.key as keyof Settings, meta.min));
     } else if (meta.kind === 'defaultZoomPct') {
       row.appendChild(text);
       row.appendChild(buildDefaultZoomEditor());

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -1584,6 +1584,23 @@ export type SettingsCategory =
   | 'comments-ai'
   | 'pairing';
 
+export type SettingCondition =
+  | keyof Settings
+  | { key: keyof Settings; equals: unknown };
+
+/** Evaluate a row's `dependsOn` against current settings. Bare key →
+ *  truthy check; object → equality; array → conjunction. Undefined → true. */
+export function evalDependsOn(
+  dependsOn: SettingCondition | readonly SettingCondition[] | undefined,
+  get: (key: keyof Settings) => unknown = (k) => settings.get(k),
+): boolean {
+  if (dependsOn === undefined) return true;
+  const conds = Array.isArray(dependsOn) ? dependsOn : [dependsOn as SettingCondition];
+  return conds.every((c) =>
+    typeof c === 'object' ? get(c.key) === c.equals : Boolean(get(c)),
+  );
+}
+
 /**
  * Human-readable metadata for each setting, used by the settings UI.
  * Add new entries when introducing new settings.
@@ -1684,11 +1701,11 @@ export interface SettingMeta {
     | 'pairingReceiveFlash';
   /** Which tab this setting lives under in the settings dialog. */
   category: SettingsCategory;
-  /** When set, this row is greyed out and its controls disabled
-   *  unless the named boolean setting evaluates to true. Used for
-   *  e.g. greying out the multi-doc layout picker when multi-doc is
-   *  off, or AI-key rows when AI features are disabled. */
-  dependsOn?: keyof Settings;
+  /** When set, this row is greyed out and its controls disabled unless
+   *  its condition holds. A bare key means "that boolean setting is
+   *  truthy"; an object means "that setting equals a value"; an array
+   *  means "all of these hold". */
+  dependsOn?: SettingCondition | readonly SettingCondition[];
   /** When true, this setting is only relevant on Electron-style
    *  hosts (real file paths, native dialogs). The settings UI
    *  hides the row entirely on the web edition. */
@@ -2869,20 +2886,32 @@ export const SETTING_METADATA: SettingMeta[] = [
     key: 'aiFeaturesEnabled',
     label: 'Enable AI features',
     description:
-      'Master switch for AI-powered comment features (in-comment "Explain" prompts, @AI mentions). Requires an Anthropic API key below.',
+      'Master switch for AI-powered comment features (in-comment "Explain" prompts, @AI mentions). Requires selecting a provider and pasting its API key below.',
     kind: 'toggle',
     category: 'comments-ai',
     mobile: true,
   },
   {
-    key: 'anthropicApiKey',
-    label: 'Anthropic API key',
+    key: 'aiProvider',
+    label: 'AI provider',
     description:
-      'Used only when AI features are enabled. Stored locally in browser settings; sent only to api.anthropic.com.',
-    kind: 'password',
+      'Which inference service the AI features use. Anthropic talks to the ' +
+      'Anthropic API; OpenRouter talks to openrouter.ai (OpenAI-compatible). ' +
+      'Each provider has its own key below.',
+    kind: 'aiProvider',
     category: 'comments-ai',
     mobile: true,
     dependsOn: 'aiFeaturesEnabled',
+    aliases: ['openrouter', 'provider', 'model provider'],
+  },
+  {
+    key: 'anthropicApiKey',
+    label: 'Anthropic API key',
+    description: 'Used when AI features are enabled and the provider is Anthropic.',
+    kind: 'password',
+    category: 'comments-ai',
+    mobile: true,
+    dependsOn: ['aiFeaturesEnabled', { key: 'aiProvider', equals: 'anthropic' }],
   },
   {
     key: 'aiModelOverride',
@@ -2892,8 +2921,32 @@ export const SETTING_METADATA: SettingMeta[] = [
     kind: 'text',
     category: 'comments-ai',
     mobile: true,
-    dependsOn: 'aiFeaturesEnabled',
+    dependsOn: ['aiFeaturesEnabled', { key: 'aiProvider', equals: 'anthropic' }],
     aliases: ['model', 'claude model', 'model override', 'opus', 'sonnet', 'haiku'],
+  },
+  {
+    key: 'openrouterApiKey',
+    label: 'OpenRouter API key',
+    description:
+      'Used when the provider is OpenRouter. Stored locally in browser ' +
+      'settings; sent only to openrouter.ai.',
+    kind: 'password',
+    category: 'comments-ai',
+    mobile: true,
+    dependsOn: ['aiFeaturesEnabled', { key: 'aiProvider', equals: 'openrouter' }],
+  },
+  {
+    key: 'openrouterModel',
+    label: 'OpenRouter model',
+    description:
+      'Required when the provider is OpenRouter. The model id, e.g. ' +
+      'anthropic/claude-sonnet-4.6 or openai/gpt-4o. No default - AI features ' +
+      'will not run until this is set.',
+    kind: 'text',
+    category: 'comments-ai',
+    mobile: true,
+    dependsOn: ['aiFeaturesEnabled', { key: 'aiProvider', equals: 'openrouter' }],
+    aliases: ['openrouter model', 'model'],
   },
   {
     key: 'clodEnabled',
@@ -3156,7 +3209,7 @@ function isSettingActionable(m: SettingMeta, env: ToggleEnv): boolean {
     (!m.windowsOnly || env.isWindows) &&
     (!m.webOnly || env.hostKind === 'browser') &&
     (!m.revealWhen || env.get(m.revealWhen) === true) &&
-    (!m.dependsOn || !!env.get(m.dependsOn))
+    evalDependsOn(m.dependsOn, env.get)
   );
 }
 

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -69,6 +69,7 @@ const TRANSIENT_SETTING_KEYS = new Set<string>([
  *  preserved (not overwritten) on import. */
 const SECRET_SETTING_KEYS = new Set<string>([
   'anthropicApiKey',
+  'openrouterApiKey',
   'googleTranslateApiKey',
   'myMemoryEmail',
 ]);
@@ -1089,6 +1090,17 @@ export interface Settings {
    *  well-formed id is sent as-is. Lets a user move to a newer model
    *  without updating the whole app when the default is retired. */
   aiModelOverride: string;
+  /** Which inference provider the AI features talk to. `'anthropic'`
+   *  uses the Anthropic Messages API + `anthropicApiKey`; `'openrouter'`
+   *  uses OpenRouter (OpenAI-chat-compatible) + `openrouterApiKey` /
+   *  `openrouterModel`. */
+  aiProvider: 'anthropic' | 'openrouter';
+  /** OpenRouter API key. Used only when `aiProvider === 'openrouter'`.
+   *  Stored locally; sent only to openrouter.ai. */
+  openrouterApiKey: string;
+  /** OpenRouter model id (e.g. `anthropic/claude-sonnet-4.6`). Required
+   *  when OpenRouter is selected; there is no built-in default. */
+  openrouterModel: string;
   /** Master switch for AI features (the explainer comment shortcut,
    *  @AI mentions inside comments, etc.). When false, no UI for
    *  AI shows up and no API calls happen even if a key is set. */
@@ -1499,6 +1511,9 @@ const DEFAULTS: Settings = {
   commentsVisible: false,
   anthropicApiKey: '',
   aiModelOverride: '',
+  aiProvider: 'anthropic',
+  openrouterApiKey: '',
+  openrouterModel: '',
   aiFeaturesEnabled: false,
   clodEnabled: false,
   clodActivitiesByTime: { morning: [], day: [], evening: [], night: [] },
@@ -1652,6 +1667,7 @@ export interface SettingMeta {
     | 'clod'
     | 'clodCustomize'
     | 'aiCitePrompt'
+    | 'aiProvider'
     | 'translationConfig'
     | 'multiDocLayoutMode'
     | 'mobileLayout'
@@ -3793,6 +3809,10 @@ function sanitize(s: Settings): Settings {
         ? s.anthropicApiKey
         : DEFAULTS.anthropicApiKey,
     aiModelOverride: typeof s.aiModelOverride === 'string' ? s.aiModelOverride.trim() : '',
+    aiProvider: s.aiProvider === 'openrouter' ? 'openrouter' : 'anthropic',
+    openrouterApiKey:
+      typeof s.openrouterApiKey === 'string' ? s.openrouterApiKey : DEFAULTS.openrouterApiKey,
+    openrouterModel: typeof s.openrouterModel === 'string' ? s.openrouterModel.trim() : '',
     aiFeaturesEnabled: !!s.aiFeaturesEnabled,
     clodEnabled: !!s.clodEnabled,
     clodActivitiesByTime: sanitizeClodActivitiesByTime(s.clodActivitiesByTime),

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -1101,6 +1101,12 @@ export interface Settings {
   /** OpenRouter model id (e.g. `anthropic/claude-sonnet-4.6`). Required
    *  when OpenRouter is selected; there is no built-in default. */
   openrouterModel: string;
+  /** Max output tokens for AI calls that don't set their own ceiling
+   *  (cite, explain, flashcards, image alt text). Applies to both
+   *  providers. Reasoning models count hidden thinking tokens against
+   *  this budget, so a low value can leave no room for the actual reply
+   *  — hence a 1024 floor and a recommendation to go higher. */
+  aiMaxTokens: number;
   /** Master switch for AI features (the explainer comment shortcut,
    *  @AI mentions inside comments, etc.). When false, no UI for
    *  AI shows up and no API calls happen even if a key is set. */
@@ -1514,6 +1520,7 @@ const DEFAULTS: Settings = {
   aiProvider: 'anthropic',
   openrouterApiKey: '',
   openrouterModel: '',
+  aiMaxTokens: 4096,
   aiFeaturesEnabled: false,
   clodEnabled: false,
   clodActivitiesByTime: { morning: [], day: [], evening: [], night: [] },
@@ -1729,6 +1736,9 @@ export interface SettingMeta {
   /** When set, the row only renders while this boolean setting is on.
    *  Used to hide the console-gated card-cutter rows until enabled. */
   revealWhen?: keyof Settings;
+  /** Floor for `kind: 'number'` editors — the input's `min` and the
+   *  clamp applied on change. Defaults to 0 when unset. */
+  min?: number;
   /** Extra search terms for the command palette. The label often
    *  uses one name for a thing the user might search by another
    *  ("Theme" vs "dark mode", "Line spacing" vs "line height"); these
@@ -2949,6 +2959,22 @@ export const SETTING_METADATA: SettingMeta[] = [
     aliases: ['openrouter model', 'model'],
   },
   {
+    key: 'aiMaxTokens',
+    label: 'Max output tokens',
+    description:
+      'Token budget for AI features that do not set their own (cite, explain, ' +
+      'flashcards, image alt text). Applies to both providers. Reasoning models ' +
+      'spend hidden thinking tokens from this budget, so we recommend higher ' +
+      'values (e.g. 4096-8192) - too low and the model can run out before it ' +
+      'writes the reply. Minimum 1024.',
+    kind: 'number',
+    min: 1024,
+    category: 'comments-ai',
+    mobile: true,
+    dependsOn: 'aiFeaturesEnabled',
+    aliases: ['max tokens', 'output tokens', 'token budget', 'reasoning', 'thinking'],
+  },
+  {
     key: 'clodEnabled',
     label: 'Enable Clod mode',
     description:
@@ -3866,6 +3892,10 @@ function sanitize(s: Settings): Settings {
     openrouterApiKey:
       typeof s.openrouterApiKey === 'string' ? s.openrouterApiKey : DEFAULTS.openrouterApiKey,
     openrouterModel: typeof s.openrouterModel === 'string' ? s.openrouterModel.trim() : '',
+    aiMaxTokens:
+      typeof s.aiMaxTokens === 'number' && Number.isFinite(s.aiMaxTokens)
+        ? Math.max(1024, Math.round(s.aiMaxTokens))
+        : DEFAULTS.aiMaxTokens,
     aiFeaturesEnabled: !!s.aiFeaturesEnabled,
     clodEnabled: !!s.clodEnabled,
     clodActivitiesByTime: sanitizeClodActivitiesByTime(s.clodActivitiesByTime),

--- a/src/editor/translate.ts
+++ b/src/editor/translate.ts
@@ -20,7 +20,7 @@
 
 import type { EditorView } from 'prosemirror-view';
 import { settings, condenseWarningCloseFor } from './settings.js';
-import { callAnthropic, AnthropicError, resolveAiModel } from './ai/anthropic.js';
+import { callLlm, LlmError, resolveAiModel } from './ai/llm.js';
 import { showToast } from './toast.js';
 
 /** Languages offered in the source / target pickers. ISO 639-1 codes —
@@ -217,7 +217,7 @@ async function translateAnthropic(
   if (!anthropicReady()) {
     throw new Error('Anthropic translation needs AI features — enable them under Comments & AI.');
   }
-  const reply = await callAnthropic({
+  const reply = await callLlm({
     apiKey: settings.get('anthropicApiKey').trim(),
     system: anthropicTranslatorPrompt(languageName(target)),
     maxTokens: ANTHROPIC_TRANSLATE_MAX_TOKENS,
@@ -373,7 +373,7 @@ export function runTranslate(view: EditorView): void {
         truncated ? { durationMs: 4000 } : undefined,
       );
     } catch (e) {
-      if (e instanceof AnthropicError) showToast(`Translate: ${e.message}`);
+      if (e instanceof LlmError) showToast(`Translate: ${e.message}`);
       else showToast(`Translate: ${e instanceof Error ? e.message : String(e)}`);
     }
   })();

--- a/src/editor/translate.ts
+++ b/src/editor/translate.ts
@@ -20,7 +20,7 @@
 
 import type { EditorView } from 'prosemirror-view';
 import { settings, condenseWarningCloseFor } from './settings.js';
-import { callLlm, LlmError, resolveAiModel } from './ai/llm.js';
+import { callLlm, LlmError, resolveAiModel, activeApiKey, aiConfigured } from './ai/llm.js';
 import { showToast } from './toast.js';
 
 /** Languages offered in the source / target pickers. ISO 639-1 codes —
@@ -77,7 +77,7 @@ type ResolvedProvider = 'mymemory' | 'anthropic' | 'google';
 
 /** True when the Anthropic path is usable (AI master switch on + a key). */
 function anthropicReady(): boolean {
-  return settings.get('aiFeaturesEnabled') && settings.get('anthropicApiKey').trim().length > 0;
+  return aiConfigured();
 }
 
 /** Resolve the configured provider, expanding `'auto'`. */
@@ -218,7 +218,7 @@ async function translateAnthropic(
     throw new Error('Anthropic translation needs AI features — enable them under Comments & AI.');
   }
   const reply = await callLlm({
-    apiKey: settings.get('anthropicApiKey').trim(),
+    apiKey: activeApiKey(),
     system: anthropicTranslatorPrompt(languageName(target)),
     maxTokens: ANTHROPIC_TRANSLATE_MAX_TOKENS,
     messages: [{ role: 'user', content: text }],

--- a/src/editor/translate.ts
+++ b/src/editor/translate.ts
@@ -125,6 +125,7 @@ export const TRANSLATION_MARKER_NAMES: readonly string[] = [
   'OPUS 4.8',
   'SONNET 4.6',
   'HAIKU 4.5',
+  'OPENROUTER',
 ];
 
 /** Build the "[TRANSLATION BY X]" marker using the same delimiter the
@@ -147,11 +148,12 @@ export async function translateText(text: string): Promise<TranslateOutcome> {
 
   if (provider === 'anthropic') {
     const reply = await translateAnthropic(text, target);
+    const openrouter = settings.get('aiProvider') === 'openrouter';
     return {
       text: reply.text,
       truncated: reply.truncated,
-      provider: 'Anthropic',
-      markerName: modelMarkerName(resolveAiModel()),
+      provider: openrouter ? 'OpenRouter' : 'Anthropic',
+      markerName: openrouter ? 'OPENROUTER' : modelMarkerName(resolveAiModel()),
     };
   }
   if (provider === 'google') {

--- a/tests/editor/ai-model.test.ts
+++ b/tests/editor/ai-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { resolveAiModel, DEFAULT_MODEL } from '../../src/editor/ai/anthropic.js';
+import { resolveAiModel, DEFAULT_MODEL } from '../../src/editor/ai/llm.js';
 import { settings } from '../../src/editor/settings.js';
 
 describe('resolveAiModel (custom model override)', () => {

--- a/tests/editor/ai-model.test.ts
+++ b/tests/editor/ai-model.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { resolveAiModel, DEFAULT_MODEL } from '../../src/editor/ai/llm.js';
+import {
+  resolveAiModel,
+  DEFAULT_MODEL,
+  activeApiKey,
+  aiConfigured,
+} from '../../src/editor/ai/llm.js';
 import { settings } from '../../src/editor/settings.js';
 
 describe('resolveAiModel (custom model override)', () => {
@@ -25,5 +30,153 @@ describe('resolveAiModel (custom model override)', () => {
   it('trims surrounding whitespace', () => {
     settings.set('aiModelOverride', '  claude-sonnet-4-6  ');
     expect(resolveAiModel()).toBe('claude-sonnet-4-6');
+  });
+});
+
+describe('resolveAiModel (OpenRouter provider)', () => {
+  afterEach(() => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('openrouterModel', '');
+  });
+
+  it('returns the openrouterModel verbatim when provider is openrouter', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('openrouterModel', 'anthropic/claude-sonnet-4-6');
+    expect(resolveAiModel()).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  it('accepts model ids with slashes (provider/model format)', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('openrouterModel', 'anthropic/claude-sonnet-4-6');
+    expect(resolveAiModel()).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  it('trims whitespace from openrouterModel', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('openrouterModel', '  anthropic/claude-sonnet-4-6  ');
+    expect(resolveAiModel()).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  it('returns empty string when openrouterModel is empty', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('openrouterModel', '');
+    expect(resolveAiModel()).toBe('');
+  });
+
+  it('ignores aiModelOverride when provider is openrouter', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('openrouterModel', 'mistral/mistral-7b');
+    settings.set('aiModelOverride', 'claude-opus-4-8');
+    expect(resolveAiModel()).toBe('mistral/mistral-7b');
+  });
+});
+
+describe('activeApiKey', () => {
+  afterEach(() => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('anthropicApiKey', '');
+    settings.set('openrouterApiKey', '');
+  });
+
+  it('returns the anthropicApiKey by default (when provider is anthropic)', () => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('anthropicApiKey', 'sk-ant-test-key-123');
+    expect(activeApiKey()).toBe('sk-ant-test-key-123');
+  });
+
+  it('returns the openrouterApiKey when provider is openrouter', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('openrouterApiKey', 'sk-or-test-key-456');
+    expect(activeApiKey()).toBe('sk-or-test-key-456');
+  });
+
+  it('trims whitespace from anthropic key', () => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('anthropicApiKey', '  sk-ant-test-key-123  ');
+    expect(activeApiKey()).toBe('sk-ant-test-key-123');
+  });
+
+  it('trims whitespace from openrouter key', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('openrouterApiKey', '  sk-or-test-key-456  ');
+    expect(activeApiKey()).toBe('sk-or-test-key-456');
+  });
+
+  it('ignores the openrouter key when provider is anthropic', () => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('anthropicApiKey', 'sk-ant-active');
+    settings.set('openrouterApiKey', 'sk-or-ignored');
+    expect(activeApiKey()).toBe('sk-ant-active');
+  });
+
+  it('ignores the anthropic key when provider is openrouter', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('anthropicApiKey', 'sk-ant-ignored');
+    settings.set('openrouterApiKey', 'sk-or-active');
+    expect(activeApiKey()).toBe('sk-or-active');
+  });
+
+  it('returns empty string when the active provider has no key', () => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('anthropicApiKey', '');
+    expect(activeApiKey()).toBe('');
+  });
+});
+
+describe('aiConfigured', () => {
+  afterEach(() => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('aiFeaturesEnabled', false);
+    settings.set('anthropicApiKey', '');
+    settings.set('openrouterApiKey', '');
+  });
+
+  it('returns false when aiFeaturesEnabled is false, even with a key', () => {
+    settings.set('aiFeaturesEnabled', false);
+    settings.set('anthropicApiKey', 'sk-ant-test-key-123');
+    expect(aiConfigured()).toBe(false);
+  });
+
+  it('returns false when enabled but no anthropic key is set', () => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('aiFeaturesEnabled', true);
+    settings.set('anthropicApiKey', '');
+    expect(aiConfigured()).toBe(false);
+  });
+
+  it('returns false when enabled but no openrouter key is set', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('aiFeaturesEnabled', true);
+    settings.set('openrouterApiKey', '');
+    expect(aiConfigured()).toBe(false);
+  });
+
+  it('returns true when enabled and anthropic key is set', () => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('aiFeaturesEnabled', true);
+    settings.set('anthropicApiKey', 'sk-ant-test-key-123');
+    expect(aiConfigured()).toBe(true);
+  });
+
+  it('returns true when enabled and openrouter key is set', () => {
+    settings.set('aiProvider', 'openrouter');
+    settings.set('aiFeaturesEnabled', true);
+    settings.set('openrouterApiKey', 'sk-or-test-key-456');
+    expect(aiConfigured()).toBe(true);
+  });
+
+  it('returns false when enabled but key is only whitespace', () => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('aiFeaturesEnabled', true);
+    settings.set('anthropicApiKey', '   ');
+    expect(aiConfigured()).toBe(false);
+  });
+
+  it('ignores the inactive provider key', () => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('aiFeaturesEnabled', true);
+    settings.set('anthropicApiKey', 'sk-ant-test-key-123');
+    settings.set('openrouterApiKey', ''); // inactive provider's key
+    expect(aiConfigured()).toBe(true);
   });
 });

--- a/tests/editor/ai-model.test.ts
+++ b/tests/editor/ai-model.test.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_MODEL,
   activeApiKey,
   aiConfigured,
+  callLlm,
+  LlmError,
 } from '../../src/editor/ai/llm.js';
 import { settings } from '../../src/editor/settings.js';
 
@@ -178,5 +180,27 @@ describe('aiConfigured', () => {
     settings.set('anthropicApiKey', 'sk-ant-test-key-123');
     settings.set('openrouterApiKey', ''); // inactive provider's key
     expect(aiConfigured()).toBe(true);
+  });
+});
+
+describe('callLlm (OpenRouter empty-model guard)', () => {
+  afterEach(() => {
+    settings.set('aiProvider', 'anthropic');
+    settings.set('openrouterApiKey', '');
+    settings.set('openrouterModel', '');
+    settings.set('aiFeaturesEnabled', false);
+  });
+
+  it('callLlm rejects with a model-kind LlmError when OpenRouter has no model set', async () => {
+    settings.set('aiFeaturesEnabled', true);
+    settings.set('aiProvider', 'openrouter');
+    settings.set('openrouterApiKey', 'sk-test');
+    settings.set('openrouterModel', '');
+    await expect(
+      callLlm({ apiKey: 'sk-test', messages: [{ role: 'user', content: 'hi' }] }),
+    ).rejects.toThrow(LlmError);
+    await expect(
+      callLlm({ apiKey: 'sk-test', messages: [{ role: 'user', content: 'hi' }] }),
+    ).rejects.toMatchObject({ kind: 'model' });
   });
 });

--- a/tests/editor/openrouter-translate.test.ts
+++ b/tests/editor/openrouter-translate.test.ts
@@ -1,0 +1,79 @@
+/**
+ * OpenRouter request/response translation (`src/editor/ai/llm.ts`).
+ * The client speaks an Anthropic-shaped request internally; these pure
+ * translators convert to/from OpenRouter's OpenAI-chat format.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  toOpenRouterMessages,
+  parseOpenRouterReply,
+  LlmError,
+} from '../../src/editor/ai/llm.js';
+
+describe('toOpenRouterMessages', () => {
+  it('prepends the system prompt as a system message', () => {
+    const msgs = toOpenRouterMessages({
+      apiKey: 'k',
+      system: 'You are helpful.',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(msgs).toEqual([
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'hi' },
+    ]);
+  });
+
+  it('omits the system message when no system prompt is given', () => {
+    const msgs = toOpenRouterMessages({
+      apiKey: 'k',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(msgs).toEqual([{ role: 'user', content: 'hi' }]);
+  });
+
+  it('converts an image block to an image_url data URL', () => {
+    const msgs = toOpenRouterMessages({
+      apiKey: 'k',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+            { type: 'text', text: 'what is this?' },
+          ],
+        },
+      ],
+    });
+    expect(msgs).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+          { type: 'text', text: 'what is this?' },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('parseOpenRouterReply', () => {
+  it('reads the first choice text', () => {
+    const reply = parseOpenRouterReply({
+      choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
+    });
+    expect(reply).toEqual({ text: 'hello', stopReason: 'stop' });
+  });
+
+  it('maps finish_reason length to max_tokens', () => {
+    const reply = parseOpenRouterReply({
+      choices: [{ message: { content: '{partial' }, finish_reason: 'length' }],
+    });
+    expect(reply.stopReason).toBe('max_tokens');
+  });
+
+  it('throws a parse LlmError on empty content', () => {
+    expect(() => parseOpenRouterReply({ choices: [{ message: { content: '' } }] })).toThrow(
+      LlmError,
+    );
+  });
+});

--- a/tests/editor/openrouter-translate.test.ts
+++ b/tests/editor/openrouter-translate.test.ts
@@ -76,4 +76,14 @@ describe('parseOpenRouterReply', () => {
       LlmError,
     );
   });
+
+  it('points at the token budget when a reasoning model returns empty + length', () => {
+    // The real failure: content null, finish_reason length, budget spent on
+    // hidden reasoning. Error should name the "Max output tokens" fix.
+    expect(() =>
+      parseOpenRouterReply({
+        choices: [{ message: { content: null }, finish_reason: 'length' }],
+      }),
+    ).toThrow(/Max output tokens/);
+  });
 });


### PR DESCRIPTION
Lets users route citation reformatting and other AI utilities through Openrouter's API, enabling non-Anthropic models & open source / weight models, as well as free inference.

Refactors anthropic.ts -> llm.ts, which is a provider-neutral dispatch util, with translators for Openrouter's API request format. Routes all AI call sites (cite-creator, translate, repair-*, flashcard-gen, image-ai, comments-ui) through provider-neutral functions instead of assuming Anthropic.

Adds setting to let users set max tokens instead of it being hard-coded. Some thinking models silently eat tokens, which led to requests timing out.

Tested on web and Mac ARM.