### PR TITLE
Let the user customize the speech document filename

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1205,12 +1205,35 @@ ipcMain.handle('host:list-cmir-files', async (_event, root: string): Promise<Cmi
   return fresh;
 });
 
-ipcMain.handle('host:write-file-at-path', async (_event, filePath: string, bytes: unknown) => {
-  if (typeof filePath !== 'string' || !filePath) throw new Error('write-file-at-path: no path');
-  // mkdir: bulk convert writes into a destination folder, preserving
-  // the input's subfolder structure.
-  await saveNewDoc(filePath, bytesToBuffer(bytes), { mkdir: true });
-});
+ipcMain.handle(
+  'host:write-file-at-path',
+  async (
+    _event,
+    filePath: string,
+    bytes: unknown,
+    opts?: { failIfExists?: boolean },
+  ) => {
+    if (typeof filePath !== 'string' || !filePath) {
+      throw new Error('write-file-at-path: no path');
+    }
+    // Opt-in existence check. Only the new-speech-doc auto-save asks
+    // for it; bulk convert still overwrites by design. Returns the
+    // 'collision' sentinel so the renderer can defer to Save As -
+    // same contract as host:save-send-doc below.
+    if (opts?.failIfExists) {
+      try {
+        await fs.access(filePath);
+        return 'collision';
+      } catch {
+        /* not there - fall through and write */
+      }
+    }
+    // mkdir: bulk convert writes into a destination folder, preserving
+    // the input's subfolder structure.
+    await saveNewDoc(filePath, bytesToBuffer(bytes), { mkdir: true });
+    return undefined;
+  },
+);
 
 ipcMain.handle(
   'host:save-as',

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -287,8 +287,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('host:cmir-files-updated', listener);
     return () => ipcRenderer.removeListener('host:cmir-files-updated', listener);
   },
-  writeFileAtPath: (filePath: string, bytes: Uint8Array) =>
-    ipcRenderer.invoke('host:write-file-at-path', filePath, bytes),
+  writeFileAtPath: (
+    filePath: string,
+    bytes: Uint8Array,
+    opts?: { failIfExists?: boolean },
+  ) => ipcRenderer.invoke('host:write-file-at-path', filePath, bytes, opts),
 
   /** Bulk-compress every `.cmir` under `dir` in place (temporary
    *  migration tool). `onProgress` fires (throttled) as files are

--- a/src/editor/host/electron-host.ts
+++ b/src/editor/host/electron-host.ts
@@ -221,7 +221,11 @@ interface ElectronAPI {
       entries: Array<{ path: string; relPath: string; mtimeMs: number; size: number }>;
     }) => void,
   ): () => void;
-  writeFileAtPath(filePath: string, bytes: Uint8Array): Promise<void>;
+  writeFileAtPath(
+    filePath: string,
+    bytes: Uint8Array,
+    opts?: { failIfExists?: boolean },
+  ): Promise<'collision' | void>;
   bulkCompress(
     dir: string,
     onProgress: (p: BulkCompressProgress) => void,
@@ -676,8 +680,12 @@ export class ElectronHost implements Host {
     return typeof fn === 'function' ? fn(handler) : () => {};
   }
 
-  async writeFileAtPath(filePath: string, bytes: Uint8Array): Promise<void> {
-    await api().writeFileAtPath(filePath, bytes);
+  async writeFileAtPath(
+    filePath: string,
+    bytes: Uint8Array,
+    opts?: { failIfExists?: boolean },
+  ): Promise<'collision' | void> {
+    return await api().writeFileAtPath(filePath, bytes, opts);
   }
 
   async bulkCompress(

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -275,6 +275,7 @@ import {
 import { captureCleanToken } from './save-clean-token.js';
 import { wireWebEditionHeaderButtons } from './web-download.js';
 import { computeSelectionChrome, type SelectionChrome } from './selection-chrome.js';
+import { formatSpeechFilename } from './speech-filename.js';
 
 // Install the last-resort error hooks before ANY app wiring — an exception
 // during boot or in a fire-and-forget flow must never be invisible again.
@@ -588,12 +589,12 @@ async function runNewSpeechDocumentSingleDoc(): Promise<void> {
   const trimmed = roundName;
 
   const format = settings.get('defaultSpeechDocFormat');
-  const filename = formatSpeechFilename(trimmed, format);
+  const initialFilename = formatSpeechFilename(trimmed, format);
   // Pocket heading is the filename minus its extension when the
   // user has opted in; otherwise start fully blank. Off case lets
   // users title their speeches inline rather than via the chip.
   const docNode = settings.get('includeSpeechDocPocket')
-    ? makeSpeechBlankDoc(filename.replace(/\.(cmir|docx)$/i, ''))
+    ? makeSpeechBlankDoc(initialFilename.replace(/\.(cmir|docx)$/i, ''))
     : makeBlankNewDoc();
 
   let docBytes: Uint8Array;
@@ -612,16 +613,37 @@ async function runNewSpeechDocumentSingleDoc(): Promise<void> {
   // Skipped silently when the setting is empty (no folder = no
   // automatic save).
   let handle: string | null = null;
+  let filename = initialFilename;
   const defaultFolder = settings.get('defaultSpeechDocFolder').trim();
   const electronForSpeechSave = getElectronHost();
   if (defaultFolder && electronForSpeechSave) {
     const targetPath = joinSpeechDocPath(defaultFolder, filename);
     try {
-      // A brand-new file — use the at-path writer (which also creates
+      // A brand-new file - use the at-path writer (which also creates
       // the folder if needed); `saveExisting` refuses paths that don't
       // exist on disk. Electron-only, like the folder setting itself.
-      await electronForSpeechSave.writeFileAtPath(targetPath, docBytes);
-      handle = targetPath;
+      // failIfExists: a custom filename template can drop the
+      // timestamp, which makes two docs of the same name easy. Hand
+      // the collision to the native dialog rather than clobbering.
+      const result = await electronForSpeechSave.writeFileAtPath(
+        targetPath,
+        docBytes,
+        { failIfExists: true },
+      );
+      if (result === 'collision') {
+        const saved = await host.saveAs(filename, docBytes, {
+          filters: saveFiltersForFormat(format),
+          nearPath: targetPath,
+        });
+        // Cancelled dialog: carry on unsaved rather than losing the
+        // doc. The user still gets the window and can Save As later.
+        if (saved) {
+          handle = typeof saved.handle === 'string' ? saved.handle : null;
+          filename = saved.name;
+        }
+      } else {
+        handle = targetPath;
+      }
     } catch (err) {
       console.warn('Auto-save of new speech doc to default folder failed:', err);
       // Continue without a handle; the user can Save As later.
@@ -644,23 +666,6 @@ async function runNewSpeechDocumentSingleDoc(): Promise<void> {
       `Failed to open new speech window: ${err instanceof Error ? err.message : err}`,
     );
   }
-}
-
-/** Format a Verbatim-style speech filename: "Speech <round> M-D
- *  H-MM(AM|PM).<ext>". Extension comes from the configured
- *  `defaultSpeechDocFormat` setting — `.docx` (Verbatim parity) or
- *  `.cmir` (autosave-eligible). */
-function formatSpeechFilename(round: string, format: 'cmir' | 'docx'): string {
-  const now = new Date();
-  const month = now.getMonth() + 1;
-  const day = now.getDate();
-  let hour = now.getHours();
-  const minute = now.getMinutes();
-  const ampm = hour < 12 ? 'AM' : 'PM';
-  if (hour === 0) hour = 12;
-  else if (hour > 12) hour -= 12;
-  const m = String(minute).padStart(2, '0');
-  return `Speech ${round} ${month}-${day} ${hour}-${m}${ampm}.${format}`;
 }
 
 /** Speech-doc starter: a Pocket heading carrying the user-supplied

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -104,6 +104,7 @@ import {
   onCollabCopresenceChange,
 } from './collab/collab-hooks.js';
 import { icon, setIcon } from './icons';
+import { formatSpeechFilename } from './speech-filename.js';
 
 type SlotId = 'slot1' | 'slot2' | 'slot3';
 const SLOT_IDS: SlotId[] = ['slot1', 'slot2', 'slot3'];
@@ -2685,23 +2686,6 @@ class MultiPaneShell {
       slot.paneEl.classList.toggle('pmd-pane-speech', isSpeech);
     }
   }
-}
-
-/** Format a Verbatim-style speech filename: "Speech <round> M-D
- *  H-MMam/pm.<ext>". Extension follows the `defaultSpeechDocFormat`
- *  setting — `.docx` (Verbatim parity) or `.cmir` (autosave-
- *  eligible). */
-function formatSpeechFilename(round: string, format: 'cmir' | 'docx'): string {
-  const now = new Date();
-  const month = now.getMonth() + 1;
-  const day = now.getDate();
-  let hour = now.getHours();
-  const minute = now.getMinutes();
-  const ampm = hour < 12 ? 'AM' : 'PM';
-  if (hour === 0) hour = 12;
-  else if (hour > 12) hour -= 12;
-  const m = String(minute).padStart(2, '0');
-  return `Speech ${round} ${month}-${day} ${hour}-${m}${ampm}.${format}`;
 }
 
 /** Minimal valid doc — one empty paragraph. Used by `createNewDoc`

--- a/src/editor/settings-ui.ts
+++ b/src/editor/settings-ui.ts
@@ -75,6 +75,10 @@ import {
   FILE_OBJECT_KIND_LABELS,
   type FileObjectKind,
 } from './file-search.js';
+import {
+  DEFAULT_SPEECH_FILENAME_TEMPLATE,
+  renderSpeechFilename,
+} from './speech-filename.js';
 
 /**
  * Body fonts for the font dropdowns, grouped into `<optgroup>`s.
@@ -792,6 +796,10 @@ class SettingsModal {
     } else if (meta.kind === 'speechDocFormat') {
       row.appendChild(text);
       row.appendChild(buildSpeechDocFormatEditor());
+      return row;
+    } else if (meta.kind === 'speechFilenameTemplate') {
+      row.appendChild(text);
+      row.appendChild(buildSpeechFilenameTemplateEditor());
       return row;
     } else if (meta.kind === 'saveFormat') {
       row.appendChild(text);
@@ -3844,6 +3852,69 @@ function buildSpeechDocFormatEditor(): HTMLElement {
     row.appendChild(labelText);
     wrap.appendChild(row);
   }
+  return wrap;
+}
+
+/** Template text box plus a live preview. The preview matters more
+ *  than usual here: the template has a syntax, and without a preview
+ *  the user only discovers a typo at the moment they create a doc
+ *  mid-round. Input event, not change, so it updates per keystroke. */
+function buildSpeechFilenameTemplateEditor(): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'pmd-speech-filename-editor';
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'pmd-settings-text';
+  input.autocomplete = 'off';
+  input.spellcheck = false;
+  input.value = settings.get('speechDocFilenameTemplate');
+
+  const preview = document.createElement('div');
+  preview.className = 'pmd-speech-filename-preview';
+  // A screen reader should hear the corrected preview, not each
+  // intermediate keystroke.
+  preview.setAttribute('aria-live', 'polite');
+
+  // A fixed sample, not the real clock: the preview must not shift
+  // under the user while they type.
+  const SAMPLE_ROUND = '1NC';
+  const SAMPLE_DATE = new Date(2026, 3, 12, 19, 5, 7);
+
+  const refresh = () => {
+    const template = input.value.trim() || DEFAULT_SPEECH_FILENAME_TEMPLATE;
+    preview.textContent = `Example: ${renderSpeechFilename(
+      template,
+      SAMPLE_ROUND,
+      settings.get('defaultSpeechDocFormat'),
+      SAMPLE_DATE,
+    )}`;
+  };
+  refresh();
+
+  input.addEventListener('input', refresh);
+  input.addEventListener('change', () => {
+    // Blank reverts to the default rather than storing an empty
+    // template. `sanitize` enforces the same rule on load.
+    const next = input.value.trim() || DEFAULT_SPEECH_FILENAME_TEMPLATE;
+    input.value = next;
+    settings.set('speechDocFilenameTemplate', next);
+    refresh();
+  });
+
+  // Keep the preview honest when the format radio above changes,
+  // since the extension comes from that setting.
+  const unsub = settings.subscribe(() => {
+    const cur = settings.get('speechDocFilenameTemplate');
+    if (document.activeElement !== input && input.value !== cur) {
+      input.value = cur;
+    }
+    refresh();
+  });
+  registerRowCleanup(wrap, () => unsub());
+
+  wrap.appendChild(input);
+  wrap.appendChild(preview);
   return wrap;
 }
 

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -13,6 +13,7 @@ import { sanitizeAcronymPattern, type AcronymPattern } from './acronym-patterns.
 import type { RibbonCommandId } from './ribbon-commands.js';
 import type { IconName } from './icons.js';
 import { getHost } from './host/index.js';
+import { DEFAULT_SPEECH_FILENAME_TEMPLATE } from './speech-filename-default.js';
 
 /** Body-text zoom bounds (percent). The live per-window / per-pane zoom AND the
  *  default-open zoom setting all clamp to these — one source of truth so
@@ -370,6 +371,12 @@ export interface Settings {
    *  background save path skips .docx because `toDocx` is too
    *  expensive to run on a debounce). */
   defaultSpeechDocFormat: 'cmir' | 'docx';
+  /** Template for the filename of a doc created by "New Speech
+   *  Document". Fields: `{round}` is the name typed at the prompt,
+   *  `{date:FMT}` is a date in day.js-style tokens (`YYYY-MM-DD`,
+   *  `h-mmA`). The extension is not part of the template -
+   *  `defaultSpeechDocFormat` owns it. */
+  speechDocFilenameTemplate: string;
   /** Format the Save-As dialog defaults to for a doc that doesn't
    *  yet have an on-disk handle (new doc, first save). Existing
    *  on-disk files always Save As in their current format — the
@@ -1463,6 +1470,7 @@ const DEFAULTS: Settings = {
   showOnboardingStarter: true,
   defaultSpeechDocFolder: '',
   defaultSpeechDocFormat: 'docx',
+  speechDocFilenameTemplate: DEFAULT_SPEECH_FILENAME_TEMPLATE,
   defaultSaveFormat: 'docx',
   prefixPresetSaveFilenames: true,
   sendDocPrefix: 'SEND_',
@@ -1784,6 +1792,7 @@ export interface SettingMeta {
     | 'maxTextWidth'
     | 'fileSearchTiebreak'
     | 'speechDocFormat'
+    | 'speechFilenameTemplate'
     | 'saveFormat'
     | 'formattingGapClass'
     | 'sendDocDestination'
@@ -2037,6 +2046,28 @@ export const SETTING_METADATA: SettingMeta[] = [
     description:
       'Docx is the Verbatim-compatible default — best when you\'re sharing speech docs with teammates who use Verbatim. Picking .cmir enables autosave on the new doc (autosave only fires for .cmir files; the Docx serializer is too expensive to run on a debounce).',
     kind: 'speechDocFormat',
+    category: 'files',
+    section: 'New documents',
+  },
+  {
+    key: 'speechDocFilenameTemplate',
+    label: 'Speech document filename',
+    description:
+      // Rendered with white-space: pre-line, so a \n is a line break
+      // but leading indentation collapses. Keep every line flush left.
+      'The name New Speech Document gives a new file.\n' +
+      '{round} is the name you type at the prompt.\n' +
+      '{date:...} is a date. Double a token to zero-pad it:\n' +
+      'year - YYYY 2026, YY 26\n' +
+      'month - M 4, MM 04, MMM Apr, MMMM April\n' +
+      'day - D 12, DD 12, ddd Sun, dddd Sunday\n' +
+      'hour - h 7, hh 07 (12-hour), H 19, HH 19 (24-hour)\n' +
+      'minute - m 5, mm 05. second - s 7, ss 07. A PM, a pm\n' +
+      '\n' +
+      'Anything that is not a token stays as you typed it, so dashes, ' +
+      'slashes and spaces need no escaping. Inside {date:...} the letters ' +
+      'are tokens, so wrap a literal word in brackets: {date:h-mmA [on] MMM D}.\n',
+    kind: 'speechFilenameTemplate',
     category: 'files',
     section: 'New documents',
   },
@@ -3815,6 +3846,14 @@ function sanitize(s: Settings): Settings {
         : '',
     defaultSpeechDocFormat:
       s.defaultSpeechDocFormat === 'cmir' ? 'cmir' : 'docx',
+    // An empty string is a legitimate stored value only by accident
+    // (it renders to the "Speech" fallback), so treat blank as unset
+    // and restore the default.
+    speechDocFilenameTemplate:
+      typeof s.speechDocFilenameTemplate === 'string' &&
+      s.speechDocFilenameTemplate.trim()
+        ? s.speechDocFilenameTemplate
+        : DEFAULT_SPEECH_FILENAME_TEMPLATE,
     defaultSaveFormat:
       s.defaultSaveFormat === 'cmir' ? 'cmir' : 'docx',
     // Default-on: only an explicit `false` disables the preset

--- a/src/editor/speech-filename-default.ts
+++ b/src/editor/speech-filename-default.ts
@@ -1,0 +1,8 @@
+/** The stock speech-doc filename template, split into its own file
+ *  so `settings.ts` and `speech-filename.ts` can both import it
+ *  without forming an import cycle (settings.ts needs the default
+ *  for `DEFAULTS`; speech-filename.ts needs `settings` for the
+ *  `formatSpeechFilename` wrapper). Byte-identical output to the
+ *  pre-template implementation, so an existing user sees no change. */
+export const DEFAULT_SPEECH_FILENAME_TEMPLATE =
+  'Speech {round} {date:M-D h-mmA}';

--- a/src/editor/speech-filename.ts
+++ b/src/editor/speech-filename.ts
@@ -1,0 +1,147 @@
+/** Speech-doc filename templating. Verbatim names a new speech doc
+ *  from a fixed pattern; we let the user set the pattern instead.
+ *
+ *  Everything here is pure (the caller passes the clock) so the
+ *  settings-UI live preview, the three creation call sites, and the
+ *  tests all share one code path with no hidden state.
+ *
+ *  The extension is NOT part of the template. `defaultSpeechDocFormat`
+ *  owns it, so a user editing the template can never produce a doc
+ *  whose extension disagrees with its bytes. */
+
+// Re-exported from its own file to avoid an import cycle with
+// settings.ts: settings.ts needs the default for `DEFAULTS`, and
+// this module needs `settings` for the `formatSpeechFilename`
+// wrapper below.
+export { DEFAULT_SPEECH_FILENAME_TEMPLATE } from './speech-filename-default.js';
+
+import { settings } from './settings.js';
+
+// English-only, on purpose. `toLocaleString` would make a filename
+// depend on the machine locale, which makes filenames inconsistent
+// across a team and makes the tests flaky.
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const MONTHS_FULL = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+const DAYS_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const DAYS_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/** Token alternation for `formatDate`, LONGEST FIRST. Order is
+ *  load-bearing: with `YY` before `YYYY`, a year would render as two
+ *  glued two-digit years. The leading `[...]` branch is the escape
+ *  hatch for a literal letter inside a date format.
+ *
+ *  Doubled token = zero-padded, single = not. That is the day.js /
+ *  moment / Luxon convention, which is what most people have already
+ *  half-absorbed from other tools. */
+const DATE_TOKEN_RE =
+  /\[([^\]]*)\]|YYYY|YY|MMMM|MMM|MM|M|dddd|ddd|DD|D|HH|H|hh|h|mm|m|ss|s|A|a/g;
+
+/** Format a date with readable tokens (`YYYY-MM-DD`, `h-mmA`) rather
+ *  than strftime's `%Y-%m-%d`. Anything that is not a token is
+ *  literal, so separators need no escaping.
+ *
+ *  Letters ARE tokens, so a literal word inside a date format needs
+ *  brackets: `{date:h-mmA [on] MMM D}`. Text outside the `{date:...}`
+ *  block never needs them - that is the point of scoping tokens to
+ *  the block instead of the whole template. */
+export function formatDate(fmt: string, d: Date): string {
+  const p2 = (n: number) => String(n).padStart(2, '0');
+  const hour24 = d.getHours();
+  const hour12 = hour24 % 12 || 12; // 0 -> 12, 13 -> 1
+  const tokens: Record<string, string> = {
+    YYYY: String(d.getFullYear()),
+    YY: String(d.getFullYear()).slice(-2),
+    MMMM: MONTHS_FULL[d.getMonth()]!,
+    MMM: MONTHS_SHORT[d.getMonth()]!,
+    MM: p2(d.getMonth() + 1),
+    M: String(d.getMonth() + 1),
+    dddd: DAYS_FULL[d.getDay()]!,
+    ddd: DAYS_SHORT[d.getDay()]!,
+    DD: p2(d.getDate()),
+    D: String(d.getDate()),
+    HH: p2(hour24),
+    H: String(hour24),
+    hh: p2(hour12),
+    h: String(hour12),
+    mm: p2(d.getMinutes()),
+    m: String(d.getMinutes()),
+    ss: p2(d.getSeconds()),
+    s: String(d.getSeconds()),
+    A: hour24 < 12 ? 'AM' : 'PM',
+    a: hour24 < 12 ? 'am' : 'pm',
+  };
+  return fmt.replace(DATE_TOKEN_RE, (whole, literal?: string) =>
+    // `literal` is undefined for a token match, and '' for an empty
+    // `[]`, so test against undefined rather than truthiness.
+    literal !== undefined ? literal : (tokens[whole] ?? whole),
+  );
+}
+
+/** Substitute the template fields. `{round}` is the text the user
+ *  typed at the prompt; `{date:FMT}` is a token-formatted date. An
+ *  unknown field stays literal, so a typo is visible in the settings
+ *  preview instead of silently eating part of the name. */
+export function renderSpeechName(
+  template: string,
+  round: string,
+  now: Date,
+): string {
+  return template.replace(/\{(round|date:[^}]*)\}/g, (_whole, body: string) =>
+    body === 'round' ? round : formatDate(body.slice('date:'.length), now),
+  );
+}
+
+/** Make a rendered name safe to use as one path segment.
+ *
+ *  This is a trust boundary, not cosmetics. The result flows into
+ *  `joinSpeechDocPath` and then straight to a filesystem write with
+ *  no further checks, so a round name of `1NC/../../evil` would
+ *  otherwise write outside the user's chosen folder. */
+export function sanitizeFilename(name: string): string {
+  const cleaned = name
+    // Path separators and the colon become a hyphen rather than
+    // vanishing. These three are exactly the characters that show up
+    // in a legitimate date format, and deleting them silently mushes
+    // the digits together: `DD/MM/YYYY` would give `12042026` and
+    // `hh:mm` would give `0705`. A hyphen keeps the fields readable
+    // and is still a single path segment.
+    .replace(/[/\\:]/g, '-')
+    // The rest of the Windows-illegal set is dropped. Unlike the
+    // three above, these never appear in a date format on purpose.
+    .replace(/[*?"<>|]/g, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/^[\s.]+/, '')
+    .slice(0, 200)
+    // Trim again: the slice can expose new trailing junk, and a
+    // trailing dot or space is silently dropped by Windows.
+    .replace(/[\s.]+$/, '');
+  return cleaned || 'Speech';
+}
+
+/** Render, sanitize, then append the extension. The one entry point
+ *  the creation call sites and the settings preview both use. */
+export function renderSpeechFilename(
+  template: string,
+  round: string,
+  format: 'cmir' | 'docx',
+  now: Date,
+): string {
+  return `${sanitizeFilename(renderSpeechName(template, round, now))}.${format}`;
+}
+
+/** The wrapper the creation call sites use: reads the template and
+ *  the format setting, stamps the current time. Same signature as
+ *  the two per-file copies it replaces, so no call site changes. */
+export function formatSpeechFilename(
+  round: string,
+  format: 'cmir' | 'docx',
+): string {
+  return renderSpeechFilename(
+    settings.get('speechDocFilenameTemplate'),
+    round,
+    format,
+    new Date(),
+  );
+}

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -5861,6 +5861,10 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
   font-size: 0.85rem;
   color: var(--pmd-c-text-muted);
   line-height: 1.4;
+  /* pre-line, not pre-wrap: a description can use \n for a line
+     break, while source-code indentation inside the string still
+     collapses. Descriptions without a \n are unaffected. */
+  white-space: pre-line;
 }
 
 .pmd-settings-toggle {
@@ -5880,6 +5884,22 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
   border-radius: 4px;
   background: var(--pmd-c-bg);
   color: var(--pmd-c-text);
+}
+.pmd-speech-filename-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  align-items: flex-start;
+}
+.pmd-speech-filename-editor .pmd-settings-text {
+  flex: 0 0 auto;
+  width: 20rem;
+  max-width: 100%;
+  font-family: var(--pmd-f-mono, ui-monospace, monospace);
+}
+.pmd-speech-filename-preview {
+  font-size: 0.85rem;
+  opacity: 0.7;
 }
 /* Shared scaffolding (input focus ring).
    Diverge by pulling a selector out, not by re-copying. */

--- a/tests/editor/speech-filename.test.ts
+++ b/tests/editor/speech-filename.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Speech-doc filename template: date tokens, field substitution, and
+ * filename sanitization. A fixed Date keeps every assertion exact (no
+ * clock flake, no locale dependence).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SPEECH_FILENAME_TEMPLATE,
+  formatDate,
+  renderSpeechFilename,
+  renderSpeechName,
+  sanitizeFilename,
+} from '../../src/editor/speech-filename.js';
+
+// 2026-04-12 19:05:07 local time. Constructed from parts (not an ISO
+// string) so the test reads local-time getters, matching the code.
+const AT = new Date(2026, 3, 12, 19, 5, 7);
+const MIDNIGHT = new Date(2026, 3, 12, 0, 30, 0);
+const NOON = new Date(2026, 3, 12, 12, 30, 0);
+
+describe('formatDate tokens', () => {
+  it('doubles the token to zero-pad, singles it to not', () => {
+    expect(formatDate('MM-DD hh-mmA', AT)).toBe('04-12 07-05PM');
+    expect(formatDate('M-D h-mmA', AT)).toBe('4-12 7-05PM');
+  });
+
+  it('is correct at midnight and at noon', () => {
+    expect(formatDate('hA', MIDNIGHT)).toBe('12AM');
+    expect(formatDate('hA', NOON)).toBe('12PM');
+    expect(formatDate('HH', MIDNIGHT)).toBe('00');
+    expect(formatDate('HH', NOON)).toBe('12');
+  });
+
+  it('supports year, seconds, name tokens, and lowercase am/pm', () => {
+    expect(formatDate('YYYY YY ss MMM MMMM ddd dddd a', AT)).toBe(
+      '2026 26 07 Apr April Sun Sunday pm',
+    );
+  });
+
+  it('matches longest-first, so YYYY is not two YY', () => {
+    // The regression this guards: alternation order. With YY listed
+    // before YYYY, this would render '2626'.
+    expect(formatDate('YYYY', AT)).toBe('2026');
+    expect(formatDate('MMMM', AT)).toBe('April');
+    expect(formatDate('dddd', AT)).toBe('Sunday');
+  });
+
+  it('leaves non-token characters literal, needing no escaping', () => {
+    expect(formatDate('--/:. ', AT)).toBe('--/:. ');
+  });
+
+  it('takes bracketed text literally, so a word can survive', () => {
+    // Without brackets every letter here is a token: 'at' would
+    // become the day-of-month plus 'pm'.
+    expect(formatDate('h[at]A', AT)).toBe('7atPM');
+    expect(formatDate('[]', AT)).toBe('');
+  });
+});
+
+describe('renderSpeechName', () => {
+  it('substitutes {round} and {date:...}', () => {
+    expect(
+      renderSpeechName('Speech {round} {date:M-D h-mmA}', '1NC', AT),
+    ).toBe('Speech 1NC 4-12 7-05PM');
+  });
+
+  it('leaves an unknown field literal', () => {
+    expect(renderSpeechName('{round} {bogus}', '1NC', AT)).toBe('1NC {bogus}');
+  });
+
+  it('supports a template with no date field at all', () => {
+    expect(renderSpeechName('Speech {round}', '2AC', AT)).toBe('Speech 2AC');
+  });
+});
+
+describe('sanitizeFilename', () => {
+  it('strips path separators so the name is a single path segment', () => {
+    const out = sanitizeFilename('1NC/../../evil');
+    expect(out).not.toContain('/');
+    expect(out).not.toContain('\\');
+    // The real property: the result cannot walk out of its folder.
+    expect(out.split(/[/\\]/)).toHaveLength(1);
+  });
+
+  it('turns separators and the colon into hyphens, not nothing', () => {
+    // The reason this matters: these are the characters a date format
+    // legitimately contains. Deleting them would mush the fields.
+    expect(sanitizeFilename('12/04/2026')).toBe('12-04-2026');
+    expect(sanitizeFilename('07:05 pm')).toBe('07-05 pm');
+    expect(sanitizeFilename('a\\b')).toBe('a-b');
+  });
+
+  it('drops the illegal characters that are never deliberate', () => {
+    expect(sanitizeFilename('a*b?c"d<e>f|g')).toBe('abcdefg');
+  });
+
+  it('collapses whitespace and trims leading/trailing spaces and dots', () => {
+    expect(sanitizeFilename('  ..Speech   1NC..  ')).toBe('Speech 1NC');
+  });
+
+  it('truncates to 200 characters', () => {
+    expect(sanitizeFilename('x'.repeat(500))).toHaveLength(200);
+  });
+
+  it('falls back to "Speech" when nothing survives', () => {
+    expect(sanitizeFilename('...   ')).toBe('Speech');
+    expect(sanitizeFilename('')).toBe('Speech');
+  });
+
+  it('defuses an absolute path into one segment', () => {
+    expect(sanitizeFilename('C:\\Windows\\evil')).toBe('C--Windows-evil');
+  });
+});
+
+describe('renderSpeechFilename', () => {
+  it('the default template reproduces the legacy filename exactly', () => {
+    // Legacy: `Speech ${round} ${month}-${day} ${hour}-${mm}${ampm}.${format}`
+    expect(
+      renderSpeechFilename(
+        DEFAULT_SPEECH_FILENAME_TEMPLATE,
+        '1NC',
+        'docx',
+        AT,
+      ),
+    ).toBe('Speech 1NC 4-12 7-05PM.docx');
+  });
+
+  it('appends the extension from the format, never from the template', () => {
+    expect(renderSpeechFilename('Speech {round}', '1NC', 'cmir', AT)).toBe(
+      'Speech 1NC.cmir',
+    );
+  });
+
+  it('sanitizes after rendering, so a hostile round name is defused', () => {
+    expect(
+      renderSpeechFilename('Speech {round}', '../../evil', 'docx', AT),
+    ).toBe('Speech ..-..-evil.docx');
+  });
+
+  it('falls back when the template renders to nothing', () => {
+    expect(renderSpeechFilename('', '', 'docx', AT)).toBe('Speech.docx');
+  });
+});
+
+describe('settings default', () => {
+  it('the shipped default equals the module default', async () => {
+    // Guards the two from drifting apart. If this fails, one of the
+    // two was edited without the other.
+    const { SETTINGS_DEFAULTS } = await import('../../src/editor/settings.js');
+    expect(SETTINGS_DEFAULTS.speechDocFilenameTemplate).toBe(
+      DEFAULT_SPEECH_FILENAME_TEMPLATE,
+    );
+  });
+});


### PR DESCRIPTION
The "New Speech Document" command named every file from a hardcoded pattern: "Speech <round> M-D h-mmAM/PM". The round name was the only part the user controlled. Make the whole pattern a setting.

The new speechDocFilenameTemplate setting takes literal text plus two fields.

- {round} is the name typed at the prompt.

- {date:...} is a date written with day.js-style tokens, which most people already half know from other tools.

  {date:M-D h-mmA}      4-12 7-05PM
  {date:YYYY-MM-DD}     2026-04-12
  {date:MMM D, YYYY}    Apr 12, 2026

Letters are tokens inside a date block, so a literal word there needs brackets: {date:h-mmA [on] MMM D}. Text outside the block never needs them, which is why the tokens are scoped to the block. The settings row shows a live preview against a fixed sample date.

Three supporting changes:

1. Sanitize rendered name. Otherwise, users can inject directory traversal into file names and write outside the target folder.
2. Guard write against overwriting existing files. Collisions are reported to the user and fall back to the native save dialog.
3. Render setting descriptions over several lines, by setting white-space: pre-line.


Tested on Mac ARM Desktop.

Assisted-by: Claude:claude-opus-4-8