### PR TITLE
Add v1 plugin API and cardmirror-bridge

### DIFF
--- a/apps/desktop/src/bridge-handshake.ts
+++ b/apps/desktop/src/bridge-handshake.ts
@@ -97,6 +97,7 @@ async function readHandshake(appId: string): Promise<HandshakeFile | null> {
   }
 }
 
+/** Headers-only deadline — fine for ping, which never reads a body. */
 function fetchWithTimeout(url: string, init: RequestInit, ms: number): Promise<Response> {
   const ctl = new AbortController();
   const timer = setTimeout(() => ctl.abort(), ms);
@@ -146,24 +147,29 @@ export async function flowPost(
   const hs = await readHandshake(appId);
   if (!hs || hs.kind !== 'flow') return { ok: false, error: 'no-such-app' };
   const routePath = route.startsWith('/') ? route : `/${route}`;
+  // One deadline covers connect, headers, AND the body read: a peer that
+  // sends headers then stalls the body must still map to 'timeout'.
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), POST_TIMEOUT_MS);
   let res: Response;
   try {
-    res = await fetchWithTimeout(
-      `http://127.0.0.1:${hs.port}${routePath}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', [BRIDGE_TOKEN_HEADER]: hs.token },
-        body: JSON.stringify(body ?? {}),
-      },
-      POST_TIMEOUT_MS,
-    );
+    res = await fetch(`http://127.0.0.1:${hs.port}${routePath}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', [BRIDGE_TOKEN_HEADER]: hs.token },
+      body: JSON.stringify(body ?? {}),
+      signal: ctl.signal,
+    });
   } catch (err) {
+    clearTimeout(timer);
     if ((err as Error).name === 'AbortError') return { ok: false, error: 'timeout' };
     return { ok: false, error: 'app-not-running' };
   }
   try {
     return { ok: true, status: res.status, body: await res.json() };
-  } catch {
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return { ok: false, error: 'timeout' };
     return { ok: false, error: 'bad-response' };
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/apps/desktop/src/bridge-handshake.ts
+++ b/apps/desktop/src/bridge-handshake.ts
@@ -16,7 +16,8 @@ export const BRIDGE_SCHEMA = 1;
 export const BRIDGE_TOKEN_HEADER = 'X-Bridge-Token';
 const PING_TIMEOUT_MS = 1500;
 const POST_TIMEOUT_MS = 3000;
-const APP_ID_RE = /^[a-z0-9][a-z0-9-]*$/i;
+const APP_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+const MAX_HANDSHAKE_BYTES = 64 * 1024;
 
 export interface FlowAppInfo {
   id: string;
@@ -73,10 +74,12 @@ export async function deleteCardmirrorHandshake(): Promise<void> {
 async function readHandshake(appId: string): Promise<HandshakeFile | null> {
   if (!APP_ID_RE.test(appId)) return null;
   try {
-    const raw = await fs.readFile(path.join(bridgeDirPath(), `${appId}.json`), 'utf8');
+    const filePath = path.join(bridgeDirPath(), `${appId}.json`);
+    if ((await fs.stat(filePath)).size > MAX_HANDSHAKE_BYTES) return null;
+    const raw = await fs.readFile(filePath, 'utf8');
     const obj = JSON.parse(raw) as Partial<HandshakeFile>;
     if (
-      typeof obj.port !== 'number' ||
+      !Number.isInteger(obj.port) || (obj.port as number) < 1 || (obj.port as number) > 65535 ||
       typeof obj.token !== 'string' ||
       typeof obj.kind !== 'string' ||
       typeof obj.app !== 'string'
@@ -88,13 +91,20 @@ async function readHandshake(appId: string): Promise<HandshakeFile | null> {
       app: obj.app,
       appVersion: typeof obj.appVersion === 'string' ? obj.appVersion : '',
       kind: obj.kind,
-      port: obj.port,
+      port: obj.port as number,
       token: obj.token,
       pid: typeof obj.pid === 'number' ? obj.pid : 0,
     };
   } catch {
     return null;
   }
+}
+
+/** An aborted/timed-out fetch surfaces as AbortError, a nested
+ *  AbortError cause, or (undici's deadline) TimeoutError. */
+function isTimeoutError(err: unknown): boolean {
+  const e = err as { name?: string; cause?: { name?: string } };
+  return e?.name === 'AbortError' || e?.name === 'TimeoutError' || e?.cause?.name === 'AbortError';
 }
 
 /** Headers-only deadline — fine for ping, which never reads a body. */
@@ -126,17 +136,24 @@ export async function scanFlowApps(): Promise<FlowAppInfo[]> {
   } catch {
     return [];
   }
-  const out: FlowAppInfo[] = [];
+  const candidates: Array<{ id: string; hs: HandshakeFile }> = [];
   for (const name of names) {
     if (!name.endsWith('.json')) continue;
     const id = name.slice(0, -'.json'.length);
     const hs = await readHandshake(id);
     if (!hs || hs.kind !== 'flow') continue;
-    if (await ping(hs)) {
-      out.push({ id, app: hs.app, appVersion: hs.appVersion, schema: hs.schema, kind: 'flow' });
-    }
+    candidates.push({ id, hs });
   }
-  return out;
+  const alive = await Promise.all(candidates.map((c) => ping(c.hs)));
+  return candidates
+    .filter((_, i) => alive[i])
+    .map(({ id, hs }) => ({
+      id,
+      app: hs.app,
+      appVersion: hs.appVersion,
+      schema: hs.schema,
+      kind: 'flow' as const,
+    }));
 }
 
 export async function flowPost(
@@ -161,13 +178,13 @@ export async function flowPost(
     });
   } catch (err) {
     clearTimeout(timer);
-    if ((err as Error).name === 'AbortError') return { ok: false, error: 'timeout' };
+    if (isTimeoutError(err)) return { ok: false, error: 'timeout' };
     return { ok: false, error: 'app-not-running' };
   }
   try {
     return { ok: true, status: res.status, body: await res.json() };
   } catch (err) {
-    if ((err as Error).name === 'AbortError') return { ok: false, error: 'timeout' };
+    if (isTimeoutError(err)) return { ok: false, error: 'timeout' };
     return { ok: false, error: 'bad-response' };
   } finally {
     clearTimeout(timer);

--- a/apps/desktop/src/bridge-handshake.ts
+++ b/apps/desktop/src/bridge-handshake.ts
@@ -1,0 +1,169 @@
+/**
+ * cardmirror-bridge — the published cross-app handshake standard.
+ * A shared per-platform directory where each debate app writes
+ * `<appId>.json` on launch (atomic), deletes it on quit, and rotates
+ * its token per session. CardMirror mirrors its fast-paste endpoint
+ * here as kind "editor"; flowing apps register as kind "flow".
+ * All cross-app transport is brokered HERE — renderer plugins never
+ * see tokens or sockets.
+ */
+import { app } from 'electron';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+export const BRIDGE_SCHEMA = 1;
+export const BRIDGE_TOKEN_HEADER = 'X-Bridge-Token';
+const PING_TIMEOUT_MS = 1500;
+const POST_TIMEOUT_MS = 3000;
+const APP_ID_RE = /^[a-z0-9][a-z0-9-]*$/i;
+
+export interface FlowAppInfo {
+  id: string;
+  app: string;
+  appVersion: string;
+  schema: number;
+  kind: 'flow';
+}
+export type FlowPostResult =
+  | { ok: true; status: number; body: unknown }
+  | { ok: false; error: 'no-such-app' | 'app-not-running' | 'timeout' | 'bad-response' };
+
+interface HandshakeFile {
+  schema: number;
+  app: string;
+  appVersion: string;
+  kind: string;
+  port: number;
+  token: string;
+  pid: number;
+}
+
+export function bridgeDirPath(): string {
+  if (process.env['CARDMIRROR_BRIDGE_DIR']) return process.env['CARDMIRROR_BRIDGE_DIR'];
+  if (process.platform === 'linux') {
+    const base = process.env['XDG_DATA_HOME'] || path.join(os.homedir(), '.local', 'share');
+    return path.join(base, 'cardmirror-bridge');
+  }
+  return path.join(app.getPath('appData'), 'cardmirror-bridge');
+}
+
+export async function writeCardmirrorHandshake(port: number, token: string): Promise<void> {
+  const dir = bridgeDirPath();
+  const data: HandshakeFile = {
+    schema: BRIDGE_SCHEMA,
+    app: 'cardmirror',
+    appVersion: app.getVersion(),
+    kind: 'editor',
+    port,
+    token,
+    pid: process.pid,
+  };
+  const finalPath = path.join(dir, 'cardmirror.json');
+  const tmpPath = `${finalPath}.tmp`;
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(tmpPath, JSON.stringify(data, null, 2));
+  await fs.rename(tmpPath, finalPath);
+}
+
+export async function deleteCardmirrorHandshake(): Promise<void> {
+  await fs.unlink(path.join(bridgeDirPath(), 'cardmirror.json')).catch(() => {});
+}
+
+async function readHandshake(appId: string): Promise<HandshakeFile | null> {
+  if (!APP_ID_RE.test(appId)) return null;
+  try {
+    const raw = await fs.readFile(path.join(bridgeDirPath(), `${appId}.json`), 'utf8');
+    const obj = JSON.parse(raw) as Partial<HandshakeFile>;
+    if (
+      typeof obj.port !== 'number' ||
+      typeof obj.token !== 'string' ||
+      typeof obj.kind !== 'string' ||
+      typeof obj.app !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      schema: typeof obj.schema === 'number' ? obj.schema : 0,
+      app: obj.app,
+      appVersion: typeof obj.appVersion === 'string' ? obj.appVersion : '',
+      kind: obj.kind,
+      port: obj.port,
+      token: obj.token,
+      pid: typeof obj.pid === 'number' ? obj.pid : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function fetchWithTimeout(url: string, init: RequestInit, ms: number): Promise<Response> {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), ms);
+  return fetch(url, { ...init, signal: ctl.signal }).finally(() => clearTimeout(timer));
+}
+
+async function ping(hs: HandshakeFile): Promise<boolean> {
+  try {
+    const res = await fetchWithTimeout(
+      `http://127.0.0.1:${hs.port}/ping`,
+      { headers: { [BRIDGE_TOKEN_HEADER]: hs.token } },
+      PING_TIMEOUT_MS,
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Live flow apps only — a stale handshake (crashed app) fails the
+ *  ping and is skipped. Tokens never leave this module. */
+export async function scanFlowApps(): Promise<FlowAppInfo[]> {
+  let names: string[];
+  try {
+    names = await fs.readdir(bridgeDirPath());
+  } catch {
+    return [];
+  }
+  const out: FlowAppInfo[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const id = name.slice(0, -'.json'.length);
+    const hs = await readHandshake(id);
+    if (!hs || hs.kind !== 'flow') continue;
+    if (await ping(hs)) {
+      out.push({ id, app: hs.app, appVersion: hs.appVersion, schema: hs.schema, kind: 'flow' });
+    }
+  }
+  return out;
+}
+
+export async function flowPost(
+  appId: string,
+  route: string,
+  body: unknown,
+): Promise<FlowPostResult> {
+  const hs = await readHandshake(appId);
+  if (!hs || hs.kind !== 'flow') return { ok: false, error: 'no-such-app' };
+  const routePath = route.startsWith('/') ? route : `/${route}`;
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(
+      `http://127.0.0.1:${hs.port}${routePath}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', [BRIDGE_TOKEN_HEADER]: hs.token },
+        body: JSON.stringify(body ?? {}),
+      },
+      POST_TIMEOUT_MS,
+    );
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return { ok: false, error: 'timeout' };
+    return { ok: false, error: 'app-not-running' };
+  }
+  try {
+    return { ok: true, status: res.status, body: await res.json() };
+  } catch {
+    return { ok: false, error: 'bad-response' };
+  }
+}

--- a/apps/desktop/src/fast-paste-bridge.ts
+++ b/apps/desktop/src/fast-paste-bridge.ts
@@ -206,6 +206,7 @@ function onJumpAck(_evt: unknown, ack: JumpAck): void {
 }
 
 // keep in sync with SOURCE_TOKEN_PREFIX in src/editor/plugin-source-token.ts
+// (this literal adds the dot separator; the source constant is the bare prefix)
 const SOURCE_TOKEN_PREFIX = 'cmsrc1.';
 
 function dispatchJumpTo(win: BrowserWindow, source: string): Promise<JumpAck> {

--- a/apps/desktop/src/fast-paste-bridge.ts
+++ b/apps/desktop/src/fast-paste-bridge.ts
@@ -205,21 +205,38 @@ function onJumpAck(_evt: unknown, ack: JumpAck): void {
   pending.resolve(ack);
 }
 
+// keep in sync with SOURCE_TOKEN_PREFIX in src/editor/plugin-source-token.ts
+const SOURCE_TOKEN_PREFIX = 'cmsrc1.';
+
 function dispatchJumpTo(win: BrowserWindow, source: string): Promise<JumpAck> {
   return new Promise((resolve) => {
+    if (win.isDestroyed()) {
+      resolve({ requestId: '', ok: false, error: 'not-mine' });
+      return;
+    }
     const requestId = crypto.randomBytes(8).toString('hex');
     const timer = setTimeout(() => {
       pendingJumpAcks.delete(requestId);
       resolve({ requestId, ok: false, error: 'not-mine' });
     }, RENDERER_ACK_TIMEOUT_MS);
     pendingJumpAcks.set(requestId, { resolve, timer });
-    win.webContents.send('external:jump', { requestId, source });
+    try {
+      win.webContents.send('external:jump', { requestId, source });
+    } catch {
+      // Window torn down between the isDestroyed() check and send
+      // (render process gone). Don't leave the route hanging on a
+      // timeout that can never be acked.
+      clearTimeout(timer);
+      pendingJumpAcks.delete(requestId);
+      resolve({ requestId, ok: false, error: 'not-mine' });
+    }
   });
 }
 
 /** Minimal token peek — main only needs docTitle for the
  *  doc-not-open message; full parsing stays renderer-side. */
 function docTitleFromToken(source: string): string | undefined {
+  if (!source.startsWith(SOURCE_TOKEN_PREFIX)) return undefined;
   const dot = source.indexOf('.');
   if (dot < 0) return undefined;
   try {
@@ -237,21 +254,39 @@ function docTitleFromToken(source: string): string | undefined {
 export async function broadcastJump(
   source: string,
 ): Promise<{ ok: boolean; error?: string; docTitle?: string }> {
-  const wins = BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed());
-  let sawBadRequest = false;
-  let sawNotFound = false;
-  for (const win of wins) {
-    const ack = await dispatchJumpTo(win, source);
-    if (ack.ok) {
-      win.show();
-      win.focus();
-      return { ok: true };
-    }
-    if (ack.error === 'bad-request') sawBadRequest = true;
-    if (ack.error === 'not-found') sawNotFound = true;
+  // An unparseable token can never match any window; reject it up front
+  // rather than broadcasting and misreporting doc-not-open (which would
+  // echo a forged docTitle from a token that isn't ours).
+  if (!source.startsWith(SOURCE_TOKEN_PREFIX)) {
+    return { ok: false, error: 'bad-request' };
   }
-  if (sawBadRequest) return { ok: false, error: 'bad-request' };
-  if (sawNotFound) return { ok: false, error: 'not-found' };
+  const wins = BrowserWindow.getAllWindows().filter(
+    (w) =>
+      !w.isDestroyed() &&
+      // ponytail: heuristic — skip windows that have no jump listener and
+      // would just burn the full ack timeout. The timer pop-out loads
+      // timer.html (main.ts:openTimerWindow); add other non-doc window
+      // URLs here if more such windows appear.
+      !w.webContents.getURL().endsWith('timer.html'),
+  );
+  const acks = await Promise.all(
+    wins.map((win) => dispatchJumpTo(win, source).then((ack) => ({ win, ack }))),
+  );
+  // First ok wins. Only one open doc holds a given docId in normal use,
+  // so multiple-ok isn't a real case; if it ever is, the first still wins.
+  const winner = acks.find((a) => a.ack.ok);
+  if (winner) {
+    if (winner.win.isMinimized()) winner.win.restore();
+    winner.win.show();
+    winner.win.focus();
+    return { ok: true };
+  }
+  if (acks.some((a) => a.ack.error === 'bad-request')) {
+    return { ok: false, error: 'bad-request' };
+  }
+  if (acks.some((a) => a.ack.error === 'not-found')) {
+    return { ok: false, error: 'not-found' };
+  }
   const docTitle = docTitleFromToken(source);
   return { ok: false, error: 'doc-not-open', ...(docTitle ? { docTitle } : {}) };
 }
@@ -338,7 +373,14 @@ async function handleRequest(
       jsonResponse(res, 400, { ok: false, error: 'bad-request' });
       return;
     }
-    const result = await broadcastJump(payload.source);
+    let result: { ok: boolean; error?: string; docTitle?: string };
+    try {
+      result = await broadcastJump(payload.source);
+    } catch {
+      // Never let an unexpected broadcast failure hang the client.
+      jsonResponse(res, 500, { ok: false, error: 'internal' });
+      return;
+    }
     if (result.ok) {
       jsonResponse(res, 200, { ok: true });
       return;

--- a/apps/desktop/src/fast-paste-bridge.ts
+++ b/apps/desktop/src/fast-paste-bridge.ts
@@ -34,7 +34,7 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 
 const PREFERRED_PORT = 17699;
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const TOKEN_BYTES = 24;
 /** Hard timeout the client also enforces at 1500ms — keep ours
  *  slightly under so the server fails fast before the client
@@ -64,10 +64,21 @@ interface RendererAck {
   docTitle?: string;
 }
 
+interface JumpAck {
+  requestId: string;
+  ok: boolean;
+  error?: string;
+}
+
 let serverState: { server: http.Server; token: string; port: number } | null = null;
 
 const pendingAcks = new Map<string, {
   resolve: (ack: RendererAck) => void;
+  timer: NodeJS.Timeout;
+}>();
+
+const pendingJumpAcks = new Map<string, {
+  resolve: (ack: JumpAck) => void;
   timer: NodeJS.Timeout;
 }>();
 
@@ -103,7 +114,9 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 function checkToken(req: http.IncomingMessage, token: string): boolean {
-  const header = req.headers['x-fdp-token'];
+  // Schema 2 accepts the cross-app X-Bridge-Token header alongside
+  // the legacy FDP one; both compare constant-time.
+  const header = req.headers['x-bridge-token'] ?? req.headers['x-fdp-token'];
   if (typeof header !== 'string') return false;
   return constantTimeEqual(header, token);
 }
@@ -182,6 +195,66 @@ function onRendererAck(_evt: unknown, ack: RendererAck): void {
   pendingAcks.delete(ack.requestId);
   pending.resolve(ack);
 }
+
+function onJumpAck(_evt: unknown, ack: JumpAck): void {
+  if (!ack || typeof ack.requestId !== 'string') return;
+  const pending = pendingJumpAcks.get(ack.requestId);
+  if (!pending) return;
+  clearTimeout(pending.timer);
+  pendingJumpAcks.delete(ack.requestId);
+  pending.resolve(ack);
+}
+
+function dispatchJumpTo(win: BrowserWindow, source: string): Promise<JumpAck> {
+  return new Promise((resolve) => {
+    const requestId = crypto.randomBytes(8).toString('hex');
+    const timer = setTimeout(() => {
+      pendingJumpAcks.delete(requestId);
+      resolve({ requestId, ok: false, error: 'not-mine' });
+    }, RENDERER_ACK_TIMEOUT_MS);
+    pendingJumpAcks.set(requestId, { resolve, timer });
+    win.webContents.send('external:jump', { requestId, source });
+  });
+}
+
+/** Minimal token peek — main only needs docTitle for the
+ *  doc-not-open message; full parsing stays renderer-side. */
+function docTitleFromToken(source: string): string | undefined {
+  const dot = source.indexOf('.');
+  if (dot < 0) return undefined;
+  try {
+    const obj = JSON.parse(
+      Buffer.from(source.slice(dot + 1), 'base64url').toString('utf8'),
+    ) as { docTitle?: unknown };
+    return typeof obj.docTitle === 'string' && obj.docTitle ? obj.docTitle : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Ask each window in turn to resolve the token; the first ok wins and
+ *  its window is focused. Exported for the host:plugin-jump IPC. */
+export async function broadcastJump(
+  source: string,
+): Promise<{ ok: boolean; error?: string; docTitle?: string }> {
+  const wins = BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed());
+  let sawBadRequest = false;
+  let sawNotFound = false;
+  for (const win of wins) {
+    const ack = await dispatchJumpTo(win, source);
+    if (ack.ok) {
+      win.show();
+      win.focus();
+      return { ok: true };
+    }
+    if (ack.error === 'bad-request') sawBadRequest = true;
+    if (ack.error === 'not-found') sawNotFound = true;
+  }
+  if (sawBadRequest) return { ok: false, error: 'bad-request' };
+  if (sawNotFound) return { ok: false, error: 'not-found' };
+  const docTitle = docTitleFromToken(source);
+  return { ok: false, error: 'doc-not-open', ...(docTitle ? { docTitle } : {}) };
+}
 let ipcSubscribed = false;
 
 async function handleRequest(
@@ -253,6 +326,35 @@ async function handleRequest(
     return;
   }
 
+  if (req.method === 'POST' && url === '/jump') {
+    let payload: { source?: unknown };
+    try {
+      payload = JSON.parse(await readRequestBody(req)) as { source?: unknown };
+    } catch {
+      jsonResponse(res, 400, { ok: false, error: 'bad-request' });
+      return;
+    }
+    if (typeof payload.source !== 'string' || !payload.source) {
+      jsonResponse(res, 400, { ok: false, error: 'bad-request' });
+      return;
+    }
+    const result = await broadcastJump(payload.source);
+    if (result.ok) {
+      jsonResponse(res, 200, { ok: true });
+      return;
+    }
+    if (result.error === 'bad-request') {
+      jsonResponse(res, 400, { ok: false, error: 'bad-request' });
+      return;
+    }
+    jsonResponse(res, 200, {
+      ok: false,
+      error: result.error,
+      ...(result.docTitle ? { docTitle: result.docTitle } : {}),
+    });
+    return;
+  }
+
   jsonResponse(res, 404, { ok: false, error: 'bad-request' });
 }
 
@@ -278,6 +380,7 @@ export async function startFastPasteBridge(): Promise<void> {
   if (serverState) return;
   if (!ipcSubscribed) {
     ipcMain.on('external:insert-result', onRendererAck);
+    ipcMain.on('external:jump-result', onJumpAck);
     ipcSubscribed = true;
   }
 
@@ -328,14 +431,22 @@ export async function stopFastPasteBridge(): Promise<void> {
     pending.resolve({ requestId: '', ok: false, error: 'internal' });
   }
   pendingAcks.clear();
+  for (const pending of pendingJumpAcks.values()) {
+    clearTimeout(pending.timer);
+    pending.resolve({ requestId: '', ok: false, error: 'not-mine' });
+  }
+  pendingJumpAcks.clear();
   // Drop the IPC subscription so a subsequent `start` re-installs
   // it cleanly. Production only ever calls `start` once per app
   // lifetime, but tests cycle the bridge across describe/it blocks
   // and would otherwise carry a stale subscription that the stub
   // can't see.
   if (ipcSubscribed) {
-    (ipcMain as unknown as { removeListener?: (ch: string, l: typeof onRendererAck) => void })
-      .removeListener?.('external:insert-result', onRendererAck);
+    const im = ipcMain as unknown as {
+      removeListener?: (ch: string, l: (...args: never[]) => void) => void;
+    };
+    im.removeListener?.('external:insert-result', onRendererAck);
+    im.removeListener?.('external:jump-result', onJumpAck);
     ipcSubscribed = false;
   }
   await deleteDiscoveryFile();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -49,7 +49,18 @@ import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { gzip as zlibGzip, gunzip as zlibGunzip } from 'node:zlib';
 import { promisify } from 'node:util';
-import { startFastPasteBridge, stopFastPasteBridge } from './fast-paste-bridge.js';
+import {
+  startFastPasteBridge,
+  stopFastPasteBridge,
+  broadcastJump,
+  getRunningEndpoint,
+} from './fast-paste-bridge.js';
+import {
+  writeCardmirrorHandshake,
+  deleteCardmirrorHandshake,
+  scanFlowApps,
+  flowPost,
+} from './bridge-handshake.js';
 
 const DEV_SERVER_URL = 'http://localhost:5173';
 
@@ -2056,6 +2067,21 @@ registerVoiceIpc();
 // Verbatim Flow bridge (Windows COM → Excel). No-ops off Windows.
 registerFlowIpc();
 
+// cardmirror-bridge plugin surface (plugin API v1): jump broadcast via
+// the fast-paste bridge, plus flow-app discovery / POST relay from the
+// shared handshake directory. Tokens never reach the renderer.
+ipcMain.handle('host:plugin-jump', async (_event, source: string) => {
+  if (typeof source !== 'string') return { ok: false, error: 'bad-request' };
+  return broadcastJump(source);
+});
+ipcMain.handle('host:flow-apps', async () => scanFlowApps());
+ipcMain.handle('host:flow-post', async (_event, appId: string, route: string, body: unknown) => {
+  if (typeof appId !== 'string' || typeof route !== 'string') {
+    return { ok: false, error: 'no-such-app' };
+  }
+  return flowPost(appId, route, body);
+});
+
 // Cross-machine card sharing — receive poller + send + inbox. Idle until
 // the renderer sends `host:pairing-configure` with sharing enabled.
 registerPairingIpc();
@@ -2984,11 +3010,22 @@ void app.whenReady().then(() => {
   }
   startAutoUpdate();
   // Fast Debate Paste integration — 127.0.0.1-only HTTP server
-  // exposing `/ping` and `/insert` for the external client. If the
-  // port is taken or the discovery file can't be written, the
+  // exposing `/ping`, `/insert`, and `/jump` for external clients. If
+  // the port is taken or the discovery file can't be written, the
   // bridge silently bails and the client falls back to its
   // keystroke path (the integration is never a hard dependency).
-  void startFastPasteBridge();
+  // Once up, mirror the endpoint into the shared cardmirror-bridge
+  // handshake directory so flow apps can discover us (plugin API v1).
+  void startFastPasteBridge().then(async () => {
+    const ep = getRunningEndpoint();
+    if (ep) {
+      try {
+        await writeCardmirrorHandshake(ep.port, ep.token);
+      } catch {
+        /* non-fatal — flow apps just won't discover us this session */
+      }
+    }
+  });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
@@ -3016,4 +3053,5 @@ app.on('before-quit', () => {
   // `host:close-cancelled` if the user backs out.
   quitInitiated = true;
   void stopFastPasteBridge();
+  void deleteCardmirrorHandshake();
 });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -45,6 +45,13 @@ import {
   recordDiskStateFromDisk,
   nearestExistingDir,
 } from './doc-writes.js';
+import {
+  installFromGithub,
+  listInstalled,
+  readPluginSource,
+  uninstallPlugin,
+  checkPluginUpdate,
+} from './plugin-manager.js';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { gzip as zlibGzip, gunzip as zlibGunzip } from 'node:zlib';
@@ -708,6 +715,40 @@ ipcMain.handle('host:cardcutter-read', async (_event, explicit: string | null) =
   } catch (err) {
     return { error: (err as Error).message, path: target };
   }
+});
+
+// ── Plugin manager (GitHub install; Obsidian model). Installed plugins
+// live in userData/plugins/<id>/ next to the legacy cardcutter file.
+// The renderer asks for a bundle's source and runs it in its main
+// world, same as the card-cutter path above. ──
+ipcMain.handle('host:plugin-install', async (_e, ref: string) => installFromGithub(String(ref)));
+ipcMain.handle('host:plugin-list', async () => listInstalled());
+ipcMain.handle('host:plugin-read', async (_e, id: string) => {
+  const source = await readPluginSource(String(id));
+  return source === null ? { error: 'not found' } : { source };
+});
+ipcMain.handle('host:plugin-read-file', async (_e, filePath: string) => {
+  // Dev path — load an arbitrary local bundle the user picked.
+  if (typeof filePath !== 'string' || !filePath) return { error: 'bad path' };
+  try {
+    return { source: await fs.readFile(filePath, 'utf8') };
+  } catch (err) {
+    return { error: (err as Error).message };
+  }
+});
+ipcMain.handle('host:plugin-uninstall', async (_e, id: string) => uninstallPlugin(String(id)));
+ipcMain.handle('host:plugin-check-update', async (_e, id: string, repoRef: string) =>
+  checkPluginUpdate(String(id), String(repoRef)),
+);
+ipcMain.handle('host:plugin-pick-file', async (event) => {
+  const win = ownerWindow(event.sender);
+  const result = await dialog.showOpenDialog(win ?? new BrowserWindow({ show: false }), {
+    title: 'Select a plugin bundle',
+    properties: ['openFile'],
+    filters: [{ name: 'JavaScript', extensions: ['js', 'mjs', 'cjs'] }],
+  });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  return result.filePaths[0]!;
 });
 
 // Read a file at a known absolute path — used by the home

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3082,10 +3082,6 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin' || quitInitiated) app.quit();
 });
 
-// Tear down the Fast Debate Paste bridge before the app exits so
-// the discovery file goes with us (stale-file tolerance is
-// designed in, but cleaning up our own state means the next launch
-// starts from a known-empty state).
 app.on('before-quit', () => {
   // Remember that a genuine quit was asked for. The per-window
   // `close` handlers will `preventDefault()` this quit to confirm
@@ -3093,6 +3089,17 @@ app.on('before-quit', () => {
   // exit once the confirmations resolve. Cleared by
   // `host:close-cancelled` if the user backs out.
   quitInitiated = true;
+});
+
+// Tear down the Fast Debate Paste bridge only once the quit truly
+// proceeds. `will-quit` fires after every window has confirmed and
+// `window-all-closed` has re-issued the quit — never on a quit the
+// user cancelled (that clears `quitInitiated`, so the second
+// `app.quit()` never runs and `will-quit` never fires). Doing the
+// teardown here instead of in `before-quit` keeps the bridge and
+// both discovery files alive for the rest of the session after a
+// cancelled quit. Stale-file tolerance still covers a hard exit.
+app.on('will-quit', () => {
   void stopFastPasteBridge();
   void deleteCardmirrorHandshake();
 });

--- a/apps/desktop/src/plugin-manager.ts
+++ b/apps/desktop/src/plugin-manager.ts
@@ -1,0 +1,224 @@
+/**
+ * Plugin install/update from GitHub releases (Obsidian model).
+ * A plugin repo publishes two release assets: `cardmirror-plugin.json`
+ * (manifest) and `plugin.js` (built bundle). Installed plugins live in
+ * userData/plugins/<id>/ — one directory per plugin, next to the
+ * legacy cardcutter.global.js FILE, which listInstalled skips.
+ */
+import { app } from 'electron';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+export const MANIFEST_NAME = 'cardmirror-plugin.json';
+export const BUNDLE_NAME = 'plugin.js';
+const PLUGIN_API_VERSION = 1; // keep in sync with src/editor/plugin-registry.ts
+const ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  apiVersion: number;
+  minAppVersion?: string;
+  /** Source repo ("owner/repo"), stamped at install time so update
+   *  checks know where the plugin came from. */
+  repo?: string;
+}
+
+export function parseRepoRef(input: string): { owner: string; repo: string } | null {
+  if (typeof input !== 'string') return null;
+  const s = input.trim();
+  let m = /^([\w.-]+)\/([\w.-]+)$/.exec(s);
+  if (!m) {
+    m = /^https:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?(?:[/?#].*)?$/.exec(s);
+  }
+  if (!m) return null;
+  return { owner: m[1]!, repo: m[2]! };
+}
+
+/** Semver-ish compare good enough for x.y.z and x.y.z-beta.N. */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string): { main: number[]; pre: (number | string)[] | null } => {
+    const [main = '', pre] = v.split('-', 2);
+    return {
+      main: main.split('.').map((n) => parseInt(n, 10) || 0),
+      pre: pre === undefined ? null : pre.split('.').map((p) => (/^\d+$/.test(p) ? parseInt(p, 10) : p)),
+    };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa.main[i] ?? 0) - (pb.main[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  if (pa.pre === null && pb.pre === null) return 0;
+  if (pa.pre === null) return 1; // release > prerelease
+  if (pb.pre === null) return -1;
+  const len = Math.max(pa.pre.length, pb.pre.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa.pre[i];
+    const y = pb.pre[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    if (x === y) continue;
+    if (typeof x === 'number' && typeof y === 'number') return x - y;
+    return String(x) < String(y) ? -1 : 1;
+  }
+  return 0;
+}
+
+export function validateManifest(
+  obj: unknown,
+): { ok: true; manifest: PluginManifest } | { ok: false; error: string } {
+  const m = obj as Partial<PluginManifest> | null;
+  if (!m || typeof m !== 'object') return { ok: false, error: 'manifest is not an object' };
+  if (typeof m.id !== 'string' || !ID_RE.test(m.id)) return { ok: false, error: 'bad plugin id' };
+  if (typeof m.name !== 'string' || !m.name) return { ok: false, error: 'missing name' };
+  if (typeof m.version !== 'string' || !m.version) return { ok: false, error: 'missing version' };
+  if (m.apiVersion !== PLUGIN_API_VERSION) {
+    return { ok: false, error: `plugin needs apiVersion ${String(m.apiVersion)}; this CardMirror supports ${PLUGIN_API_VERSION}` };
+  }
+  return { ok: true, manifest: m as PluginManifest };
+}
+
+function pluginsRootDir(): string {
+  return path.join(app.getPath('userData'), 'plugins');
+}
+function pluginDir(id: string): string {
+  return path.join(pluginsRootDir(), id);
+}
+
+interface GithubAsset { name: string; browser_download_url: string; }
+interface GithubRelease { tag_name: string; assets: GithubAsset[]; }
+
+async function fetchLatestRelease(owner: string, repo: string): Promise<GithubRelease | null> {
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'cardmirror' },
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as GithubRelease;
+}
+
+async function downloadAsset(release: GithubRelease, name: string): Promise<string | null> {
+  const asset = release.assets.find((a) => a.name === name);
+  if (!asset) return null;
+  const res = await fetch(asset.browser_download_url, {
+    headers: { 'User-Agent': 'cardmirror' },
+  });
+  if (!res.ok) return null;
+  return res.text();
+}
+
+export async function installFromGithub(
+  ref: string,
+): Promise<{ ok: true; plugin: PluginManifest } | { ok: false; error: string }> {
+  const parsed = parseRepoRef(ref);
+  if (!parsed) return { ok: false, error: 'Enter a GitHub URL or owner/repo.' };
+  let release: GithubRelease | null;
+  try {
+    release = await fetchLatestRelease(parsed.owner, parsed.repo);
+  } catch {
+    return { ok: false, error: 'Could not reach GitHub.' };
+  }
+  if (!release) return { ok: false, error: 'No releases found for that repository.' };
+  const manifestText = await downloadAsset(release, MANIFEST_NAME).catch(() => null);
+  const bundleText = await downloadAsset(release, BUNDLE_NAME).catch(() => null);
+  if (!manifestText || !bundleText) {
+    return { ok: false, error: `The latest release must attach ${MANIFEST_NAME} and ${BUNDLE_NAME}.` };
+  }
+  let manifestObj: unknown;
+  try {
+    manifestObj = JSON.parse(manifestText);
+  } catch {
+    return { ok: false, error: `${MANIFEST_NAME} is not valid JSON.` };
+  }
+  const v = validateManifest(manifestObj);
+  if (!v.ok) return { ok: false, error: v.error };
+  if (v.manifest.minAppVersion && compareVersions(app.getVersion(), v.manifest.minAppVersion) < 0) {
+    return { ok: false, error: `This plugin needs CardMirror ${v.manifest.minAppVersion} or newer.` };
+  }
+  // Persist the source repo so checkPluginUpdate (and the settings UI)
+  // know where this install came from. Written into the saved manifest,
+  // not just returned — the info must survive an app restart.
+  v.manifest.repo = `${parsed.owner}/${parsed.repo}`;
+  const savedManifestText = JSON.stringify(v.manifest, null, 2);
+  const dir = pluginDir(v.manifest.id);
+  await fs.mkdir(dir, { recursive: true });
+  for (const [name, text] of [
+    [MANIFEST_NAME, savedManifestText],
+    [BUNDLE_NAME, bundleText],
+  ] as const) {
+    const finalPath = path.join(dir, name);
+    const tmpPath = `${finalPath}.tmp`;
+    await fs.writeFile(tmpPath, text);
+    await fs.rename(tmpPath, finalPath);
+  }
+  return { ok: true, plugin: v.manifest };
+}
+
+export async function listInstalled(): Promise<PluginManifest[]> {
+  let entries: { name: string; isDirectory(): boolean }[];
+  try {
+    entries = await fs.readdir(pluginsRootDir(), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: PluginManifest[] = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue; // skips cardcutter.global.js
+    try {
+      const raw = await fs.readFile(path.join(pluginsRootDir(), e.name, MANIFEST_NAME), 'utf8');
+      const v = validateManifest(JSON.parse(raw));
+      if (v.ok && v.manifest.id === e.name) out.push(v.manifest);
+    } catch {
+      /* skip broken installs */
+    }
+  }
+  return out;
+}
+
+export async function readPluginSource(id: string): Promise<string | null> {
+  if (!ID_RE.test(id)) return null;
+  try {
+    return await fs.readFile(path.join(pluginDir(id), BUNDLE_NAME), 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+export async function uninstallPlugin(id: string): Promise<void> {
+  if (!ID_RE.test(id)) return;
+  await fs.rm(pluginDir(id), { recursive: true, force: true });
+}
+
+export async function checkPluginUpdate(
+  id: string,
+  repoRef: string,
+): Promise<{ ok: true; current: string; latest: string; hasUpdate: boolean } | { ok: false; error: string }> {
+  const installed = (await listInstalled()).find((p) => p.id === id);
+  if (!installed) return { ok: false, error: 'not installed' };
+  const parsed = parseRepoRef(repoRef);
+  if (!parsed) return { ok: false, error: 'bad repo ref' };
+  let release: GithubRelease | null;
+  try {
+    release = await fetchLatestRelease(parsed.owner, parsed.repo);
+  } catch {
+    return { ok: false, error: 'Could not reach GitHub.' };
+  }
+  if (!release) return { ok: false, error: 'No releases found.' };
+  const manifestText = await downloadAsset(release, MANIFEST_NAME).catch(() => null);
+  if (!manifestText) return { ok: false, error: 'Release has no manifest.' };
+  try {
+    const latest = (JSON.parse(manifestText) as PluginManifest).version;
+    return {
+      ok: true,
+      current: installed.version,
+      latest,
+      hasUpdate: compareVersions(latest, installed.version) > 0,
+    };
+  } catch {
+    return { ok: false, error: 'Bad manifest in release.' };
+  }
+}

--- a/apps/desktop/src/plugin-manager.ts
+++ b/apps/desktop/src/plugin-manager.ts
@@ -13,6 +13,8 @@ export const MANIFEST_NAME = 'cardmirror-plugin.json';
 export const BUNDLE_NAME = 'plugin.js';
 const PLUGIN_API_VERSION = 1; // keep in sync with src/editor/plugin-registry.ts
 const ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+const RESERVED_ID_RE = /^(con|prn|aux|nul|com\d|lpt\d)$/i; // Windows device names
+const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MiB per release asset
 
 export interface PluginManifest {
   id: string;
@@ -74,13 +76,42 @@ export function validateManifest(
 ): { ok: true; manifest: PluginManifest } | { ok: false; error: string } {
   const m = obj as Partial<PluginManifest> | null;
   if (!m || typeof m !== 'object') return { ok: false, error: 'manifest is not an object' };
-  if (typeof m.id !== 'string' || !ID_RE.test(m.id)) return { ok: false, error: 'bad plugin id' };
+  if (typeof m.id !== 'string' || !ID_RE.test(m.id) || RESERVED_ID_RE.test(m.id)) {
+    return { ok: false, error: 'bad plugin id' };
+  }
   if (typeof m.name !== 'string' || !m.name) return { ok: false, error: 'missing name' };
   if (typeof m.version !== 'string' || !m.version) return { ok: false, error: 'missing version' };
   if (m.apiVersion !== PLUGIN_API_VERSION) {
     return { ok: false, error: `plugin needs apiVersion ${String(m.apiVersion)}; this CardMirror supports ${PLUGIN_API_VERSION}` };
   }
   return { ok: true, manifest: m as PluginManifest };
+}
+
+/**
+ * Guard against id hijack: a second repo publishing a manifest with an
+ * id already owned by an installed plugin would overwrite it. Returns an
+ * error message to block, or null to allow. Same-repo reinstall (the
+ * update path) is allowed; a missing stored repo on the existing install
+ * (pre-repo-field manifests) can't be proven to match, so it blocks —
+ * uninstall + reinstall is the recovery.
+ */
+export function checkInstallCollision(
+  existing: PluginManifest | undefined,
+  ref: string,
+): string | null {
+  if (!existing) return null;
+  if (existing.repo && existing.repo === ref) return null;
+  return `A different plugin ("${existing.repo ?? 'unknown source'}") already owns the id "${existing.id}". Uninstall it first.`;
+}
+
+async function readInstalledManifest(id: string): Promise<PluginManifest | undefined> {
+  try {
+    const raw = await fs.readFile(path.join(pluginDir(id), MANIFEST_NAME), 'utf8');
+    const v = validateManifest(JSON.parse(raw));
+    return v.ok ? v.manifest : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function pluginsRootDir(): string {
@@ -108,7 +139,11 @@ async function downloadAsset(release: GithubRelease, name: string): Promise<stri
     headers: { 'User-Agent': 'cardmirror' },
   });
   if (!res.ok) return null;
-  return res.text();
+  const declared = Number(res.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > MAX_ASSET_BYTES) return null;
+  const text = await res.text();
+  if (text.length > MAX_ASSET_BYTES) return null;
+  return text;
 }
 
 export async function installFromGithub(
@@ -139,10 +174,13 @@ export async function installFromGithub(
   if (v.manifest.minAppVersion && compareVersions(app.getVersion(), v.manifest.minAppVersion) < 0) {
     return { ok: false, error: `This plugin needs CardMirror ${v.manifest.minAppVersion} or newer.` };
   }
+  const ownerRepo = `${parsed.owner}/${parsed.repo}`;
+  const collision = checkInstallCollision(await readInstalledManifest(v.manifest.id), ownerRepo);
+  if (collision) return { ok: false, error: collision };
   // Persist the source repo so checkPluginUpdate (and the settings UI)
   // know where this install came from. Written into the saved manifest,
   // not just returned — the info must survive an app restart.
-  v.manifest.repo = `${parsed.owner}/${parsed.repo}`;
+  v.manifest.repo = ownerRepo;
   const savedManifestText = JSON.stringify(v.manifest, null, 2);
   const dir = pluginDir(v.manifest.id);
   await fs.mkdir(dir, { recursive: true });
@@ -171,7 +209,15 @@ export async function listInstalled(): Promise<PluginManifest[]> {
     try {
       const raw = await fs.readFile(path.join(pluginsRootDir(), e.name, MANIFEST_NAME), 'utf8');
       const v = validateManifest(JSON.parse(raw));
-      if (v.ok && v.manifest.id === e.name) out.push(v.manifest);
+      if (!v.ok || v.manifest.id !== e.name) continue;
+      // The version gate applies at load too, not just install: an app
+      // downgrade must not boot a plugin built for a newer CardMirror.
+      // ponytail: incompatible installs hidden, not listed as disabled
+      if (v.manifest.minAppVersion && compareVersions(app.getVersion(), v.manifest.minAppVersion) < 0) {
+        console.warn(`[plugins] ${e.name} needs CardMirror ${v.manifest.minAppVersion}; skipping`);
+        continue;
+      }
+      out.push(v.manifest);
     } catch {
       /* skip broken installs */
     }

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -905,4 +905,44 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return { ok: false, error: String(e), path: res.path };
     }
   },
+  /** Plugin manager (GitHub install; Obsidian model). Install/list/
+   *  uninstall/update-check round-trip to main; `pluginLoad` /
+   *  `pluginLoadFile` fetch a bundle's source from main and run it in
+   *  the renderer's MAIN world (same mechanism as cardCutterLoad),
+   *  where it self-registers via window.__registerCardMirrorPlugin. */
+  pluginInstall: (ref: string): Promise<Record<string, unknown>> =>
+    ipcRenderer.invoke('host:plugin-install', ref),
+  pluginList: (): Promise<unknown[]> => ipcRenderer.invoke('host:plugin-list'),
+  pluginUninstall: (id: string): Promise<void> => ipcRenderer.invoke('host:plugin-uninstall', id),
+  pluginCheckUpdate: (id: string, repoRef: string): Promise<Record<string, unknown>> =>
+    ipcRenderer.invoke('host:plugin-check-update', id, repoRef),
+  pluginPickFile: (): Promise<string | null> => ipcRenderer.invoke('host:plugin-pick-file'),
+  pluginLoad: async (id: string): Promise<{ ok: boolean; error?: string }> => {
+    const res = (await ipcRenderer.invoke('host:plugin-read', id)) as
+      | { source: string }
+      | { error: string };
+    if (!('source' in res) || !res.source) {
+      return { ok: false, error: 'error' in res ? res.error : 'not found' };
+    }
+    try {
+      await webFrame.executeJavaScript(res.source);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: String(e) };
+    }
+  },
+  pluginLoadFile: async (filePath: string): Promise<{ ok: boolean; error?: string }> => {
+    const res = (await ipcRenderer.invoke('host:plugin-read-file', filePath)) as
+      | { source: string }
+      | { error: string };
+    if (!('source' in res) || !res.source) {
+      return { ok: false, error: 'error' in res ? res.error : 'not found' };
+    }
+    try {
+      await webFrame.executeJavaScript(res.source);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: String(e) };
+    }
+  },
 });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -853,6 +853,33 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('host:flow-create', templatePath),
   /** Pre-warm the persistent PowerShell host (no Excel interaction). */
   flowStartHost: (): Promise<Record<string, unknown>> => ipcRenderer.invoke('host:flow-start'),
+  /** Plugin bridge (plugin API v1 — see the plugin API spec). Jump
+   *  broadcast + flow-app discovery/POST relay resolve through main;
+   *  the jump request/result pair mirrors the external-insert pair
+   *  above (`external:jump` / `external:jump-result`). */
+  pluginJump: (source: string): Promise<Record<string, unknown>> =>
+    ipcRenderer.invoke('host:plugin-jump', source),
+  flowApps: (): Promise<unknown[]> => ipcRenderer.invoke('host:flow-apps'),
+  flowPost: (appId: string, route: string, body: unknown): Promise<Record<string, unknown>> =>
+    ipcRenderer.invoke('host:flow-post', appId, route, body),
+  onExternalJumpRequest(handler: (req: {
+    requestId: string;
+    source: string;
+  }) => void): () => void {
+    const listener = (
+      _evt: unknown,
+      req: { requestId: string; source: string },
+    ): void => handler(req);
+    ipcRenderer.on('external:jump', listener);
+    return () => ipcRenderer.removeListener('external:jump', listener);
+  },
+  sendExternalJumpResult: (result: {
+    requestId: string;
+    ok: boolean;
+    error?: string;
+  }): void => {
+    ipcRenderer.send('external:jump-result', result);
+  },
 
   /** Card-cutter local plugin (experimental). `pick` opens the native
    *  file dialog and returns the chosen path. `load` asks main for the

--- a/reference-docs/cardmirror-plugin-api.md
+++ b/reference-docs/cardmirror-plugin-api.md
@@ -23,7 +23,7 @@ A plugin is one GitHub repository. Each release attaches two assets:
 
 | Field | Type | Required | Rule |
 | --- | --- | --- | --- |
-| `id` | string | yes | Lowercase. Must match `^[a-z0-9][a-z0-9-]*$`. |
+| `id` | string | yes | Lowercase. Must match `^[a-z0-9][a-z0-9-]*$`. Cannot be a Windows reserved device name (`con`, `prn`, `aux`, `nul`, `comN`, `lptN`). |
 | `name` | string | yes | Display name. |
 | `version` | string | yes | Semver, for example `0.1.0` or `0.2.0-beta.1`. |
 | `description` | string | no | One line for the Plugins tab. |
@@ -51,11 +51,14 @@ Example:
 1. The user pastes a GitHub URL or an `owner/repo` shorthand into the
    Plugins settings tab.
 2. The main process fetches the latest GitHub release and downloads
-   the two assets.
+   the two assets. Each asset must be 5 MiB or less.
 3. The app validates the manifest and applies the version gates below.
-4. The app writes both files into `userData/plugins/<id>/` with an
+4. The app checks for an id collision. If a different repository
+   already owns the id, install fails and asks the user to uninstall
+   the existing plugin first.
+5. The app writes both files into `userData/plugins/<id>/` with an
    atomic write (tmp file, then rename).
-5. The user enables the plugin in the Plugins tab. Enabled plugins
+6. The user enables the plugin in the Plugins tab. Enabled plugins
    load from disk at each launch and work offline.
 
 A developer path exists: "Load plugin from file..." in the Plugins tab
@@ -67,6 +70,9 @@ loads a local `plugin.js` without an install.
   Registration rejects it again at load time (section 2).
 - If `minAppVersion` is newer than the app version, install fails with
   "This plugin needs CardMirror `<minAppVersion>` or newer."
+- Both gates also run at every app launch, not only at install. An
+  installed plugin that fails either gate does not load and does not
+  appear in the Plugins tab.
 - The gate is two-sided. At run time, read `api.appVersion` and refuse
   an app that is too old for your plugin.
 
@@ -214,7 +220,8 @@ export interface CardMirrorPluginApi {
   flowing app. The main process reads the target's handshake file,
   attaches the token header, and applies a timeout. Plugins never see
   tokens or sockets. `unsupported` means the desktop host surface is
-  absent.
+  absent. The `ok` field shows transport success only. Read the
+  `status` field for the HTTP result.
 - `docInfo()` - `docId` and `docTitle` of the focused document, or
   `null` when there is none or the doc has no id yet.
 - `showToast(message)` - a transient notification in the app.

--- a/reference-docs/cardmirror-plugin-api.md
+++ b/reference-docs/cardmirror-plugin-api.md
@@ -1,0 +1,424 @@
+# CardMirror plugin API v1
+
+The published contract for CardMirror plugins and for flowing apps.
+This document freezes the v1 surface. The sources of truth are
+`src/editor/plugin-api.ts`, `src/editor/plugin-registry.ts`,
+`apps/desktop/src/plugin-manager.ts`,
+`apps/desktop/src/bridge-handshake.ts`, and
+`apps/desktop/src/fast-paste-bridge.ts`.
+
+Audience: plugin authors and authors of flowing apps. Sections 1 to 3
+and 6 cover renderer plugins. Sections 4 and 5 cover cross-app
+integration over HTTP.
+
+## 1. Plugin packaging
+
+A plugin is one GitHub repository. Each release attaches two assets:
+
+- `cardmirror-plugin.json` - the manifest.
+- `plugin.js` - the built bundle. Only the released bundle loads. The
+  repo source format does not matter.
+
+### Manifest fields
+
+| Field | Type | Required | Rule |
+| --- | --- | --- | --- |
+| `id` | string | yes | Lowercase. Must match `^[a-z0-9][a-z0-9-]*$`. |
+| `name` | string | yes | Display name. |
+| `version` | string | yes | Semver, for example `0.1.0` or `0.2.0-beta.1`. |
+| `description` | string | no | One line for the Plugins tab. |
+| `author` | string | no | Shown in the consent prompt. |
+| `apiVersion` | number | yes | Must be `1`. |
+| `minAppVersion` | string | no | Oldest CardMirror version that the plugin supports. |
+| `repo` | string | never in your release | The installer stamps `owner/repo` into the saved manifest. Update checks read it. Do not set it yourself. |
+
+Example:
+
+```json
+{
+  "id": "cardmirror-ebb",
+  "name": "ebb Flow Integration",
+  "version": "0.1.0",
+  "description": "Send to flow, send extension, and inverse search for ebb.",
+  "author": "smodi",
+  "apiVersion": 1,
+  "minAppVersion": "0.1.0-beta.18"
+}
+```
+
+### Install flow
+
+1. The user pastes a GitHub URL or an `owner/repo` shorthand into the
+   Plugins settings tab.
+2. The main process fetches the latest GitHub release and downloads
+   the two assets.
+3. The app validates the manifest and applies the version gates below.
+4. The app writes both files into `userData/plugins/<id>/` with an
+   atomic write (tmp file, then rename).
+5. The user enables the plugin in the Plugins tab. Enabled plugins
+   load from disk at each launch and work offline.
+
+A developer path exists: "Load plugin from file..." in the Plugins tab
+loads a local `plugin.js` without an install.
+
+### Version gates
+
+- `apiVersion` must equal `1`. Install rejects any other value.
+  Registration rejects it again at load time (section 2).
+- If `minAppVersion` is newer than the app version, install fails with
+  "This plugin needs CardMirror `<minAppVersion>` or newer."
+- The gate is two-sided. At run time, read `api.appVersion` and refuse
+  an app that is too old for your plugin.
+
+## 2. Registration
+
+The bundle self-registers. Call the window global once at load:
+
+```js
+window.__registerCardMirrorPlugin?.({ /* PluginDefinition */ });
+```
+
+The definition types, verbatim from `src/editor/plugin-registry.ts`:
+
+```ts
+export const PLUGIN_API_VERSION = 1;
+
+export interface PluginCommandDef {
+  /** Must start with `<pluginId>.` */
+  id: string;
+  label: string;
+  keywords?: readonly string[];
+  defaultKey?: string | string[] | null;
+  run: (api: CardMirrorPluginApi) => void | Promise<void>;
+}
+
+export interface PluginDefinition {
+  id: string;
+  name: string;
+  apiVersion: number;
+  commands: PluginCommandDef[];
+}
+```
+
+Rules:
+
+- `id` must match the manifest `id`.
+- Every command `id` must start with `<pluginId>.`, for example
+  `cardmirror-ebb.sendToFlow`.
+- Command ids must be unique, both inside the definition and across
+  all registered plugins.
+- Every command needs a non-empty `label` and a `run` function.
+- Each registered plugin receives one `CardMirrorPluginApi` object,
+  minted for its plugin id. Registered commands appear in the command
+  palette and the keymap.
+
+### Failure behavior
+
+Registration never throws and never crashes the app. The registry
+rejects a bad definition, writes a console warning, and shows the
+toast "Plugin failed to load: `<reason>`". Rejection reasons:
+
+- `apiVersion` is not `1`.
+- The plugin id is missing, or a plugin with that id is already
+  registered.
+- `commands` is not an array.
+- A command id lacks the `<pluginId>.` prefix, or is a duplicate.
+- A command lacks a `label` or a `run` function.
+
+A `run` function that throws, or that returns a rejected promise, does
+not crash the app. The registry logs the error and shows a toast with
+the plugin name.
+
+## 3. The capability API
+
+Each command's `run` receives one `api` argument. The full surface,
+verbatim from `src/editor/plugin-api.ts`:
+
+```ts
+export type ExtractedKind =
+  | 'pocket'
+  | 'hat'
+  | 'block'
+  | 'tag'
+  | 'analytic'
+  | 'undertag'
+  | 'cite';
+
+export interface ExtractedItem {
+  kind: ExtractedKind;
+  text: string;
+  /** Opaque provenance token (see plugin-source-token.ts). */
+  source: string;
+}
+
+export interface ExtractResult {
+  ok: true;
+  docId: string;
+  docTitle: string;
+  items: ExtractedItem[];
+}
+
+export type ExtractErrorCode = 'no-heading-at-cursor' | 'no-active-doc' | 'empty-selection';
+export interface ExtractError {
+  ok: false;
+  error: ExtractErrorCode;
+}
+
+export type JumpResult =
+  | { ok: true }
+  | { ok: false; error: 'doc-not-open' | 'not-found' | 'bad-request'; docTitle?: string };
+
+export interface FlowAppInfo {
+  id: string;
+  app: string;
+  appVersion: string;
+  schema: number;
+  kind: 'flow';
+}
+
+export type FlowPostResult =
+  | { ok: true; status: number; body: unknown }
+  | { ok: false; error: 'no-such-app' | 'app-not-running' | 'timeout' | 'bad-response' | 'unsupported' };
+
+export interface PluginStorage {
+  get(key: string): unknown;
+  set(key: string, value: unknown): void;
+}
+
+export interface CardMirrorPluginApi {
+  readonly appVersion: string;
+  extractSelection(): ExtractResult | ExtractError;
+  jumpToSource(token: string): Promise<JumpResult>;
+  flowApps(): Promise<FlowAppInfo[]>;
+  flowPost(appId: string, route: string, body: unknown): Promise<FlowPostResult>;
+  docInfo(): { docId: string; docTitle: string } | null;
+  showToast(message: string): void;
+  storage: PluginStorage;
+}
+```
+
+### Methods
+
+- `appVersion` - the CardMirror version string. Use it for your own
+  compatibility check.
+- `extractSelection()` - synchronous typed extraction from the focused
+  document (rules below). If the document has no `docId` yet, the call
+  mints and stamps one.
+- `jumpToSource(token)` - scroll to and select the source of an
+  extracted item. The resolver tries the focused document first, then
+  every open window. `doc-not-open` carries `docTitle` so you can tell
+  the user which document to open.
+- `flowApps()` - live flowing apps from the handshake directory
+  (section 4). Stale entries fail the liveness ping and do not appear.
+- `flowPost(appId, route, body)` - a brokered loopback POST to a
+  flowing app. The main process reads the target's handshake file,
+  attaches the token header, and applies a timeout. Plugins never see
+  tokens or sockets. `unsupported` means the desktop host surface is
+  absent.
+- `docInfo()` - `docId` and `docTitle` of the focused document, or
+  `null` when there is none or the doc has no id yet.
+- `showToast(message)` - a transient notification in the app.
+- `storage` - per-plugin persistent key-value storage. Values must be
+  JSON-serializable.
+
+### Extraction rules
+
+The selection rule:
+
+- An explicit selection wins. Extraction walks only the selected range.
+- A collapsed cursor expands to the enclosing heading section: from
+  the nearest enclosing heading to the next heading of the same or a
+  shallower level.
+- A cursor above all headings returns `no-heading-at-cursor`. Core
+  does not guess.
+- A range that yields no items returns `empty-selection`.
+- No focused document returns `no-active-doc`.
+
+The item rules, in document order:
+
+- Pocket, hat, block, tag, and analytic nodes emit their full text.
+- Cite paragraphs emit the short cite only, with kind `cite`.
+- Undertags always emit, with kind `undertag`. The plugin decides what
+  to do with them: skip, treat as header, or treat as extension.
+- Card bodies and loose paragraphs never emit. This rule is deliberate
+  and has no override.
+- Whitespace in each item collapses to single spaces. Empty items are
+  dropped.
+
+Heading attribution per item: pocket, hat, block, tag, and analytic
+items carry their own heading UUID. An undertag or cite inside a card
+carries the UUID of the parent card's tag or analytic. A top-level
+undertag carries the UUID of the nearest preceding heading.
+
+### The source token
+
+Each extracted item carries one provenance string in `source`. The
+current format starts with the `cmsrc1` prefix. The token is opaque:
+
+- Store it.
+- Pass it back verbatim, to `jumpToSource` or to the `/jump` route.
+- Never parse it and never build one. Only CardMirror mints and parses
+  tokens. A future format change bumps the prefix, and old tokens stay
+  valid.
+
+## 4. The cardmirror-bridge handshake
+
+This section and section 5 are the frozen cross-app contract. Flowing
+apps build against this file format and these routes. Changes require
+a schema bump.
+
+Each debate app announces its local HTTP endpoint in a shared
+directory. The directory per platform:
+
+- macOS: `~/Library/Application Support/cardmirror-bridge/`
+- Windows: `%APPDATA%/cardmirror-bridge/`
+- Linux: `$XDG_DATA_HOME/cardmirror-bridge/` (fallback
+  `~/.local/share/cardmirror-bridge/`)
+
+Each app writes `<appId>.json` on launch and deletes it on quit. The
+write must be atomic: write a tmp file, then rename it into place.
+CardMirror writes `cardmirror.json` with `kind: "editor"`. Flowing
+apps register with `kind: "flow"`. The file name (without `.json`) is
+the app id and must match `^[a-z0-9][a-z0-9-]*$`.
+
+File format, schema 1:
+
+```json
+{
+  "schema": 1,
+  "app": "ebb",
+  "appVersion": "0.3.0",
+  "kind": "flow",
+  "port": 17700,
+  "token": "hoyfR3k9vXqLmZ2wN8cT1bUj",
+  "pid": 12345
+}
+```
+
+Rules:
+
+- The token is random and rotates each session. A port scan finds
+  nothing usable without the current file.
+- Every request between apps carries the target's token in the
+  `X-Bridge-Token` header. The receiver must compare it in constant
+  time.
+- Liveness: a reader sends `GET /ping` with the token before it trusts
+  a file. A stale file from a crashed process fails the ping, and the
+  reader skips it.
+- Bind the endpoint to `127.0.0.1` only. Never bind `0.0.0.0`.
+
+## 5. CardMirror's HTTP routes for flowing apps
+
+CardMirror serves these routes on the port in `cardmirror.json`. All
+routes require the token, in `X-Bridge-Token` or in the legacy
+`X-FDP-Token` header. A request with an `Origin` or `Referer` header
+is rejected with 403; those requests come from browser pages.
+
+### GET /ping
+
+Liveness and capability probe. Response, schema 2:
+
+```json
+{
+  "ok": true,
+  "app": "cardmirror",
+  "appVersion": "0.1.0-beta.18",
+  "schema": 2,
+  "hasActiveDoc": true
+}
+```
+
+`schema: 2` signals that `/jump` is available.
+
+### POST /insert
+
+Insert text into the focused document. This route predates the plugin
+API and is unchanged. The full wire contract is in
+`cardmirror-integration-spec.md` in this folder. In short: the body is
+`{ "text": "...", "role": "card" | "cite" | "inline", "newParagraph": true, "omitted": false }`,
+and the response is `{ "ok": true, "inserted": true, "docTitle": "..." }`
+or `{ "ok": false, "error": "no-target-doc" | "doc-readonly" | "bad-request" }`.
+
+### POST /jump
+
+Inverse search: jump to the source of an extracted item. Send the
+stored source token, verbatim:
+
+```json
+{ "source": "cmsrc1.eyJkb2NJZCI6..." }
+```
+
+On success, CardMirror focuses the right window, scrolls to the
+source, and selects it:
+
+```json
+{ "ok": true }
+```
+
+Error responses:
+
+| Error | HTTP status | Meaning | Extra field |
+| --- | --- | --- | --- |
+| `doc-not-open` | 200 | The token's document is not open in any window. | `docTitle` - show "open `<docTitle>` first". |
+| `not-found` | 200 | The document is open, but the heading and the text anchor both failed to resolve. | none |
+| `bad-request` | 400 | The body is not JSON, `source` is missing, or the token does not parse. | none |
+
+Example `doc-not-open` response:
+
+```json
+{ "ok": false, "error": "doc-not-open", "docTitle": "AT - Cap K" }
+```
+
+Any other path returns 404 with `{ "ok": false, "error": "bad-request" }`.
+
+## 6. A minimal example plugin
+
+`plugin.js` - registers one command. The command extracts the
+selection and toasts the item count:
+
+```js
+// plugin.js - complete example bundle
+window.__registerCardMirrorPlugin?.({
+  id: 'item-counter',
+  name: 'Item Counter',
+  apiVersion: 1,
+  commands: [
+    {
+      id: 'item-counter.countSelection',
+      label: 'Count extracted items',
+      keywords: ['count', 'extract'],
+      defaultKey: null,
+      run(api) {
+        const result = api.extractSelection();
+        if (!result.ok) {
+          api.showToast('Extraction failed: ' + result.error);
+          return;
+        }
+        const n = result.items.length;
+        api.showToast(
+          'Extracted ' + n + (n === 1 ? ' item from "' : ' items from "') +
+            result.docTitle + '"',
+        );
+      },
+    },
+  ],
+});
+```
+
+`cardmirror-plugin.json`:
+
+```json
+{
+  "id": "item-counter",
+  "name": "Item Counter",
+  "version": "0.1.0",
+  "description": "Count the items that selection extraction returns.",
+  "author": "you",
+  "apiVersion": 1,
+  "minAppVersion": "0.1.0-beta.18"
+}
+```
+
+To test it, open Settings, then Plugins, then "Load plugin from
+file...", and pick `plugin.js`. Run "Count extracted items" from the
+command palette.

--- a/src/editor/host/electron-host.ts
+++ b/src/editor/host/electron-host.ts
@@ -454,6 +454,21 @@ interface ElectronAPI {
     error?: string;
     docTitle?: string;
   }): void;
+  /** Plugin bridge (plugin API v1). Optional so an older preload
+   *  tolerates their absence — callers fall back gracefully. The
+   *  jump request/result pair mirrors the external-insert pair
+   *  above (`external:jump` / `external:jump-result`). */
+  pluginJump?(source: string): Promise<Record<string, unknown>>;
+  flowApps?(): Promise<unknown[]>;
+  flowPost?(appId: string, route: string, body: unknown): Promise<Record<string, unknown>>;
+  onExternalJumpRequest?(
+    handler: (req: { requestId: string; source: string }) => void,
+  ): () => void;
+  sendExternalJumpResult?(result: {
+    requestId: string;
+    ok: boolean;
+    error?: string;
+  }): void;
 }
 
 function api(): ElectronAPI {

--- a/src/editor/host/electron-host.ts
+++ b/src/editor/host/electron-host.ts
@@ -581,6 +581,14 @@ export class ElectronHost implements Host {
     );
   }
 
+  /** Plugin bridge (v1) — bound only when the preload exposes it, so a
+   *  capability check (`host.pluginJump`) reflects the running shell:
+   *  callers pick their own renderer-side fallback (e.g. jumpToSource's
+   *  doc-not-open-with-title), which a stub wrapper couldn't produce. */
+  readonly pluginJump? = api().pluginJump?.bind(api());
+  readonly flowApps? = api().flowApps?.bind(api());
+  readonly flowPost? = api().flowPost?.bind(api());
+
   async openFile(opts: OpenFileOptions = {}): Promise<OpenedFile | null> {
     const result = await api().openFile({ filters: opts.filters ?? [] });
     if (!result) return null;

--- a/src/editor/host/electron-host.ts
+++ b/src/editor/host/electron-host.ts
@@ -169,6 +169,15 @@ interface ElectronAPI {
   cardCutterLoad?(
     enginePath?: string | null,
   ): Promise<{ ok: boolean; path?: string; error?: string }>;
+  /** Plugin manager (GitHub install; optional so an older preload
+   *  tolerates its absence). */
+  pluginInstall?(ref: string): Promise<Record<string, unknown>>;
+  pluginList?(): Promise<unknown[]>;
+  pluginUninstall?(id: string): Promise<void>;
+  pluginCheckUpdate?(id: string, repoRef: string): Promise<Record<string, unknown>>;
+  pluginPickFile?(): Promise<string | null>;
+  pluginLoad?(id: string): Promise<{ ok: boolean; error?: string }>;
+  pluginLoadFile?(filePath: string): Promise<{ ok: boolean; error?: string }>;
   getPathForFile(file: File): string;
   readFileAtPath(filePath: string): Promise<{
     name: string;
@@ -534,6 +543,40 @@ export class ElectronHost implements Host {
       (await api().cardCutterLoad?.(enginePath ?? null)) ?? {
         ok: false,
         error: 'card-cutter loading unsupported by this build',
+      }
+    );
+  }
+
+  /** Plugin manager (GitHub install). No-ops gracefully on an older
+   *  preload that predates the plugin surface. */
+  async pluginInstall(ref: string): Promise<Record<string, unknown>> {
+    return (await api().pluginInstall?.(ref)) ?? { ok: false, error: 'unsupported' };
+  }
+  async pluginList(): Promise<unknown[]> {
+    return (await api().pluginList?.()) ?? [];
+  }
+  async pluginUninstall(id: string): Promise<void> {
+    await api().pluginUninstall?.(id);
+  }
+  async pluginCheckUpdate(id: string, repoRef: string): Promise<Record<string, unknown>> {
+    return (await api().pluginCheckUpdate?.(id, repoRef)) ?? { ok: false, error: 'unsupported' };
+  }
+  async pluginPickFile(): Promise<string | null> {
+    return (await api().pluginPickFile?.()) ?? null;
+  }
+  async pluginLoad(id: string): Promise<{ ok: boolean; error?: string }> {
+    return (
+      (await api().pluginLoad?.(id)) ?? {
+        ok: false,
+        error: 'plugin loading unsupported by this build',
+      }
+    );
+  }
+  async pluginLoadFile(filePath: string): Promise<{ ok: boolean; error?: string }> {
+    return (
+      (await api().pluginLoadFile?.(filePath)) ?? {
+        ok: false,
+        error: 'plugin loading unsupported by this build',
       }
     );
   }

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -8033,7 +8033,19 @@ async function initPlugins(): Promise<void> {
       },
       ensureDocId: () => {
         try {
-          return ensureActiveDocId();
+          // Same three-step path the Learn flows use: mint the id, register
+          // the doc (even unsaved) with the store, and stamp it into the file
+          // so a plugin's extracted tokens re-associate on reload.
+          const docId = ensureActiveDocId();
+          const f = activeFile();
+          learnStore.registerDoc({
+            docId,
+            path: typeof f.handle === 'string' ? f.handle : null,
+            name: f.filename ?? 'Untitled',
+            format: f.format,
+          });
+          void stampActiveFileDocId(docId);
+          return docId;
         } catch {
           return null;
         }

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -269,6 +269,7 @@ import {
   RIBBON_COMMAND_IDS,
   type StructuralRibbonCommandId,
   type RibbonContext,
+  type AnyCommandId,
   type RibbonCommandId,
 } from './ribbon-commands.js';
 import { openWordCount } from './word-count-ui.js';
@@ -2003,7 +2004,7 @@ settingsBtn.addEventListener('click', () => {
  * as clicking the UI — and so binding/unbinding a command never leaves
  * the UI orphaned.
  */
-export function runRibbon(id: RibbonCommandId): void {
+export function runRibbon(id: AnyCommandId): void {
   if (!view) return;
   getRibbonCommand(id, ribbonContext)(view.state, view.dispatch.bind(view), view);
 }
@@ -3807,7 +3808,7 @@ document.addEventListener('keydown', suppressGuiSelectAll, true);
  *  invoke them without a live view — single-doc startup is
  *  view-ful by the time this fires, but multi-doc with no panes
  *  open hits this path. */
-const VIEWLESS_RIBBON_COMMANDS = new Set<RibbonCommandId>([
+const VIEWLESS_RIBBON_COMMANDS = new Set<AnyCommandId>([
   'newDocument',
   'openFile',
   'saveAs',
@@ -3863,7 +3864,7 @@ const VIEWLESS_RIBBON_COMMANDS = new Set<RibbonCommandId>([
   'openDevConsole',
 ]);
 
-function runViewlessRibbon(id: RibbonCommandId): void {
+function runViewlessRibbon(id: AnyCommandId): void {
   switch (id) {
     case 'newDocument': ribbonContext.newDocument(); return;
     case 'openFile': ribbonContext.openFile(); return;
@@ -3920,7 +3921,7 @@ function runViewlessRibbon(id: RibbonCommandId): void {
  *  view-less commands run regardless of focus; the rest go through
  *  `runRibbon` (which no-ops when there's no active view). Used by the
  *  search palette's command source. */
-function runRibbonCommandById(id: RibbonCommandId): void {
+function runRibbonCommandById(id: AnyCommandId): void {
   if (VIEWLESS_RIBBON_COMMANDS.has(id)) {
     runViewlessRibbon(id);
     return;

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -887,6 +887,11 @@ let multiDocSetFocusedFile:
   | null = null;
 /** Set the focused DocRecord's Learn docId (minted/forked lazily). */
 let multiDocSetFocusedDocId: ((docId: string) => void) | null = null;
+/** Find the live view of any pane in this window (focused or not) whose
+ *  DocRecord carries `docId`, else null. Backs the inbound-jump host and
+ *  the plugin API's local-first jump, so a doc open in an unfocused pane
+ *  jumps without the main-process broadcast hop. */
+let multiDocFindViewForDocId: ((docId: string) => EditorView | null) | null = null;
 /** Crash-recovery hook: clear the focused pane's journal after a
  *  successful save in multi-doc mode. The shell knows the
  *  DocRecord's uid; the editor only knows it has a focused doc. */
@@ -962,6 +967,8 @@ export function enableMultiDocMode(opts: {
   } | null;
   setFocusedFile?: (file: { filename: string; handle: unknown | null; format: 'cmir' | 'docx' | null }) => void;
   setFocusedDocId?: (docId: string) => void;
+  /** Live view of any pane holding `docId` (focused or background), or null. */
+  findViewForDocId?: (docId: string) => EditorView | null;
   getAllFilenames?: () => (string | null)[];
   /** Filename of the open doc with `uid` (across all panes + stacks), or null.
    *  Lets collab publish/label a session with its OWNER doc's name rather than
@@ -1018,6 +1025,7 @@ export function enableMultiDocMode(opts: {
   multiDocGetFocusedFile = opts.getFocusedFile ?? null;
   multiDocSetFocusedFile = opts.setFocusedFile ?? null;
   multiDocSetFocusedDocId = opts.setFocusedDocId ?? null;
+  multiDocFindViewForDocId = opts.findViewForDocId ?? null;
   multiDocGetAllFilenames = opts.getAllFilenames ?? null;
   multiDocGetFilenameForUid = opts.getFilenameForUid ?? null;
   multiDocCreateSessionDoc = opts.createSessionDoc ?? null;
@@ -5397,6 +5405,14 @@ function activeDocIdentity(): { docId: string | null; sessionUid: string } {
   return { docId: currentDocId, sessionUid: currentDocUid };
 }
 
+/** Find the live view for a doc open anywhere in THIS window — any pane
+ *  in multi-pane, the single view in single-doc — regardless of focus.
+ *  Returns null when no open doc has that id. */
+function findViewForDocId(docId: string): EditorView | null {
+  if (multiDocActive && multiDocFindViewForDocId) return multiDocFindViewForDocId(docId);
+  return currentDocId === docId ? getActiveView() : null;
+}
+
 /** Write the active doc's persistent docId back into its record
  *  (focused pane in multi-pane, module global in single-doc). */
 function setActiveDocId(docId: string): void {
@@ -8013,8 +8029,7 @@ installExternalInsertHost({
 // answer `external:jump`, regardless of the `pluginsEnabled` switch.
 // No-ops when the preload bridge is absent (web / old shells).
 installPluginJumpHost({
-  getFocusedView: () => getActiveView(),
-  getFocusedDocId: () => activeDocIdentity().docId,
+  findViewForDocId: (docId) => findViewForDocId(docId),
 });
 // Plugin system boot: install the window registry, then load the
 // user-enabled plugins. Gated on the `pluginsEnabled` setting and on
@@ -8027,6 +8042,7 @@ async function initPlugins(): Promise<void> {
     createPluginApi(pluginId, {
       appVersion,
       getView: () => getActiveView(),
+      findViewForDocId: (docId) => findViewForDocId(docId),
       getDocIdentity: () => {
         const a = activeDocIdentity();
         return { docId: a.docId, docTitle: activeFile().filename || 'Untitled' };

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -8068,7 +8068,14 @@ async function initPlugins(): Promise<void> {
       },
     }),
   );
-  const installed = (await host.pluginList()) as { id: string; name: string }[];
+  let installed: { id: string; name: string }[];
+  try {
+    installed = (await host.pluginList()) as { id: string; name: string }[];
+  } catch (err) {
+    console.warn('[plugins] could not list installed plugins:', err);
+    showToast('Plugins failed to load.');
+    return;
+  }
   for (const p of installed) {
     if (!isPluginEnabled(p.id)) continue;
     // A rejecting IPC call must not skip the remaining plugins (or escape

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -57,6 +57,11 @@ import { mountPairingPills, initPairingWiring } from './pairing/pairing-wiring.j
 import { insertMostRecentReceived } from './pairing/inbox-insert.js';
 import { sendViewToStarred } from './pairing/send-to-starred.js';
 import { installExternalInsertHost } from './external-insert-host.js';
+import { installPluginRegistry } from './plugin-registry.js';
+import { createPluginApi } from './plugin-api.js';
+import { installPluginJumpHost } from './plugin-jump-host.js';
+import { isPluginEnabled } from './plugins-store.js';
+import { appVersion } from './install-info.js';
 import {
   decodeModeSwitchMarker,
   encodeModeSwitchMarker,
@@ -8003,6 +8008,45 @@ installExternalInsertHost({
   getFocusedView: () => getActiveView(),
   getFocusedDocTitle: () => activeFile().filename,
 });
+// Plugin system boot: install the window registry + jump host, then
+// load the user-enabled plugins. Gated on the `pluginsEnabled` setting
+// and on a plugin-capable desktop host (no-op on web / old shells).
+async function initPlugins(): Promise<void> {
+  if (!settings.get('pluginsEnabled')) return;
+  const host = getElectronHost();
+  if (!host?.pluginList || !host.pluginLoad) return; // desktop only
+  installPluginRegistry((pluginId) =>
+    createPluginApi(pluginId, {
+      appVersion,
+      getView: () => getActiveView(),
+      getDocIdentity: () => {
+        const a = activeDocIdentity();
+        return { docId: a.docId, docTitle: activeFile().filename || 'Untitled' };
+      },
+      ensureDocId: () => {
+        try {
+          return ensureActiveDocId();
+        } catch {
+          return null;
+        }
+      },
+    }),
+  );
+  installPluginJumpHost({
+    getFocusedView: () => getActiveView(),
+    getFocusedDocId: () => activeDocIdentity().docId,
+  });
+  const installed = (await host.pluginList()) as { id: string; name: string }[];
+  for (const p of installed) {
+    if (!isPluginEnabled(p.id)) continue;
+    const r = await host.pluginLoad(p.id);
+    if (!r.ok) {
+      console.warn(`[plugins] ${p.id} failed to load:`, r.error);
+      showToast(`Plugin ${p.name} failed to load.`);
+    }
+  }
+}
+void initPlugins();
 // Experimental, console-gated AI card cutter. Installs the
 // `__cardcutter('on')` console entry point; does nothing visible
 // until enabled.

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -8008,9 +8008,17 @@ installExternalInsertHost({
   getFocusedView: () => getActiveView(),
   getFocusedDocTitle: () => activeFile().filename,
 });
-// Plugin system boot: install the window registry + jump host, then
-// load the user-enabled plugins. Gated on the `pluginsEnabled` setting
-// and on a plugin-capable desktop host (no-op on web / old shells).
+// Inbound /jump handler — core-owned surface (spec 6): the fast-paste
+// bridge advertises schema 2 unconditionally, so a window must always
+// answer `external:jump`, regardless of the `pluginsEnabled` switch.
+// No-ops when the preload bridge is absent (web / old shells).
+installPluginJumpHost({
+  getFocusedView: () => getActiveView(),
+  getFocusedDocId: () => activeDocIdentity().docId,
+});
+// Plugin system boot: install the window registry, then load the
+// user-enabled plugins. Gated on the `pluginsEnabled` setting and on
+// a plugin-capable desktop host (no-op on web / old shells).
 async function initPlugins(): Promise<void> {
   if (!settings.get('pluginsEnabled')) return;
   const host = getElectronHost();
@@ -8032,10 +8040,6 @@ async function initPlugins(): Promise<void> {
       },
     }),
   );
-  installPluginJumpHost({
-    getFocusedView: () => getActiveView(),
-    getFocusedDocId: () => activeDocIdentity().docId,
-  });
   const installed = (await host.pluginList()) as { id: string; name: string }[];
   for (const p of installed) {
     if (!isPluginEnabled(p.id)) continue;

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -8039,7 +8039,12 @@ async function initPlugins(): Promise<void> {
   const installed = (await host.pluginList()) as { id: string; name: string }[];
   for (const p of installed) {
     if (!isPluginEnabled(p.id)) continue;
-    const r = await host.pluginLoad(p.id);
+    // A rejecting IPC call must not skip the remaining plugins (or escape
+    // the un-awaited initPlugins() as an unhandled rejection).
+    const r = await host.pluginLoad(p.id).catch((err: unknown) => ({
+      ok: false as const,
+      error: err instanceof Error ? err.message : String(err),
+    }));
     if (!r.ok) {
       console.warn(`[plugins] ${p.id} failed to load:`, r.error);
       showToast(`Plugin ${p.name} failed to load.`);

--- a/src/editor/keybindings-editor.ts
+++ b/src/editor/keybindings-editor.ts
@@ -1,5 +1,7 @@
 /**
- * Keybindings editor — one row per `RibbonCommandId`. Each row shows
+ * Keybindings editor — one row per command: every static
+ * `RibbonCommandId` (grouped per `RIBBON_GROUPS`), plus a "Plugins"
+ * section for registered plugin commands. Each row shows
  * the command label, its current bindings (overrides win over
  * defaults) as removable chips, a "+" button to capture a new
  * binding, and a "↺" reset that drops any override for that command
@@ -31,7 +33,6 @@ import {
   formatKeyForDisplay,
   commandLabelFor,
   type AnyCommandId,
-  type RibbonCommandId,
 } from './ribbon-commands.js';
 import { pluginCommandIds, pluginDefaultKey } from './plugin-registry.js';
 import { RIBBON_GROUPS } from './ribbon-groups.js';
@@ -237,7 +238,7 @@ export function buildKeybindingsEditor(): HTMLElement {
     }, 2400);
   }
 
-  function startCapture(id: RibbonCommandId, row: HTMLElement): void {
+  function startCapture(id: AnyCommandId, row: HTMLElement): void {
     if (activeCapture) exitCapture();
     const addBtn = row.querySelector<HTMLButtonElement>('.pmd-keybinding-add');
     const capturePill =
@@ -297,7 +298,7 @@ export function buildKeybindingsEditor(): HTMLElement {
     };
   }
 
-  function renderRow(id: RibbonCommandId): HTMLElement {
+  function renderRow(id: AnyCommandId): HTMLElement {
     const row = document.createElement('div');
     row.className = 'pmd-keybinding-row';
 
@@ -588,6 +589,22 @@ export function buildKeybindingsEditor(): HTMLElement {
       heading.textContent = group.title;
       section.appendChild(heading);
       for (const id of ids) section.appendChild(renderRow(id));
+      list.appendChild(section);
+    }
+    // Registered plugin commands get their own rebind section (spec 3),
+    // reusing the exact same row machinery — the override helpers and
+    // conflict handling above already speak `AnyCommandId`. Skipped
+    // entirely while no plugin has registered commands, so the static
+    // list never grows a stranded empty heading.
+    const pluginIds = pluginCommandIds();
+    if (pluginIds.length > 0) {
+      const section = document.createElement('section');
+      section.className = 'pmd-keybindings-group';
+      const heading = document.createElement('h3');
+      heading.className = 'pmd-keybindings-group-title';
+      heading.textContent = 'Plugins';
+      section.appendChild(heading);
+      for (const id of pluginIds) section.appendChild(renderRow(id));
       list.appendChild(section);
     }
     wrap.appendChild(list);

--- a/src/editor/keybindings-editor.ts
+++ b/src/editor/keybindings-editor.ts
@@ -32,9 +32,11 @@ import {
   ribbonKeyStringFor,
   formatKeyForDisplay,
   commandLabelFor,
+  effectivePluginDefaultKeys,
+  foldKeyString,
   type AnyCommandId,
 } from './ribbon-commands.js';
-import { pluginCommandIds, pluginDefaultKey } from './plugin-registry.js';
+import { pluginCommandIds } from './plugin-registry.js';
 import { RIBBON_GROUPS } from './ribbon-groups.js';
 import { isRibbonCommandAvailable } from './ribbon-availability.js';
 import { settings, type KeyboardMacro } from './settings.js';
@@ -51,12 +53,15 @@ function getOverrides(): Partial<Record<string, string | string[]>> {
  *  out at the chip-rendering level). */
 function resolvedKeys(id: AnyCommandId): string[] {
   const overrides = getOverrides();
+  // Plugin ids resolve through the shared helper so a plugin default that
+  // loses a static collision doesn't show a chip that never dispatches.
+  if (!(id in (DEFAULT_RIBBON_KEYS as Record<string, unknown>))) {
+    return effectivePluginDefaultKeys(id, overrides);
+  }
   const spec =
     id in overrides
       ? overrides[id]!
-      : ((DEFAULT_RIBBON_KEYS as Record<string, string | string[] | undefined>)[id] ??
-        pluginDefaultKey(id) ??
-        []);
+      : ((DEFAULT_RIBBON_KEYS as Record<string, string | string[] | undefined>)[id] ?? []);
   const arr = Array.isArray(spec) ? spec : [spec];
   return arr.filter((k) => typeof k === 'string') as string[];
 }
@@ -124,9 +129,10 @@ function findConflict(
   key: string,
   excludeId: AnyCommandId,
 ): AnyCommandId | null {
+  const folded = foldKeyString(key);
   for (const id of [...RIBBON_COMMAND_IDS, ...pluginCommandIds()]) {
     if (id === excludeId) continue;
-    if (resolvedKeys(id).includes(key)) return id;
+    if (resolvedKeys(id).some((k) => foldKeyString(k) === folded)) return id;
   }
   return null;
 }
@@ -135,7 +141,8 @@ function findConflict(
  *  default exactly, the override is dropped; otherwise the trimmed
  *  list becomes the new override. */
 function removeKeyFromCommand(id: AnyCommandId, key: string): void {
-  const current = resolvedKeys(id).filter((k) => k !== key);
+  const folded = foldKeyString(key);
+  const current = resolvedKeys(id).filter((k) => foldKeyString(k) !== folded);
   setOverrideKeys(id, current);
 }
 

--- a/src/editor/keybindings-editor.ts
+++ b/src/editor/keybindings-editor.ts
@@ -26,18 +26,20 @@
 
 import {
   RIBBON_COMMAND_IDS,
-  RIBBON_COMMAND_LABELS,
   DEFAULT_RIBBON_KEYS,
   ribbonKeyStringFor,
   formatKeyForDisplay,
+  commandLabelFor,
+  type AnyCommandId,
   type RibbonCommandId,
 } from './ribbon-commands.js';
+import { pluginCommandIds, pluginDefaultKey } from './plugin-registry.js';
 import { RIBBON_GROUPS } from './ribbon-groups.js';
 import { isRibbonCommandAvailable } from './ribbon-availability.js';
 import { settings, type KeyboardMacro } from './settings.js';
 import { setIcon } from './icons';
 
-function getOverrides(): Partial<Record<RibbonCommandId, string | string[]>> {
+function getOverrides(): Partial<Record<string, string | string[]>> {
   return settings.get('ribbonKeyOverrides');
 }
 
@@ -46,9 +48,14 @@ function getOverrides(): Partial<Record<RibbonCommandId, string | string[]>> {
  *  in the array (they're meaningless for display but the override
  *  map uses them to signal "explicitly unbound" — we filter those
  *  out at the chip-rendering level). */
-function resolvedKeys(id: RibbonCommandId): string[] {
+function resolvedKeys(id: AnyCommandId): string[] {
   const overrides = getOverrides();
-  const spec = id in overrides ? overrides[id]! : DEFAULT_RIBBON_KEYS[id];
+  const spec =
+    id in overrides
+      ? overrides[id]!
+      : ((DEFAULT_RIBBON_KEYS as Record<string, string | string[] | undefined>)[id] ??
+        pluginDefaultKey(id) ??
+        []);
   const arr = Array.isArray(spec) ? spec : [spec];
   return arr.filter((k) => typeof k === 'string') as string[];
 }
@@ -56,7 +63,7 @@ function resolvedKeys(id: RibbonCommandId): string[] {
 /** Mutator: write a normalized key list back to the override map for
  *  a single command. Always overwrites (so once a row has been
  *  touched, defaults stop applying — explicit list wins). */
-function setOverrideKeys(id: RibbonCommandId, keys: string[]): void {
+function setOverrideKeys(id: AnyCommandId, keys: string[]): void {
   const next = { ...getOverrides() };
   // Normalize: store strings as strings when there's exactly one
   // non-empty entry, arrays otherwise. Keeps the JSON-persisted shape
@@ -74,7 +81,7 @@ function setOverrideKeys(id: RibbonCommandId, keys: string[]): void {
 }
 
 /** Drop any override entry for `id`, falling back to defaults. */
-function clearOverride(id: RibbonCommandId): void {
+function clearOverride(id: AnyCommandId): void {
   const next = { ...getOverrides() };
   delete next[id];
   settings.set('ribbonKeyOverrides', next);
@@ -114,9 +121,9 @@ function setMacroKey(id: string, key: string): void {
  */
 function findConflict(
   key: string,
-  excludeId: RibbonCommandId,
-): RibbonCommandId | null {
-  for (const id of RIBBON_COMMAND_IDS) {
+  excludeId: AnyCommandId,
+): AnyCommandId | null {
+  for (const id of [...RIBBON_COMMAND_IDS, ...pluginCommandIds()]) {
     if (id === excludeId) continue;
     if (resolvedKeys(id).includes(key)) return id;
   }
@@ -126,7 +133,7 @@ function findConflict(
 /** Remove `key` from `id`'s binding set. If the result equals the
  *  default exactly, the override is dropped; otherwise the trimmed
  *  list becomes the new override. */
-function removeKeyFromCommand(id: RibbonCommandId, key: string): void {
+function removeKeyFromCommand(id: AnyCommandId, key: string): void {
   const current = resolvedKeys(id).filter((k) => k !== key);
   setOverrideKeys(id, current);
 }
@@ -270,7 +277,7 @@ export function buildKeybindingsEditor(): HTMLElement {
         removeKeyFromCommand(conflict, key);
         flashConflict(
           row,
-          `Removed ${formatKeyForDisplay(key)} from "${RIBBON_COMMAND_LABELS[conflict]}".`,
+          `Removed ${formatKeyForDisplay(key)} from "${commandLabelFor(conflict)}".`,
         );
       }
       const next = [...resolvedKeys(id)];
@@ -296,7 +303,7 @@ export function buildKeybindingsEditor(): HTMLElement {
 
     const label = document.createElement('span');
     label.className = 'pmd-keybinding-label';
-    label.textContent = RIBBON_COMMAND_LABELS[id];
+    label.textContent = commandLabelFor(id);
     row.appendChild(label);
 
     const chips = document.createElement('span');

--- a/src/editor/learn-anchor.ts
+++ b/src/editor/learn-anchor.ts
@@ -114,19 +114,31 @@ function endPos(flat: Flat, idx: number): number {
   return (flat.pos[flat.pos.length - 1] ?? 0) + 1;
 }
 
+/** Flatten `doc` once and return a builder that maps any `[from, to)` to a
+ *  descriptor. Callers building many descriptors against the same doc (e.g.
+ *  extraction over a selection) MUST use this so the O(doc) flatten happens
+ *  once, not per descriptor. */
+export function createDescriptorBuilder(
+  doc: PMNode,
+): (from: number, to: number) => AnchorDescriptor {
+  const flat = flatten(doc);
+  return (from, to) => {
+    let start = flat.pos.findIndex((p) => p >= from);
+    if (start < 0) start = flat.text.length;
+    let end = flat.pos.findIndex((p) => p >= to);
+    if (end < 0) end = flat.text.length;
+    return {
+      quote: flat.text.slice(start, end),
+      prefix: flat.text.slice(Math.max(0, start - CONTEXT), start),
+      suffix: flat.text.slice(end, end + CONTEXT),
+      approxPos: start,
+    };
+  };
+}
+
 /** Build a descriptor for the selection `[from, to)` in `doc`. */
 export function buildDescriptor(doc: PMNode, from: number, to: number): AnchorDescriptor {
-  const flat = flatten(doc);
-  let start = flat.pos.findIndex((p) => p >= from);
-  if (start < 0) start = flat.text.length;
-  let end = flat.pos.findIndex((p) => p >= to);
-  if (end < 0) end = flat.text.length;
-  return {
-    quote: flat.text.slice(start, end),
-    prefix: flat.text.slice(Math.max(0, start - CONTEXT), start),
-    suffix: flat.text.slice(end, end + CONTEXT),
-    approxPos: start,
-  };
+  return createDescriptorBuilder(doc)(from, to);
 }
 
 /** Length of the common suffix of `a` and the trailing of `b` (how well a

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -2142,11 +2142,21 @@ class MultiPaneShell {
 
   /** View of any pane holding `docId` — every slot's full stack (visible
    *  AND background), so an inbound jump reaches a doc open in an
-   *  unfocused pane. Returns null when no open doc has that id. */
+   *  unfocused pane. A background (stacked-but-hidden) record is RAISED
+   *  to its slot's visible position first: its view stays memory-resident
+   *  while hidden but its `editorEl` is detached, so jumping into it would
+   *  select in an invisible editor and the user would see nothing.
+   *  `showRecord` mounts synchronously (appendChild), so on return the
+   *  view's DOM is attached and `scrollToHeadingId` has an element to hit.
+   *  Returns null when no open doc has that id. */
   findViewForDocId(docId: string): EditorView | null {
     for (const id of SLOT_IDS) {
-      for (const rec of this.slots[id].stack) {
-        if (rec.docId === docId) return rec.view;
+      const slot = this.slots[id];
+      for (const rec of slot.stack) {
+        if (rec.docId === docId) {
+          slot.showRecord(rec); // no-op when already visible
+          return rec.view;
+        }
       }
     }
     return null;

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -2154,6 +2154,10 @@ class MultiPaneShell {
       const slot = this.slots[id];
       for (const rec of slot.stack) {
         if (rec.docId === docId) {
+          // Raised before resolution: if the jump then fails not-found, the
+          // raised record stays visible anyway. Accepted - the doc was
+          // explicitly requested, so surfacing it is reasonable regardless.
+          // Revisit if failed jumps raising docs turns out to be noisy.
           slot.showRecord(rec); // no-op when already visible
           return rec.view;
         }

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -2140,6 +2140,18 @@ class MultiPaneShell {
     if (rec) rec.docId = docId;
   }
 
+  /** View of any pane holding `docId` — every slot's full stack (visible
+   *  AND background), so an inbound jump reaches a doc open in an
+   *  unfocused pane. Returns null when no open doc has that id. */
+  findViewForDocId(docId: string): EditorView | null {
+    for (const id of SLOT_IDS) {
+      for (const rec of this.slots[id].stack) {
+        if (rec.docId === docId) return rec.view;
+      }
+    }
+    return null;
+  }
+
   /** Filenames in every slot, in slot order. Empty slots map to
    *  `null` so callers can preserve positional context if they
    *  want (or filter the nulls out). Used by the OS window-title
@@ -3152,6 +3164,7 @@ export function mountMultiPaneShell(): void {
     getFocusedFile: () => shell!.getFocusedFile(),
     setFocusedFile: (f) => shell!.setFocusedFile(f),
     setFocusedDocId: (id) => shell!.setFocusedDocId(id),
+    findViewForDocId: (id) => shell!.findViewForDocId(id),
     getAllFilenames: () => shell!.getAllFilenames(),
     getFilenameForUid: (uid) => shell!.filenameForUid(uid),
     createSessionDoc: () => shell!.createSessionDocIntoSlot(),

--- a/src/editor/nav-panel.ts
+++ b/src/editor/nav-panel.ts
@@ -48,7 +48,7 @@ function collectOutlineWithWindows(doc: PMNode): HeadingEntry[] {
   // position (no base heading shares a self_ref's pos), preserving inner order.
   return [...base, ...projected].sort((a, b) => a.pos - b.pos);
 }
-import { preciseScrollIntoView } from './precise-scroll.js';
+import { preciseScrollIntoView, scrollToHeadingId } from './precise-scroll.js';
 import {
   collectHeadings,
   computeHeadingRange,
@@ -2090,13 +2090,7 @@ export class NavigationPanel {
       // Fall through to scroll-only behavior if the position is stale.
     }
 
-    if (entry.id) {
-      const target = this.view.dom.querySelector<HTMLElement>(`[data-id="${cssEscape(entry.id)}"]`);
-      if (target) {
-        preciseScrollIntoView(this.view, target);
-        return;
-      }
-    }
+    if (entry.id && scrollToHeadingId(this.view, entry.id)) return;
 
     // Fallback: resolve the doc position and scroll the editor's
     // closest containing element into view.
@@ -2144,10 +2138,4 @@ function maybeCloseContextMenu(e: MouseEvent | KeyboardEvent): void {
 }
 
 /** Minimal CSS.escape polyfill for jsdom-style environments. */
-function cssEscape(s: string): string {
-  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
-    return CSS.escape(s);
-  }
-  return s.replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
-}
 

--- a/src/editor/plugin-api.ts
+++ b/src/editor/plugin-api.ts
@@ -118,7 +118,10 @@ export function createPluginApi(pluginId: string, deps: PluginApiDeps): CardMirr
       const view = deps.findViewForDocId(payload.docId);
       // A matched view always carries payload.docId, so the local jump is
       // authoritative — jumpToTokenInView can't answer 'not-mine' here.
-      if (view) return jumpToTokenInView(view, payload.docId, token) as JumpResult;
+      if (view) {
+        const local = jumpToTokenInView(view, payload.docId, token);
+        if (local !== 'not-mine') return local;
+      }
       const host = getElectronHost();
       if (host?.pluginJump) return (await host.pluginJump(token)) as JumpResult;
       return { ok: false, error: 'doc-not-open', docTitle: payload.docTitle };

--- a/src/editor/plugin-api.ts
+++ b/src/editor/plugin-api.ts
@@ -74,6 +74,10 @@ export interface CardMirrorPluginApi {
 export interface PluginApiDeps {
   appVersion: string;
   getView(): EditorView | null;
+  /** Live view of any pane in this window holding `docId` (focused or
+   *  not), or null. Lets a jump land locally without the IPC hop even
+   *  when the target doc is in an unfocused pane. */
+  findViewForDocId(docId: string): EditorView | null;
   /** Identity of the focused doc; docId null until minted. */
   getDocIdentity(): { docId: string | null; docTitle: string } | null;
   /** Mint + stamp a docId for the focused doc; null when no doc. */
@@ -111,10 +115,9 @@ export function createPluginApi(pluginId: string, deps: PluginApiDeps): CardMirr
     async jumpToSource(token) {
       const payload = parseSourceToken(token);
       if (!payload) return { ok: false, error: 'bad-request' };
-      const view = deps.getView();
-      const ident = deps.getDocIdentity();
-      if (view && ident?.docId === payload.docId) {
-        const local = jumpToTokenInView(view, ident.docId, token);
+      const view = deps.findViewForDocId(payload.docId);
+      if (view) {
+        const local = jumpToTokenInView(view, payload.docId, token);
         if (local !== 'not-mine') return local;
       }
       const host = getElectronHost();

--- a/src/editor/plugin-api.ts
+++ b/src/editor/plugin-api.ts
@@ -1,0 +1,67 @@
+/**
+ * Public plugin API surface — the types a plugin author codes against.
+ * Narrow by design: only what flowing commands need (see the v1 spec).
+ * `createPluginApi` (the implementation) is added by the renderer
+ * wiring task; this file starts as the type contract.
+ */
+
+export type ExtractedKind =
+  | 'pocket'
+  | 'hat'
+  | 'block'
+  | 'tag'
+  | 'analytic'
+  | 'undertag'
+  | 'cite';
+
+export interface ExtractedItem {
+  kind: ExtractedKind;
+  text: string;
+  /** Opaque provenance token (see plugin-source-token.ts). */
+  source: string;
+}
+
+export interface ExtractResult {
+  ok: true;
+  docId: string;
+  docTitle: string;
+  items: ExtractedItem[];
+}
+
+export type ExtractErrorCode = 'no-heading-at-cursor' | 'no-active-doc' | 'empty-selection';
+export interface ExtractError {
+  ok: false;
+  error: ExtractErrorCode;
+}
+
+export type JumpResult =
+  | { ok: true }
+  | { ok: false; error: 'doc-not-open' | 'not-found' | 'bad-request'; docTitle?: string };
+
+export interface FlowAppInfo {
+  id: string;
+  app: string;
+  appVersion: string;
+  schema: number;
+  kind: 'flow';
+}
+
+export type FlowPostResult =
+  | { ok: true; status: number; body: unknown }
+  | { ok: false; error: 'no-such-app' | 'app-not-running' | 'timeout' | 'bad-response' | 'unsupported' };
+
+export interface PluginStorage {
+  get(key: string): unknown;
+  set(key: string, value: unknown): void;
+}
+
+export interface CardMirrorPluginApi {
+  readonly appVersion: string;
+  extractSelection(): ExtractResult | ExtractError;
+  jumpToSource(token: string): Promise<JumpResult>;
+  flowApps(): Promise<FlowAppInfo[]>;
+  flowPost(appId: string, route: string, body: unknown): Promise<FlowPostResult>;
+  docInfo(): { docId: string; docTitle: string } | null;
+  showToast(message: string): void;
+  storage: PluginStorage;
+}

--- a/src/editor/plugin-api.ts
+++ b/src/editor/plugin-api.ts
@@ -116,10 +116,9 @@ export function createPluginApi(pluginId: string, deps: PluginApiDeps): CardMirr
       const payload = parseSourceToken(token);
       if (!payload) return { ok: false, error: 'bad-request' };
       const view = deps.findViewForDocId(payload.docId);
-      if (view) {
-        const local = jumpToTokenInView(view, payload.docId, token);
-        if (local !== 'not-mine') return local;
-      }
+      // A matched view always carries payload.docId, so the local jump is
+      // authoritative — jumpToTokenInView can't answer 'not-mine' here.
+      if (view) return jumpToTokenInView(view, payload.docId, token) as JumpResult;
       const host = getElectronHost();
       if (host?.pluginJump) return (await host.pluginJump(token)) as JumpResult;
       return { ok: false, error: 'doc-not-open', docTitle: payload.docTitle };

--- a/src/editor/plugin-api.ts
+++ b/src/editor/plugin-api.ts
@@ -94,9 +94,18 @@ export function createPluginApi(pluginId: string, deps: PluginApiDeps): CardMirr
     extractSelection() {
       const view = deps.getView();
       if (!view) return { ok: false, error: 'no-active-doc' };
-      const docId = deps.ensureDocId();
       const ident = deps.getDocIdentity();
-      if (!docId || !ident) return { ok: false, error: 'no-active-doc' };
+      if (!ident) return { ok: false, error: 'no-active-doc' };
+      // Extract against the doc's current identity FIRST, so a failed
+      // extraction never mints/stamps a docId onto a pristine file.
+      const res = extractSelection(view, { docId: ident.docId ?? '', docTitle: ident.docTitle });
+      if (!res.ok) return res;
+      if (ident.docId) return res;
+      // First-ever successful extraction on an unstamped doc: mint + stamp,
+      // then re-walk so the emitted tokens carry the real docId.
+      // ponytail: double extraction on first-ever run; cache if it ever shows up in profiles
+      const docId = deps.ensureDocId();
+      if (!docId) return { ok: false, error: 'no-active-doc' };
       return extractSelection(view, { docId, docTitle: ident.docTitle });
     },
     async jumpToSource(token) {

--- a/src/editor/plugin-api.ts
+++ b/src/editor/plugin-api.ts
@@ -1,9 +1,14 @@
 /**
- * Public plugin API surface — the types a plugin author codes against.
- * Narrow by design: only what flowing commands need (see the v1 spec).
- * `createPluginApi` (the implementation) is added by the renderer
- * wiring task; this file starts as the type contract.
+ * Public plugin API surface — the types a plugin author codes against,
+ * plus `createPluginApi`, the renderer-side implementation. Narrow by
+ * design: only what flowing commands need (see the v1 spec).
  */
+import type { EditorView } from 'prosemirror-view';
+import { getElectronHost } from './host/index.js';
+import { showToast } from './toast.js';
+import { extractSelection } from './plugin-extract.js';
+import { jumpToTokenInView } from './plugin-jump.js';
+import { parseSourceToken } from './plugin-source-token.js';
 
 export type ExtractedKind =
   | 'pocket'
@@ -64,4 +69,79 @@ export interface CardMirrorPluginApi {
   docInfo(): { docId: string; docTitle: string } | null;
   showToast(message: string): void;
   storage: PluginStorage;
+}
+
+export interface PluginApiDeps {
+  appVersion: string;
+  getView(): EditorView | null;
+  /** Identity of the focused doc; docId null until minted. */
+  getDocIdentity(): { docId: string | null; docTitle: string } | null;
+  /** Mint + stamp a docId for the focused doc; null when no doc. */
+  ensureDocId(): string | null;
+}
+
+export function createPluginApi(pluginId: string, deps: PluginApiDeps): CardMirrorPluginApi {
+  const storageKey = `plugin:${pluginId}`;
+  const readBag = (): Record<string, unknown> => {
+    try {
+      return JSON.parse(localStorage.getItem(storageKey) || '{}') as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  };
+  return {
+    appVersion: deps.appVersion,
+    extractSelection() {
+      const view = deps.getView();
+      if (!view) return { ok: false, error: 'no-active-doc' };
+      const docId = deps.ensureDocId();
+      const ident = deps.getDocIdentity();
+      if (!docId || !ident) return { ok: false, error: 'no-active-doc' };
+      return extractSelection(view, { docId, docTitle: ident.docTitle });
+    },
+    async jumpToSource(token) {
+      const payload = parseSourceToken(token);
+      if (!payload) return { ok: false, error: 'bad-request' };
+      const view = deps.getView();
+      const ident = deps.getDocIdentity();
+      if (view && ident?.docId === payload.docId) {
+        const local = jumpToTokenInView(view, ident.docId, token);
+        if (local !== 'not-mine') return local;
+      }
+      const host = getElectronHost();
+      if (host?.pluginJump) return (await host.pluginJump(token)) as JumpResult;
+      return { ok: false, error: 'doc-not-open', docTitle: payload.docTitle };
+    },
+    async flowApps() {
+      const host = getElectronHost();
+      if (!host?.flowApps) return [];
+      return (await host.flowApps()) as FlowAppInfo[];
+    },
+    async flowPost(appId, route, body) {
+      const host = getElectronHost();
+      if (!host?.flowPost) return { ok: false, error: 'unsupported' };
+      return (await host.flowPost(appId, route, body)) as FlowPostResult;
+    },
+    docInfo() {
+      const i = deps.getDocIdentity();
+      return i && i.docId ? { docId: i.docId, docTitle: i.docTitle } : null;
+    },
+    showToast(message) {
+      showToast(String(message));
+    },
+    storage: {
+      get(key) {
+        return readBag()[key];
+      },
+      set(key, value) {
+        const bag = readBag();
+        bag[key] = value;
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(bag));
+        } catch {
+          /* quota — non-fatal */
+        }
+      },
+    },
+  };
 }

--- a/src/editor/plugin-extract.ts
+++ b/src/editor/plugin-extract.ts
@@ -1,0 +1,124 @@
+// src/editor/plugin-extract.ts
+/**
+ * Plugin extraction - the core-owned, opinionated "what leaves the doc"
+ * step of send-to-flow. Emits typed heading-like items only. Card
+ * bodies and loose paragraphs NEVER emit (spec rule, no override).
+ * Undertags always emit; the plugin decides what to do with them.
+ */
+import type { EditorView } from 'prosemirror-view';
+import type { Node as PMNode } from 'prosemirror-model';
+import {
+  collectHeadings,
+  computeHeadingRange,
+  collectCiteText,
+  TYPE_TO_LEVEL,
+  type HeadingEntry,
+} from './headings.js';
+import { buildDescriptor } from './learn-anchor.js';
+import { mintSourceToken } from './plugin-source-token.js';
+import type {
+  ExtractResult,
+  ExtractError,
+  ExtractedItem,
+  ExtractedKind,
+} from './plugin-api.js';
+
+export function extractSelection(
+  view: EditorView,
+  ident: { docId: string; docTitle: string },
+): ExtractResult | ExtractError {
+  const { doc } = view.state;
+  const sel = view.state.selection;
+  let from: number;
+  let to: number;
+  if (sel.empty) {
+    const range = enclosingSectionRange(doc, sel.from);
+    if (!range) return { ok: false, error: 'no-heading-at-cursor' };
+    from = range.from;
+    to = range.to;
+  } else {
+    from = sel.from;
+    to = sel.to;
+  }
+  const items = collectItems(doc, from, to, ident);
+  if (items.length === 0) return { ok: false, error: 'empty-selection' };
+  return { ok: true, docId: ident.docId, docTitle: ident.docTitle, items };
+}
+
+/** The section of the nearest heading whose range contains `pos` -
+ *  walking outward: a tag whose card ended before `pos` is skipped in
+ *  favor of the enclosing block/hat/pocket. Null above all headings. */
+function enclosingSectionRange(
+  doc: PMNode,
+  pos: number,
+): { from: number; to: number } | null {
+  const headings = collectHeadings(doc, { skipCite: true });
+  let idx = -1;
+  for (let i = 0; i < headings.length; i++) {
+    if (headings[i]!.pos <= pos) idx = i;
+    else break;
+  }
+  for (let i = idx; i >= 0; i--) {
+    const r = computeHeadingRange(doc, headings[i]!);
+    if (r && pos >= r.from && pos <= r.to) return r;
+  }
+  return null;
+}
+
+/** The governing heading id at `pos` - for selections that start
+ *  mid-card (undertag selected without its tag). */
+function governingHeadingId(doc: PMNode, pos: number): string | null {
+  const headings = collectHeadings(doc, { skipCite: true });
+  let best: HeadingEntry | null = null;
+  for (const h of headings) {
+    if (h.pos <= pos) best = h;
+    else break;
+  }
+  return best?.id ?? null;
+}
+
+function collectItems(
+  doc: PMNode,
+  from: number,
+  to: number,
+  ident: { docId: string; docTitle: string },
+): ExtractedItem[] {
+  const items: ExtractedItem[] = [];
+  let lastHeadingId = governingHeadingId(doc, from);
+  doc.nodesBetween(from, to, (node, pos) => {
+    if (!node.isTextblock) return true; // descend into card / analytic_unit / etc.
+    const type = node.type.name;
+    let kind: ExtractedKind | null = null;
+    let text = '';
+    if (type in TYPE_TO_LEVEL) {
+      kind = type as ExtractedKind;
+      text = node.textContent;
+      const id = node.attrs['id'];
+      lastHeadingId = typeof id === 'string' && id ? id : lastHeadingId;
+    } else if (type === 'undertag') {
+      kind = 'undertag';
+      text = node.textContent;
+    } else if (type === 'cite_paragraph') {
+      kind = 'cite';
+      text = collectCiteText(node);
+    }
+    if (!kind) return false; // card_body / paragraph: never emitted
+    const clean = text.replace(/\s+/g, ' ').trim();
+    if (!clean) return false;
+    const contentFrom = pos + 1;
+    const contentTo = pos + node.nodeSize - 1;
+    const anchor = contentTo > contentFrom ? buildDescriptor(doc, contentFrom, contentTo) : null;
+    items.push({
+      kind,
+      text: clean,
+      source: mintSourceToken({
+        docId: ident.docId,
+        docTitle: ident.docTitle,
+        headingId: lastHeadingId,
+        anchor,
+      }),
+    });
+    return false;
+  });
+  return items;
+}

--- a/src/editor/plugin-extract.ts
+++ b/src/editor/plugin-extract.ts
@@ -14,7 +14,7 @@ import {
   TYPE_TO_LEVEL,
   type HeadingEntry,
 } from './headings.js';
-import { buildDescriptor } from './learn-anchor.js';
+import { createDescriptorBuilder } from './learn-anchor.js';
 import { mintSourceToken } from './plugin-source-token.js';
 import type {
   ExtractResult,
@@ -85,7 +85,15 @@ function collectItems(
 ): ExtractedItem[] {
   const items: ExtractedItem[] = [];
   let lastHeadingId = governingHeadingId(doc, from);
+  const buildDescriptor = createDescriptorBuilder(doc); // flatten once, not per item
   doc.nodesBetween(from, to, (node, pos) => {
+    // Live-view / linked-copy containers hold DERIVED, id-less mirror content
+    // (a duplicate of a section that lives elsewhere in this doc, or in
+    // another file). Emitting it would double up items with wrong
+    // attribution, so skip the whole subtree - same guard collectHeadings
+    // uses for self_ref.
+    if (node.type.name === 'self_ref' || node.type.name === 'transclusion_ref') return false;
+    // ponytail: item-granularity emission; a grazed heading emits in full
     if (!node.isTextblock) return true; // descend into card / analytic_unit / etc.
     const type = node.type.name;
     let kind: ExtractedKind | null = null;
@@ -107,7 +115,7 @@ function collectItems(
     if (!clean) return false;
     const contentFrom = pos + 1;
     const contentTo = pos + node.nodeSize - 1;
-    const anchor = contentTo > contentFrom ? buildDescriptor(doc, contentFrom, contentTo) : null;
+    const anchor = contentTo > contentFrom ? buildDescriptor(contentFrom, contentTo) : null;
     items.push({
       kind,
       text: clean,

--- a/src/editor/plugin-jump-host.ts
+++ b/src/editor/plugin-jump-host.ts
@@ -5,6 +5,7 @@
  */
 import type { EditorView } from 'prosemirror-view';
 import { jumpToTokenInView } from './plugin-jump.js';
+import { parseSourceToken } from './plugin-source-token.js';
 
 interface JumpRequest {
   requestId: string;
@@ -25,8 +26,9 @@ interface JumpBridge {
 }
 
 export interface PluginJumpHostOpts {
-  getFocusedView: () => EditorView | null;
-  getFocusedDocId: () => string | null;
+  /** Return a live view for `docId` if any pane in this window has that
+   *  doc open (focused or not), else null. */
+  findViewForDocId: (docId: string) => EditorView | null;
 }
 
 export function installPluginJumpHost(opts: PluginJumpHostOpts): () => void {
@@ -34,12 +36,19 @@ export function installPluginJumpHost(opts: PluginJumpHostOpts): () => void {
   if (!bridge) return () => {};
   return bridge.onExternalJumpRequest((req) => {
     const requestId = req.requestId;
-    const view = opts.getFocusedView();
+    // Parse FIRST: a garbage token is `bad-request` regardless of which
+    // panes are open, so it never masquerades as `not-mine`.
+    const payload = parseSourceToken(req.source);
+    if (!payload) {
+      bridge.sendExternalJumpResult({ requestId, ok: false, error: 'bad-request' });
+      return;
+    }
+    const view = opts.findViewForDocId(payload.docId);
     if (!view) {
       bridge.sendExternalJumpResult({ requestId, ok: false, error: 'not-mine' });
       return;
     }
-    const res = jumpToTokenInView(view, opts.getFocusedDocId(), req.source);
+    const res = jumpToTokenInView(view, payload.docId, req.source);
     if (res === 'not-mine') {
       bridge.sendExternalJumpResult({ requestId, ok: false, error: 'not-mine' });
     } else if (res.ok) {

--- a/src/editor/plugin-jump-host.ts
+++ b/src/editor/plugin-jump-host.ts
@@ -1,0 +1,64 @@
+/**
+ * Renderer-side handler for inbound jump requests (the fast-paste
+ * bridge's POST /jump, broadcast per window). Mirrors
+ * external-insert-host.ts: structural preload bridge, ack per request.
+ */
+import type { EditorView } from 'prosemirror-view';
+import { jumpToTokenInView } from './plugin-jump.js';
+
+interface JumpRequest {
+  requestId: string;
+  source: string;
+}
+interface JumpAck {
+  requestId: string;
+  ok: boolean;
+  error?: 'not-mine' | 'not-found' | 'bad-request';
+}
+
+/** Preload-exposed API surface this module reads. Defined here as
+ *  a structural type so the renderer build doesn't take a
+ *  build-time dependency on the desktop preload. */
+interface JumpBridge {
+  onExternalJumpRequest(handler: (req: JumpRequest) => void): () => void;
+  sendExternalJumpResult(result: JumpAck): void;
+}
+
+export interface PluginJumpHostOpts {
+  getFocusedView: () => EditorView | null;
+  getFocusedDocId: () => string | null;
+}
+
+export function installPluginJumpHost(opts: PluginJumpHostOpts): () => void {
+  const bridge = pickBridge();
+  if (!bridge) return () => {};
+  return bridge.onExternalJumpRequest((req) => {
+    const requestId = req.requestId;
+    const view = opts.getFocusedView();
+    if (!view) {
+      bridge.sendExternalJumpResult({ requestId, ok: false, error: 'not-mine' });
+      return;
+    }
+    const res = jumpToTokenInView(view, opts.getFocusedDocId(), req.source);
+    if (res === 'not-mine') {
+      bridge.sendExternalJumpResult({ requestId, ok: false, error: 'not-mine' });
+    } else if (res.ok) {
+      bridge.sendExternalJumpResult({ requestId, ok: true });
+    } else {
+      bridge.sendExternalJumpResult({
+        requestId,
+        ok: false,
+        error: res.error === 'doc-not-open' ? 'not-mine' : res.error,
+      });
+    }
+  });
+}
+
+function pickBridge(): JumpBridge | null {
+  const w = window as unknown as { electronAPI?: JumpBridge };
+  const api = w.electronAPI;
+  if (!api) return null;
+  if (typeof api.onExternalJumpRequest !== 'function') return null;
+  if (typeof api.sendExternalJumpResult !== 'function') return null;
+  return api;
+}

--- a/src/editor/plugin-jump.ts
+++ b/src/editor/plugin-jump.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared jump resolution for plugin provenance tokens — used by
+ * api.jumpToSource (local window) and the inbound /jump host.
+ * Resolution order per spec 4.3: heading UUID, then text anchor.
+ */
+import type { EditorView } from 'prosemirror-view';
+import { TextSelection } from 'prosemirror-state';
+import { collectHeadings } from './headings.js';
+import { resolveDescriptor } from './learn-anchor.js';
+import { parseSourceToken, type SourcePayload } from './plugin-source-token.js';
+import type { JumpResult } from './plugin-api.js';
+
+export function resolveJumpInView(view: EditorView, payload: SourcePayload): boolean {
+  const { doc } = view.state;
+  if (payload.headingId) {
+    const entry = collectHeadings(doc, { skipCite: true }).find(
+      (h) => h.id === payload.headingId,
+    );
+    if (entry) {
+      select(view, entry.pos + 1);
+      return true;
+    }
+  }
+  if (payload.anchor) {
+    const r = resolveDescriptor(doc, payload.anchor);
+    if (r) {
+      select(view, r.from);
+      return true;
+    }
+  }
+  return false;
+}
+
+function select(view: EditorView, pos: number): void {
+  const tr = view.state.tr;
+  tr.setSelection(TextSelection.create(tr.doc, Math.min(pos, tr.doc.content.size)));
+  view.dispatch(tr.scrollIntoView());
+  view.focus();
+}
+
+/** Resolve a token against THIS window's doc. 'not-mine' = valid token
+ *  for a different docId (the caller escalates to the main-process
+ *  broadcast). */
+export function jumpToTokenInView(
+  view: EditorView,
+  currentDocId: string | null,
+  token: string,
+): JumpResult | 'not-mine' {
+  const payload = parseSourceToken(token);
+  if (!payload) return { ok: false, error: 'bad-request' };
+  if (!currentDocId || currentDocId !== payload.docId) return 'not-mine';
+  if (resolveJumpInView(view, payload)) return { ok: true };
+  return { ok: false, error: 'not-found', docTitle: payload.docTitle };
+}

--- a/src/editor/plugin-jump.ts
+++ b/src/editor/plugin-jump.ts
@@ -25,10 +25,10 @@ export function resolveJumpInView(view: EditorView, payload: SourcePayload): boo
   }
   if (payload.anchor) {
     const r = resolveDescriptor(doc, payload.anchor);
-    // Never land inside a `self_ref`: its children are read-only mirrored
-    // text, so a match there is a coincidence, not the real source. Treat
-    // it as unresolved and fall through to not-found.
-    if (r && !inSelfRef(doc, r.from)) {
+    // Never land inside a `self_ref` or `transclusion_ref`: their children
+    // are read-only mirrored text, so a match there is a coincidence, not
+    // the real source. Treat it as unresolved and fall through to not-found.
+    if (r && !inMirroredContent(doc, r.from)) {
       select(view, r.from);
       return true;
     }
@@ -36,11 +36,14 @@ export function resolveJumpInView(view: EditorView, payload: SourcePayload): boo
   return false;
 }
 
-/** True when `pos` sits inside a `self_ref` mirror subtree. */
-function inSelfRef(doc: PMNode, pos: number): boolean {
+/** True when `pos` sits inside a `self_ref` or `transclusion_ref` mirror
+ *  subtree. */
+function inMirroredContent(doc: PMNode, pos: number): boolean {
   const $pos = doc.resolve(pos);
   for (let d = $pos.depth; d > 0; d--) {
-    if ($pos.node(d).type.name === 'self_ref') return true;
+    if ($pos.node(d).type.name === 'self_ref' || $pos.node(d).type.name === 'transclusion_ref') {
+      return true;
+    }
   }
   return false;
 }

--- a/src/editor/plugin-jump.ts
+++ b/src/editor/plugin-jump.ts
@@ -4,10 +4,12 @@
  * Resolution order per spec 4.3: heading UUID, then text anchor.
  */
 import type { EditorView } from 'prosemirror-view';
+import type { Node as PMNode } from 'prosemirror-model';
 import { TextSelection } from 'prosemirror-state';
 import { collectHeadings } from './headings.js';
 import { resolveDescriptor } from './learn-anchor.js';
 import { parseSourceToken, type SourcePayload } from './plugin-source-token.js';
+import { scrollToHeadingId } from './precise-scroll.js';
 import type { JumpResult } from './plugin-api.js';
 
 export function resolveJumpInView(view: EditorView, payload: SourcePayload): boolean {
@@ -17,13 +19,16 @@ export function resolveJumpInView(view: EditorView, payload: SourcePayload): boo
       (h) => h.id === payload.headingId,
     );
     if (entry) {
-      select(view, entry.pos + 1);
+      select(view, entry.pos + 1, payload.headingId);
       return true;
     }
   }
   if (payload.anchor) {
     const r = resolveDescriptor(doc, payload.anchor);
-    if (r) {
+    // Never land inside a `self_ref`: its children are read-only mirrored
+    // text, so a match there is a coincidence, not the real source. Treat
+    // it as unresolved and fall through to not-found.
+    if (r && !inSelfRef(doc, r.from)) {
       select(view, r.from);
       return true;
     }
@@ -31,10 +36,25 @@ export function resolveJumpInView(view: EditorView, payload: SourcePayload): boo
   return false;
 }
 
-function select(view: EditorView, pos: number): void {
+/** True when `pos` sits inside a `self_ref` mirror subtree. */
+function inSelfRef(doc: PMNode, pos: number): boolean {
+  const $pos = doc.resolve(pos);
+  for (let d = $pos.depth; d > 0; d--) {
+    if ($pos.node(d).type.name === 'self_ref') return true;
+  }
+  return false;
+}
+
+function select(view: EditorView, pos: number, headingId?: string): void {
   const tr = view.state.tr;
   tr.setSelection(TextSelection.create(tr.doc, Math.min(pos, tr.doc.content.size)));
-  view.dispatch(tr.scrollIntoView());
+  view.dispatch(tr);
+  // Route through the nav-pane precise-scroll path when a heading id is
+  // known and rendered; fall back to a plain scroll (anchor-only jumps,
+  // or a headless/test DOM where the element isn't present).
+  if (!headingId || !scrollToHeadingId(view, headingId)) {
+    view.dispatch(view.state.tr.scrollIntoView());
+  }
   view.focus();
 }
 

--- a/src/editor/plugin-registry.ts
+++ b/src/editor/plugin-registry.ts
@@ -62,7 +62,12 @@ export function registerPluginDefinition(
       error: `unsupported apiVersion ${String(def.apiVersion)} (this CardMirror supports ${PLUGIN_API_VERSION})`,
     };
   }
-  if (plugins.has(def.id)) return { ok: false, error: `plugin "${def.id}" already registered` };
+  // Ids this plugin already owns — so a re-registration (e.g. re-enable
+  // re-runs the bundle) doesn't trip the global command-collision check
+  // against its own previously-registered commands.
+  const ownIds = new Set(
+    [...commands.entries()].filter(([, e]) => e.pluginId === def.id).map(([id]) => id),
+  );
   const raw = def.commands;
   const cmds = Array.isArray(raw) ? [...raw] : null;
   if (!cmds) return { ok: false, error: 'commands must be an array' };
@@ -93,11 +98,18 @@ export function registerPluginDefinition(
     ) {
       return { ok: false, error: `command "${id}" has invalid defaultKey` };
     }
-    if (commands.has(id) || seen.has(id)) {
+    if ((commands.has(id) && !ownIds.has(id)) || seen.has(id)) {
       return { ok: false, error: `command id "${id}" already registered` };
     }
     seen.add(id);
     snapshots.push({ id, label, keywords, defaultKey, run });
+  }
+  if (plugins.has(def.id)) {
+    // Already registered: an identical command-id list is a silent no-op
+    // success (the re-enable path); any difference still rejects.
+    const same = seen.size === ownIds.size && [...seen].every((id) => ownIds.has(id));
+    if (same) return { ok: true };
+    return { ok: false, error: `plugin "${def.id}" already registered` };
   }
   const api = makeApi(def.id);
   plugins.set(def.id, { def, api });

--- a/src/editor/plugin-registry.ts
+++ b/src/editor/plugin-registry.ts
@@ -56,6 +56,7 @@ export function registerPluginDefinition(
   }
   if (plugins.has(def.id)) return { ok: false, error: `plugin "${def.id}" already registered` };
   if (!Array.isArray(def.commands)) return { ok: false, error: 'commands must be an array' };
+  const seen = new Set<string>();
   for (const c of def.commands) {
     if (typeof c.id !== 'string' || !c.id.startsWith(`${def.id}.`)) {
       return { ok: false, error: `command id "${String(c.id)}" must start with "${def.id}."` };
@@ -66,7 +67,10 @@ export function registerPluginDefinition(
     if (typeof c.run !== 'function') {
       return { ok: false, error: `command "${c.id}" has no run function` };
     }
-    if (commands.has(c.id)) return { ok: false, error: `command id "${c.id}" already registered` };
+    if (commands.has(c.id) || seen.has(c.id)) {
+      return { ok: false, error: `command id "${c.id}" already registered` };
+    }
+    seen.add(c.id);
   }
   const api = makeApi(def.id);
   plugins.set(def.id, { def, api });
@@ -116,7 +120,8 @@ export function runPluginCommand(id: string): boolean {
   if (!plugin) return false;
   const report = (err: unknown): void => {
     console.error(`[plugins] ${id} failed:`, err);
-    showToast(`${plugin.def.name}: command failed — ${(err as Error).message}`);
+    const message = err instanceof Error ? err.message : String(err);
+    showToast(`${plugin.def.name}: command failed — ${message}`);
   };
   try {
     const r = entry.cmd.run(plugin.api);

--- a/src/editor/plugin-registry.ts
+++ b/src/editor/plugin-registry.ts
@@ -1,0 +1,141 @@
+/**
+ * Plugin registry — the only place plugin bundles register. A bundle
+ * (loaded by the desktop host) calls `window.__registerCardMirrorPlugin`
+ * with a versioned definition; the registry validates it, mints the
+ * plugin's capability api object, and indexes its commands so the
+ * ribbon/palette/keymap chokepoints can find them. Card-cutter-port
+ * precedent: if nothing registers, everything stays inert.
+ */
+import { showToast } from './toast.js';
+import type { CardMirrorPluginApi } from './plugin-api.js';
+
+export const PLUGIN_API_VERSION = 1;
+
+export interface PluginCommandDef {
+  /** Must start with `<pluginId>.` */
+  id: string;
+  label: string;
+  keywords?: readonly string[];
+  defaultKey?: string | string[] | null;
+  run: (api: CardMirrorPluginApi) => void | Promise<void>;
+}
+
+export interface PluginDefinition {
+  id: string;
+  name: string;
+  apiVersion: number;
+  commands: PluginCommandDef[];
+}
+
+declare global {
+  interface Window {
+    __registerCardMirrorPlugin?: (def: PluginDefinition) => void;
+  }
+}
+
+interface RegisteredPlugin {
+  def: PluginDefinition;
+  api: CardMirrorPluginApi;
+}
+
+const plugins = new Map<string, RegisteredPlugin>();
+const commands = new Map<string, { pluginId: string; cmd: PluginCommandDef }>();
+let makeApi: ((pluginId: string) => CardMirrorPluginApi) | null = null;
+
+export function registerPluginDefinition(
+  def: PluginDefinition,
+): { ok: true } | { ok: false; error: string } {
+  if (!makeApi) return { ok: false, error: 'plugin system not initialized' };
+  if (!def || typeof def !== 'object') return { ok: false, error: 'bad definition' };
+  if (typeof def.id !== 'string' || !def.id) return { ok: false, error: 'missing plugin id' };
+  if (def.apiVersion !== PLUGIN_API_VERSION) {
+    return {
+      ok: false,
+      error: `unsupported apiVersion ${String(def.apiVersion)} (this CardMirror supports ${PLUGIN_API_VERSION})`,
+    };
+  }
+  if (plugins.has(def.id)) return { ok: false, error: `plugin "${def.id}" already registered` };
+  if (!Array.isArray(def.commands)) return { ok: false, error: 'commands must be an array' };
+  for (const c of def.commands) {
+    if (typeof c.id !== 'string' || !c.id.startsWith(`${def.id}.`)) {
+      return { ok: false, error: `command id "${String(c.id)}" must start with "${def.id}."` };
+    }
+    if (typeof c.label !== 'string' || !c.label) {
+      return { ok: false, error: `command "${c.id}" has no label` };
+    }
+    if (typeof c.run !== 'function') {
+      return { ok: false, error: `command "${c.id}" has no run function` };
+    }
+    if (commands.has(c.id)) return { ok: false, error: `command id "${c.id}" already registered` };
+  }
+  const api = makeApi(def.id);
+  plugins.set(def.id, { def, api });
+  for (const c of def.commands) commands.set(c.id, { pluginId: def.id, cmd: c });
+  return { ok: true };
+}
+
+/** Install the window global. `createApi` mints one capability object
+ *  per plugin id (dependency-injected so tests can stub it). */
+export function installPluginRegistry(
+  createApi: (pluginId: string) => CardMirrorPluginApi,
+): void {
+  makeApi = createApi;
+  window.__registerCardMirrorPlugin = (def) => {
+    const res = registerPluginDefinition(def);
+    if (res.ok) {
+      console.log(`[plugins] registered ${def.id} (${def.commands.length} commands)`);
+    } else {
+      console.warn(`[plugins] registration rejected: ${res.error}`);
+      showToast(`Plugin failed to load: ${res.error}`);
+    }
+  };
+}
+
+export function pluginCommandIds(): string[] {
+  return [...commands.keys()];
+}
+export function isPluginCommandId(id: string): boolean {
+  return commands.has(id);
+}
+export function pluginCommandLabel(id: string): string | null {
+  return commands.get(id)?.cmd.label ?? null;
+}
+export function pluginCommandKeywords(id: string): readonly string[] {
+  return commands.get(id)?.cmd.keywords ?? [];
+}
+export function pluginDefaultKey(id: string): string | string[] | null {
+  return commands.get(id)?.cmd.defaultKey ?? null;
+}
+
+/** Run a plugin command by id. Never throws: sync and async failures
+ *  both log and toast with the plugin's name. */
+export function runPluginCommand(id: string): boolean {
+  const entry = commands.get(id);
+  if (!entry) return false;
+  const plugin = plugins.get(entry.pluginId);
+  if (!plugin) return false;
+  const report = (err: unknown): void => {
+    console.error(`[plugins] ${id} failed:`, err);
+    showToast(`${plugin.def.name}: command failed — ${(err as Error).message}`);
+  };
+  try {
+    const r = entry.cmd.run(plugin.api);
+    if (r && typeof (r as Promise<void>).catch === 'function') {
+      void (r as Promise<void>).catch(report);
+    }
+  } catch (err) {
+    report(err);
+  }
+  return true;
+}
+
+export function registeredPlugins(): { id: string; name: string }[] {
+  return [...plugins.values()].map((p) => ({ id: p.def.id, name: p.def.name }));
+}
+
+export function resetPluginRegistryForTests(): void {
+  plugins.clear();
+  commands.clear();
+  makeApi = null;
+  if (typeof window !== 'undefined') delete window.__registerCardMirrorPlugin;
+}

--- a/src/editor/plugin-registry.ts
+++ b/src/editor/plugin-registry.ts
@@ -63,43 +63,41 @@ export function registerPluginDefinition(
     };
   }
   if (plugins.has(def.id)) return { ok: false, error: `plugin "${def.id}" already registered` };
-  const cmds = Array.isArray(def.commands) ? [...def.commands] : null;
+  const raw = def.commands;
+  const cmds = Array.isArray(raw) ? [...raw] : null;
   if (!cmds) return { ok: false, error: 'commands must be an array' };
   const seen = new Set<string>();
   const snapshots: PluginCommandDef[] = [];
   const prefix = `${def.id}.`;
   for (const c of cmds) {
-    if (typeof c.id !== 'string' || !c.id.startsWith(prefix) || c.id.length === prefix.length) {
-      return { ok: false, error: `command id "${String(c.id)}" must start with "${prefix}"` };
+    // Read every field exactly once — a stateful getter must not be able
+    // to pass validation with one value and register a different one.
+    const { id, label, keywords, defaultKey, run } = c;
+    if (typeof id !== 'string' || !id.startsWith(prefix) || id.length === prefix.length) {
+      return { ok: false, error: `command id "${String(id)}" must start with "${prefix}"` };
     }
-    if (typeof c.label !== 'string' || !c.label) {
-      return { ok: false, error: `command "${c.id}" has no label` };
+    if (typeof label !== 'string' || !label) {
+      return { ok: false, error: `command "${id}" has no label` };
     }
-    if (typeof c.run !== 'function') {
-      return { ok: false, error: `command "${c.id}" has no run function` };
+    if (typeof run !== 'function') {
+      return { ok: false, error: `command "${id}" has no run function` };
     }
-    if (c.keywords !== undefined && !isStringArray(c.keywords)) {
-      return { ok: false, error: `command "${c.id}" has invalid keywords` };
+    if (keywords !== undefined && !isStringArray(keywords)) {
+      return { ok: false, error: `command "${id}" has invalid keywords` };
     }
     if (
-      c.defaultKey !== undefined &&
-      c.defaultKey !== null &&
-      typeof c.defaultKey !== 'string' &&
-      !isStringArray(c.defaultKey)
+      defaultKey !== undefined &&
+      defaultKey !== null &&
+      typeof defaultKey !== 'string' &&
+      !isStringArray(defaultKey)
     ) {
-      return { ok: false, error: `command "${c.id}" has invalid defaultKey` };
+      return { ok: false, error: `command "${id}" has invalid defaultKey` };
     }
-    if (commands.has(c.id) || seen.has(c.id)) {
-      return { ok: false, error: `command id "${c.id}" already registered` };
+    if (commands.has(id) || seen.has(id)) {
+      return { ok: false, error: `command id "${id}" already registered` };
     }
-    seen.add(c.id);
-    snapshots.push({
-      id: c.id,
-      label: c.label,
-      keywords: c.keywords,
-      defaultKey: c.defaultKey,
-      run: c.run,
-    });
+    seen.add(id);
+    snapshots.push({ id, label, keywords, defaultKey, run });
   }
   const api = makeApi(def.id);
   plugins.set(def.id, { def, api });

--- a/src/editor/plugin-registry.ts
+++ b/src/editor/plugin-registry.ts
@@ -42,12 +42,20 @@ const plugins = new Map<string, RegisteredPlugin>();
 const commands = new Map<string, { pluginId: string; cmd: PluginCommandDef }>();
 let makeApi: ((pluginId: string) => CardMirrorPluginApi) | null = null;
 
+const PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string');
+}
+
 export function registerPluginDefinition(
   def: PluginDefinition,
 ): { ok: true } | { ok: false; error: string } {
   if (!makeApi) return { ok: false, error: 'plugin system not initialized' };
   if (!def || typeof def !== 'object') return { ok: false, error: 'bad definition' };
   if (typeof def.id !== 'string' || !def.id) return { ok: false, error: 'missing plugin id' };
+  if (!PLUGIN_ID_RE.test(def.id)) return { ok: false, error: `invalid plugin id "${def.id}"` };
+  if (typeof def.name !== 'string' || !def.name) return { ok: false, error: 'missing plugin name' };
   if (def.apiVersion !== PLUGIN_API_VERSION) {
     return {
       ok: false,
@@ -55,11 +63,14 @@ export function registerPluginDefinition(
     };
   }
   if (plugins.has(def.id)) return { ok: false, error: `plugin "${def.id}" already registered` };
-  if (!Array.isArray(def.commands)) return { ok: false, error: 'commands must be an array' };
+  const cmds = Array.isArray(def.commands) ? [...def.commands] : null;
+  if (!cmds) return { ok: false, error: 'commands must be an array' };
   const seen = new Set<string>();
-  for (const c of def.commands) {
-    if (typeof c.id !== 'string' || !c.id.startsWith(`${def.id}.`)) {
-      return { ok: false, error: `command id "${String(c.id)}" must start with "${def.id}."` };
+  const snapshots: PluginCommandDef[] = [];
+  const prefix = `${def.id}.`;
+  for (const c of cmds) {
+    if (typeof c.id !== 'string' || !c.id.startsWith(prefix) || c.id.length === prefix.length) {
+      return { ok: false, error: `command id "${String(c.id)}" must start with "${prefix}"` };
     }
     if (typeof c.label !== 'string' || !c.label) {
       return { ok: false, error: `command "${c.id}" has no label` };
@@ -67,14 +78,32 @@ export function registerPluginDefinition(
     if (typeof c.run !== 'function') {
       return { ok: false, error: `command "${c.id}" has no run function` };
     }
+    if (c.keywords !== undefined && !isStringArray(c.keywords)) {
+      return { ok: false, error: `command "${c.id}" has invalid keywords` };
+    }
+    if (
+      c.defaultKey !== undefined &&
+      c.defaultKey !== null &&
+      typeof c.defaultKey !== 'string' &&
+      !isStringArray(c.defaultKey)
+    ) {
+      return { ok: false, error: `command "${c.id}" has invalid defaultKey` };
+    }
     if (commands.has(c.id) || seen.has(c.id)) {
       return { ok: false, error: `command id "${c.id}" already registered` };
     }
     seen.add(c.id);
+    snapshots.push({
+      id: c.id,
+      label: c.label,
+      keywords: c.keywords,
+      defaultKey: c.defaultKey,
+      run: c.run,
+    });
   }
   const api = makeApi(def.id);
   plugins.set(def.id, { def, api });
-  for (const c of def.commands) commands.set(c.id, { pluginId: def.id, cmd: c });
+  for (const c of snapshots) commands.set(c.id, { pluginId: def.id, cmd: c });
   return { ok: true };
 }
 
@@ -87,7 +116,8 @@ export function installPluginRegistry(
   window.__registerCardMirrorPlugin = (def) => {
     const res = registerPluginDefinition(def);
     if (res.ok) {
-      console.log(`[plugins] registered ${def.id} (${def.commands.length} commands)`);
+      const count = [...commands.values()].filter((c) => c.pluginId === def.id).length;
+      console.log(`[plugins] registered ${def.id} (${count} commands)`);
     } else {
       console.warn(`[plugins] registration rejected: ${res.error}`);
       showToast(`Plugin failed to load: ${res.error}`);

--- a/src/editor/plugin-source-token.ts
+++ b/src/editor/plugin-source-token.ts
@@ -1,0 +1,64 @@
+// src/editor/plugin-source-token.ts
+/**
+ * Opaque provenance token — the versioned blob a flowing app stores and
+ * hands back verbatim. Only CardMirror mints and parses these. The
+ * `cmsrc1` prefix is the version indicator; a future format change
+ * bumps the prefix and keeps this parser for old tokens.
+ */
+import type { AnchorDescriptor } from './learn-anchor.js';
+
+export const SOURCE_TOKEN_PREFIX = 'cmsrc1';
+
+export interface SourcePayload {
+  docId: string;
+  /** For user-facing "open <title> first" messages when the doc isn't open. */
+  docTitle: string;
+  /** Stable heading UUID of the governing heading, or null. */
+  headingId: string | null;
+  /** Text anchor over the item's own text, for UUID-less fallback. */
+  anchor: AnchorDescriptor | null;
+}
+
+function toBase64Url(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(s: string): string | null {
+  try {
+    const bin = atob(s.replace(/-/g, '+').replace(/_/g, '/'));
+    return new TextDecoder().decode(Uint8Array.from(bin, (c) => c.charCodeAt(0)));
+  } catch {
+    return null;
+  }
+}
+
+export function mintSourceToken(payload: SourcePayload): string {
+  return `${SOURCE_TOKEN_PREFIX}.${toBase64Url(JSON.stringify(payload))}`;
+}
+
+export function parseSourceToken(token: string): SourcePayload | null {
+  if (typeof token !== 'string') return null;
+  const dot = token.indexOf('.');
+  if (dot < 0 || token.slice(0, dot) !== SOURCE_TOKEN_PREFIX) return null;
+  const json = fromBase64Url(token.slice(dot + 1));
+  if (json === null) return null;
+  try {
+    const obj = JSON.parse(json) as Partial<SourcePayload>;
+    if (typeof obj.docId !== 'string' || !obj.docId) return null;
+    return {
+      docId: obj.docId,
+      docTitle: typeof obj.docTitle === 'string' ? obj.docTitle : '',
+      headingId:
+        typeof obj.headingId === 'string' && obj.headingId ? obj.headingId : null,
+      anchor:
+        obj.anchor && typeof obj.anchor === 'object'
+          ? (obj.anchor as AnchorDescriptor)
+          : null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/editor/plugin-source-token.ts
+++ b/src/editor/plugin-source-token.ts
@@ -53,12 +53,23 @@ export function parseSourceToken(token: string): SourcePayload | null {
       docTitle: typeof obj.docTitle === 'string' ? obj.docTitle : '',
       headingId:
         typeof obj.headingId === 'string' && obj.headingId ? obj.headingId : null,
-      anchor:
-        obj.anchor && typeof obj.anchor === 'object'
-          ? (obj.anchor as AnchorDescriptor)
-          : null,
+      anchor: isAnchorDescriptor(obj.anchor) ? obj.anchor : null,
     };
   } catch {
     return null;
   }
+}
+
+/** Field-level check mirroring `AnchorDescriptor` — a token is
+ *  outside input handed back by other apps, so the inner shape is
+ *  validated, never cast. Anything malformed degrades to no anchor. */
+function isAnchorDescriptor(v: unknown): v is AnchorDescriptor {
+  if (typeof v !== 'object' || v === null) return false;
+  const a = v as Record<string, unknown>;
+  return (
+    typeof a['quote'] === 'string' &&
+    typeof a['prefix'] === 'string' &&
+    typeof a['suffix'] === 'string' &&
+    typeof a['approxPos'] === 'number'
+  );
 }

--- a/src/editor/plugin-source-token.ts
+++ b/src/editor/plugin-source-token.ts
@@ -53,7 +53,14 @@ export function parseSourceToken(token: string): SourcePayload | null {
       docTitle: typeof obj.docTitle === 'string' ? obj.docTitle : '',
       headingId:
         typeof obj.headingId === 'string' && obj.headingId ? obj.headingId : null,
-      anchor: isAnchorDescriptor(obj.anchor) ? obj.anchor : null,
+      anchor: isAnchorDescriptor(obj.anchor)
+        ? {
+            quote: obj.anchor.quote,
+            prefix: obj.anchor.prefix,
+            suffix: obj.anchor.suffix,
+            approxPos: obj.anchor.approxPos,
+          }
+        : null,
     };
   } catch {
     return null;
@@ -70,6 +77,6 @@ function isAnchorDescriptor(v: unknown): v is AnchorDescriptor {
     typeof a['quote'] === 'string' &&
     typeof a['prefix'] === 'string' &&
     typeof a['suffix'] === 'string' &&
-    typeof a['approxPos'] === 'number'
+    Number.isFinite(a['approxPos'])
   );
 }

--- a/src/editor/plugins-settings-ui.ts
+++ b/src/editor/plugins-settings-ui.ts
@@ -26,23 +26,39 @@ function guarded(work: () => Promise<void>): void {
   });
 }
 
+/** Panel-level status text — same treatment as an empty settings tab. */
+function placeholder(container: HTMLElement, text: string): void {
+  const p = document.createElement('p');
+  p.className = 'pmd-settings-empty';
+  p.textContent = text;
+  container.append(p);
+}
+
+/** A settings-style section header, matching the rest of the dialog. */
+function sectionTitle(text: string): HTMLElement {
+  const h = document.createElement('h3');
+  h.className = 'pmd-settings-section-title';
+  h.textContent = text;
+  return h;
+}
+
 export function renderPluginsPanel(container: HTMLElement): void {
   const host = getElectronHost();
   if (!host) {
-    container.textContent = 'Plugins are available on the desktop app only.';
+    placeholder(container, 'Plugins are available on the desktop app only.');
     return;
   }
   // The panel's install / dev-load actions execute third-party bundles
   // (webFrame.executeJavaScript), so they must be unreachable while the
   // master switch that promises to gate plugins is off.
   if (!settings.get('pluginsEnabled')) {
-    container.textContent = 'Enable plugins above, then restart CardMirror.';
+    placeholder(container, 'Enable plugins above, then restart CardMirror.');
     return;
   }
   // Switch is on but boot ran with it off — the window registry was never
   // installed, so a loaded bundle's registration would silently no-op.
   if (typeof window.__registerCardMirrorPlugin !== 'function') {
-    container.textContent = 'Restart CardMirror to activate plugins.';
+    placeholder(container, 'Restart CardMirror to activate plugins.');
     return;
   }
 
@@ -50,8 +66,11 @@ export function renderPluginsPanel(container: HTMLElement): void {
   installRow.className = 'pmd-plugins-install';
   const input = document.createElement('input');
   input.type = 'text';
+  input.className = 'pmd-settings-text pmd-plugins-input';
   input.placeholder = 'GitHub URL or owner/repo';
   const installBtn = document.createElement('button');
+  installBtn.type = 'button';
+  installBtn.className = 'pmd-install-info-btn';
   installBtn.textContent = 'Install';
   installRow.append(input, installBtn);
 
@@ -77,17 +96,32 @@ export function renderPluginsPanel(container: HTMLElement): void {
   list.className = 'pmd-plugins-list';
 
   const devRow = document.createElement('div');
+  devRow.className = 'pmd-plugins-dev';
+  const devDesc = document.createElement('p');
+  devDesc.className = 'pmd-settings-row-desc';
+  devDesc.textContent = 'Load an unpackaged plugin bundle for this session only.';
   const devBtn = document.createElement('button');
+  devBtn.type = 'button';
+  devBtn.className = 'pmd-install-info-btn';
   devBtn.textContent = 'Load plugin from file…';
-  devRow.append(devBtn);
+  devRow.append(devDesc, devBtn);
 
-  container.append(installRow, errorEl, list, devRow);
+  container.append(
+    sectionTitle('Install a plugin'),
+    installRow,
+    errorEl,
+    sectionTitle('Installed plugins'),
+    list,
+    sectionTitle('Developer'),
+    devRow,
+  );
 
   async function refresh(): Promise<void> {
     const plugins = ((await host!.pluginList()) as InstalledPlugin[]) ?? [];
     list.textContent = '';
     if (plugins.length === 0) {
       const empty = document.createElement('p');
+      empty.className = 'pmd-settings-empty';
       empty.textContent = 'No plugins installed.';
       list.append(empty);
       return;
@@ -96,9 +130,12 @@ export function renderPluginsPanel(container: HTMLElement): void {
       const row = document.createElement('div');
       row.className = 'pmd-plugins-row';
       const label = document.createElement('span');
+      label.className = 'pmd-plugins-name';
       label.textContent = `${p.name} v${p.version}${p.author ? ` — ${p.author}` : ''}`;
       const enable = document.createElement('input');
       enable.type = 'checkbox';
+      enable.className = 'pmd-settings-toggle';
+      enable.setAttribute('aria-label', `Enable ${p.name}`);
       enable.checked = isPluginEnabled(p.id);
       enable.addEventListener('change', () => {
         setPluginEnabled(p.id, enable.checked);
@@ -113,6 +150,8 @@ export function renderPluginsPanel(container: HTMLElement): void {
         }
       });
       const update = document.createElement('button');
+      update.type = 'button';
+      update.className = 'pmd-install-info-btn';
       update.textContent = 'Check for updates';
       update.addEventListener('click', () => {
         guardedInline(async () => {
@@ -140,6 +179,8 @@ export function renderPluginsPanel(container: HTMLElement): void {
         });
       });
       const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'pmd-install-info-btn';
       remove.textContent = 'Uninstall';
       remove.addEventListener('click', () => {
         guardedInline(async () => {

--- a/src/editor/plugins-settings-ui.ts
+++ b/src/editor/plugins-settings-ui.ts
@@ -1,0 +1,156 @@
+/**
+ * The Plugins settings tab body: install-from-GitHub field, installed
+ * plugin rows (enable / update / uninstall), and the developer
+ * load-from-file row. All operations go through the desktop host;
+ * off Electron this panel never mounts (category is electronOnly).
+ */
+import { getElectronHost } from './host/index.js';
+import { isPluginEnabled, setPluginEnabled } from './plugins-store.js';
+import { confirmDialog } from './text-prompt.js';
+import { showToast } from './toast.js';
+
+interface InstalledPlugin {
+  id: string;
+  name: string;
+  version: string;
+  author?: string;
+  description?: string;
+  repo?: string;
+}
+
+export function renderPluginsPanel(container: HTMLElement): void {
+  const host = getElectronHost();
+  if (!host) {
+    container.textContent = 'Plugins are available on the desktop app only.';
+    return;
+  }
+
+  const installRow = document.createElement('div');
+  installRow.className = 'pmd-plugins-install';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = 'GitHub URL or owner/repo';
+  const installBtn = document.createElement('button');
+  installBtn.textContent = 'Install';
+  installRow.append(input, installBtn);
+
+  const list = document.createElement('div');
+  list.className = 'pmd-plugins-list';
+
+  const devRow = document.createElement('div');
+  const devBtn = document.createElement('button');
+  devBtn.textContent = 'Load plugin from file…';
+  devRow.append(devBtn);
+
+  container.append(installRow, list, devRow);
+
+  async function refresh(): Promise<void> {
+    const plugins = ((await host!.pluginList()) as InstalledPlugin[]) ?? [];
+    list.textContent = '';
+    if (plugins.length === 0) {
+      const empty = document.createElement('p');
+      empty.textContent = 'No plugins installed.';
+      list.append(empty);
+      return;
+    }
+    for (const p of plugins) {
+      const row = document.createElement('div');
+      row.className = 'pmd-plugins-row';
+      const label = document.createElement('span');
+      label.textContent = `${p.name} v${p.version}${p.author ? ` — ${p.author}` : ''}`;
+      const enable = document.createElement('input');
+      enable.type = 'checkbox';
+      enable.checked = isPluginEnabled(p.id);
+      enable.addEventListener('change', () => {
+        setPluginEnabled(p.id, enable.checked);
+        if (enable.checked) {
+          void host!.pluginLoad(p.id).then((r) => {
+            if (!r.ok) showToast(`${p.name} failed to load: ${r.error ?? 'unknown error'}`);
+          });
+        } else {
+          showToast('Plugin disabled. It stops fully on the next launch.');
+        }
+      });
+      const update = document.createElement('button');
+      update.textContent = 'Check for updates';
+      update.addEventListener('click', () => {
+        void (async () => {
+          const res = (await host!.pluginCheckUpdate(p.id, p.repo ?? '')) as
+            | { ok: true; latest: string; hasUpdate: boolean }
+            | { ok: false; error: string }
+            | undefined;
+          if (!res || !res.ok) {
+            showToast(`Update check failed: ${res && 'error' in res ? res.error : 'unavailable'}`);
+            return;
+          }
+          if (!res.hasUpdate) {
+            showToast(`${p.name} is up to date.`);
+            return;
+          }
+          if (await confirmDialog(`Update ${p.name} to v${res.latest}?`)) {
+            const r = (await host!.pluginInstall(p.repo ?? '')) as { ok?: boolean } | undefined;
+            showToast(r?.ok ? `${p.name} updated. Restart to apply.` : 'Update failed.');
+          }
+        })();
+      });
+      const remove = document.createElement('button');
+      remove.textContent = 'Uninstall';
+      remove.addEventListener('click', () => {
+        void (async () => {
+          if (!(await confirmDialog(`Uninstall ${p.name}?`))) return;
+          await host!.pluginUninstall(p.id);
+          setPluginEnabled(p.id, false);
+          showToast(`${p.name} uninstalled. Restart to fully unload it.`);
+          void refresh();
+        })();
+      });
+      row.append(enable, label, update, remove);
+      list.append(row);
+    }
+  }
+
+  installBtn.addEventListener('click', () => {
+    void (async () => {
+      const ref = input.value.trim();
+      if (!ref) return;
+      installBtn.disabled = true;
+      try {
+        const res = (await host.pluginInstall(ref)) as
+          | { ok: true; plugin: InstalledPlugin }
+          | { ok: false; error: string }
+          | undefined;
+        if (!res || !res.ok) {
+          showToast(`Install failed: ${res && 'error' in res ? res.error : 'unavailable'}`);
+          return;
+        }
+        const p = res.plugin;
+        const consent = await confirmDialog(
+          `Install ${p.name} v${p.version}${p.author ? ` by ${p.author}` : ''}? ` +
+            'This plugin runs with full access to CardMirror and your documents.',
+        );
+        if (!consent) {
+          await host.pluginUninstall(p.id);
+          return;
+        }
+        setPluginEnabled(p.id, true);
+        const r = await host.pluginLoad(p.id);
+        showToast(r.ok ? `${p.name} installed and loaded.` : `${p.name} installed; loads on next launch.`);
+        input.value = '';
+        void refresh();
+      } finally {
+        installBtn.disabled = false;
+      }
+    })();
+  });
+
+  devBtn.addEventListener('click', () => {
+    void (async () => {
+      const path = await host.pluginPickFile();
+      if (!path) return;
+      const r = await host.pluginLoadFile(path);
+      showToast(r.ok ? 'Plugin bundle loaded for this session.' : `Load failed: ${r.error ?? 'unknown'}`);
+    })();
+  });
+
+  void refresh();
+}

--- a/src/editor/plugins-settings-ui.ts
+++ b/src/editor/plugins-settings-ui.ts
@@ -55,6 +55,24 @@ export function renderPluginsPanel(container: HTMLElement): void {
   installBtn.textContent = 'Install';
   installRow.append(input, installBtn);
 
+  // Install/update/uninstall failures surface here, next to the action,
+  // not as a transient toast that scrolls away. Cleared on the next
+  // successful action.
+  const errorEl = document.createElement('p');
+  errorEl.className = 'pmd-plugins-error';
+  const showError = (msg: string): void => {
+    errorEl.textContent = msg;
+  };
+  const clearError = (): void => {
+    errorEl.textContent = '';
+  };
+  /** Like `guarded`, but routes the rejection inline instead of a toast. */
+  const guardedInline = (work: () => Promise<void>): void => {
+    void work().catch((err: unknown) => {
+      showError(`Plugin operation failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  };
+
   const list = document.createElement('div');
   list.className = 'pmd-plugins-list';
 
@@ -63,7 +81,7 @@ export function renderPluginsPanel(container: HTMLElement): void {
   devBtn.textContent = 'Load plugin from file…';
   devRow.append(devBtn);
 
-  container.append(installRow, list, devRow);
+  container.append(installRow, errorEl, list, devRow);
 
   async function refresh(): Promise<void> {
     const plugins = ((await host!.pluginList()) as InstalledPlugin[]) ?? [];
@@ -85,9 +103,10 @@ export function renderPluginsPanel(container: HTMLElement): void {
       enable.addEventListener('change', () => {
         setPluginEnabled(p.id, enable.checked);
         if (enable.checked) {
-          guarded(async () => {
+          guardedInline(async () => {
+            clearError();
             const r = await host!.pluginLoad(p.id);
-            if (!r.ok) showToast(`${p.name} failed to load: ${r.error ?? 'unknown error'}`);
+            if (!r.ok) showError(`${p.name} failed to load: ${r.error ?? 'unknown error'}`);
           });
         } else {
           showToast('Plugin disabled. It stops fully on the next launch.');
@@ -96,13 +115,14 @@ export function renderPluginsPanel(container: HTMLElement): void {
       const update = document.createElement('button');
       update.textContent = 'Check for updates';
       update.addEventListener('click', () => {
-        guarded(async () => {
+        guardedInline(async () => {
+          clearError();
           const res = (await host!.pluginCheckUpdate(p.id, p.repo ?? '')) as
             | { ok: true; latest: string; hasUpdate: boolean }
             | { ok: false; error: string }
             | undefined;
           if (!res || !res.ok) {
-            showToast(`Update check failed: ${res && 'error' in res ? res.error : 'unavailable'}`);
+            showError(`Update check failed: ${res && 'error' in res ? res.error : 'unavailable'}`);
             return;
           }
           if (!res.hasUpdate) {
@@ -110,18 +130,25 @@ export function renderPluginsPanel(container: HTMLElement): void {
             return;
           }
           if (await confirmDialog(`Update ${p.name} to v${res.latest}?`)) {
-            const r = (await host!.pluginInstall(p.repo ?? '')) as { ok?: boolean } | undefined;
-            showToast(r?.ok ? `${p.name} updated. Restart to apply.` : 'Update failed.');
+            const r = (await host!.pluginInstall(p.repo ?? '')) as
+              | { ok: true }
+              | { ok: false; error: string }
+              | undefined;
+            if (r?.ok) showToast(`${p.name} updated. Restart to apply.`);
+            else showError(`Update failed: ${r && 'error' in r ? r.error : 'unavailable'}`);
           }
         });
       });
       const remove = document.createElement('button');
       remove.textContent = 'Uninstall';
       remove.addEventListener('click', () => {
-        guarded(async () => {
+        guardedInline(async () => {
           if (!(await confirmDialog(`Uninstall ${p.name}?`))) return;
+          clearError();
           await host!.pluginUninstall(p.id);
           setPluginEnabled(p.id, false);
+          // Drop the plugin's storage bag so a reinstall starts clean.
+          localStorage.removeItem(`plugin:${p.id}`);
           showToast(`${p.name} uninstalled. Restart to fully unload it.`);
           guarded(refresh);
         });
@@ -132,9 +159,10 @@ export function renderPluginsPanel(container: HTMLElement): void {
   }
 
   installBtn.addEventListener('click', () => {
-    guarded(async () => {
+    guardedInline(async () => {
       const ref = input.value.trim();
       if (!ref) return;
+      clearError();
       installBtn.disabled = true;
       try {
         const res = (await host.pluginInstall(ref)) as
@@ -142,12 +170,12 @@ export function renderPluginsPanel(container: HTMLElement): void {
           | { ok: false; error: string }
           | undefined;
         if (!res || !res.ok) {
-          showToast(`Install failed: ${res && 'error' in res ? res.error : 'unavailable'}`);
+          showError(`Install failed: ${res && 'error' in res ? res.error : 'unavailable'}`);
           return;
         }
         const p = res.plugin;
         const consent = await confirmDialog(
-          `Install ${p.name} v${p.version}${p.author ? ` by ${p.author}` : ''}? ` +
+          `Install ${p.name} v${p.version} by ${p.author ?? 'an unknown author'}? ` +
             'This plugin runs with full access to CardMirror and your documents.',
         );
         if (!consent) {

--- a/src/editor/plugins-settings-ui.ts
+++ b/src/editor/plugins-settings-ui.ts
@@ -18,6 +18,13 @@ interface InstalledPlugin {
   repo?: string;
 }
 
+/** Surface an IPC rejection as a toast instead of an unhandled rejection. */
+function guarded(work: () => Promise<void>): void {
+  void work().catch((err: unknown) => {
+    showToast(`Plugin operation failed: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}
+
 export function renderPluginsPanel(container: HTMLElement): void {
   const host = getElectronHost();
   if (!host) {
@@ -64,7 +71,8 @@ export function renderPluginsPanel(container: HTMLElement): void {
       enable.addEventListener('change', () => {
         setPluginEnabled(p.id, enable.checked);
         if (enable.checked) {
-          void host!.pluginLoad(p.id).then((r) => {
+          guarded(async () => {
+            const r = await host!.pluginLoad(p.id);
             if (!r.ok) showToast(`${p.name} failed to load: ${r.error ?? 'unknown error'}`);
           });
         } else {
@@ -74,7 +82,7 @@ export function renderPluginsPanel(container: HTMLElement): void {
       const update = document.createElement('button');
       update.textContent = 'Check for updates';
       update.addEventListener('click', () => {
-        void (async () => {
+        guarded(async () => {
           const res = (await host!.pluginCheckUpdate(p.id, p.repo ?? '')) as
             | { ok: true; latest: string; hasUpdate: boolean }
             | { ok: false; error: string }
@@ -91,18 +99,18 @@ export function renderPluginsPanel(container: HTMLElement): void {
             const r = (await host!.pluginInstall(p.repo ?? '')) as { ok?: boolean } | undefined;
             showToast(r?.ok ? `${p.name} updated. Restart to apply.` : 'Update failed.');
           }
-        })();
+        });
       });
       const remove = document.createElement('button');
       remove.textContent = 'Uninstall';
       remove.addEventListener('click', () => {
-        void (async () => {
+        guarded(async () => {
           if (!(await confirmDialog(`Uninstall ${p.name}?`))) return;
           await host!.pluginUninstall(p.id);
           setPluginEnabled(p.id, false);
           showToast(`${p.name} uninstalled. Restart to fully unload it.`);
-          void refresh();
-        })();
+          guarded(refresh);
+        });
       });
       row.append(enable, label, update, remove);
       list.append(row);
@@ -110,7 +118,7 @@ export function renderPluginsPanel(container: HTMLElement): void {
   }
 
   installBtn.addEventListener('click', () => {
-    void (async () => {
+    guarded(async () => {
       const ref = input.value.trim();
       if (!ref) return;
       installBtn.disabled = true;
@@ -136,21 +144,21 @@ export function renderPluginsPanel(container: HTMLElement): void {
         const r = await host.pluginLoad(p.id);
         showToast(r.ok ? `${p.name} installed and loaded.` : `${p.name} installed; loads on next launch.`);
         input.value = '';
-        void refresh();
+        guarded(refresh);
       } finally {
         installBtn.disabled = false;
       }
-    })();
+    });
   });
 
   devBtn.addEventListener('click', () => {
-    void (async () => {
+    guarded(async () => {
       const path = await host.pluginPickFile();
       if (!path) return;
       const r = await host.pluginLoadFile(path);
       showToast(r.ok ? 'Plugin bundle loaded for this session.' : `Load failed: ${r.error ?? 'unknown'}`);
-    })();
+    });
   });
 
-  void refresh();
+  guarded(refresh);
 }

--- a/src/editor/plugins-settings-ui.ts
+++ b/src/editor/plugins-settings-ui.ts
@@ -6,6 +6,7 @@
  */
 import { getElectronHost } from './host/index.js';
 import { isPluginEnabled, setPluginEnabled } from './plugins-store.js';
+import { settings } from './settings.js';
 import { confirmDialog } from './text-prompt.js';
 import { showToast } from './toast.js';
 
@@ -29,6 +30,19 @@ export function renderPluginsPanel(container: HTMLElement): void {
   const host = getElectronHost();
   if (!host) {
     container.textContent = 'Plugins are available on the desktop app only.';
+    return;
+  }
+  // The panel's install / dev-load actions execute third-party bundles
+  // (webFrame.executeJavaScript), so they must be unreachable while the
+  // master switch that promises to gate plugins is off.
+  if (!settings.get('pluginsEnabled')) {
+    container.textContent = 'Enable plugins above, then restart CardMirror.';
+    return;
+  }
+  // Switch is on but boot ran with it off — the window registry was never
+  // installed, so a loaded bundle's registration would silently no-op.
+  if (typeof window.__registerCardMirrorPlugin !== 'function') {
+    container.textContent = 'Restart CardMirror to activate plugins.';
     return;
   }
 

--- a/src/editor/plugins-store.ts
+++ b/src/editor/plugins-store.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-plugin enabled flags — localStorage blob, pins-store style.
+ * Install state (which plugins exist) lives on disk with main; this
+ * store only remembers which ones the user switched on.
+ */
+const STORAGE_KEY = 'pmd-plugins';
+
+interface PluginsBlob {
+  enabled: Record<string, boolean>;
+}
+
+function read(): PluginsBlob {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<PluginsBlob>;
+      if (parsed && typeof parsed === 'object' && parsed.enabled && typeof parsed.enabled === 'object') {
+        return { enabled: parsed.enabled };
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+  return { enabled: {} };
+}
+
+function write(blob: PluginsBlob): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(blob));
+  } catch {
+    /* quota — non-fatal */
+  }
+}
+
+export function isPluginEnabled(id: string): boolean {
+  return read().enabled[id] === true;
+}
+
+export function setPluginEnabled(id: string, on: boolean): void {
+  const blob = read();
+  blob.enabled[id] = on;
+  write(blob);
+}

--- a/src/editor/precise-scroll.ts
+++ b/src/editor/precise-scroll.ts
@@ -79,6 +79,27 @@ export type PreciseScrollBlock = 'start' | 'center';
  *  passes. Latest scroll wins. */
 let scrollGeneration = 0;
 
+/** Escape a value for use inside a CSS attribute selector. */
+function cssEscape(s: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(s);
+  return s.replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+}
+
+/** Scroll a heading into view by its stable `data-id`, the reliable
+ *  nav-pane jump path. Returns true when the element was found and
+ *  scrolled; false when it isn't in the rendered DOM (e.g. tests, or a
+ *  cv:auto-skipped region the caller must fall back for). */
+export function scrollToHeadingId(
+  view: EditorView,
+  headingId: string,
+  block: PreciseScrollBlock = 'start',
+): boolean {
+  const target = view.dom.querySelector<HTMLElement>(`[data-id="${cssEscape(headingId)}"]`);
+  if (!target) return false;
+  preciseScrollIntoView(view, target, block);
+  return true;
+}
+
 export function preciseScrollIntoView(
   _view: EditorView,
   target: HTMLElement,

--- a/src/editor/quick-card-search-ui.ts
+++ b/src/editor/quick-card-search-ui.ts
@@ -106,9 +106,9 @@ import {
   formatKeyForDisplay,
   commandLabelFor,
   commandAliasesFor,
+  effectivePluginDefaultKeys,
   type AnyCommandId,
 } from './ribbon-commands.js';
-import { pluginDefaultKey } from './plugin-registry.js';
 import { availableRibbonCommandIds } from './ribbon-availability.js';
 
 // ── Warm-cache machinery (module-level, shared by the open palette and
@@ -381,11 +381,15 @@ function searchDropzoneSource(query: string): PaletteResult[] {
 
 /** The current display keybinding for a command (first binding), or ''. */
 function commandKeyDisplay(id: AnyCommandId): string {
-  const spec =
-    settings.get('ribbonKeyOverrides')[id] ??
-    (DEFAULT_RIBBON_KEYS as Record<string, string | string[] | undefined>)[id] ??
-    pluginDefaultKey(id) ??
-    '';
+  const overrides = settings.get('ribbonKeyOverrides');
+  const isStatic = id in (DEFAULT_RIBBON_KEYS as Record<string, unknown>);
+  // Plugin ids: show only the keys that survive static collision, so the
+  // palette never advertises a chord the plugin doesn't actually own.
+  const spec = isStatic
+    ? (overrides[id] ??
+      (DEFAULT_RIBBON_KEYS as Record<string, string | string[] | undefined>)[id] ??
+      '')
+    : effectivePluginDefaultKeys(id, overrides);
   const first = Array.isArray(spec) ? spec[0] : spec;
   return first ? formatKeyForDisplay(first) : '';
 }

--- a/src/editor/quick-card-search-ui.ts
+++ b/src/editor/quick-card-search-ui.ts
@@ -102,12 +102,13 @@ interface WarmEntry {
 }
 const warmCache = new Map<string, WarmEntry>();
 import {
-  RIBBON_COMMAND_LABELS,
-  RIBBON_COMMAND_ALIASES,
   DEFAULT_RIBBON_KEYS,
   formatKeyForDisplay,
-  type RibbonCommandId,
+  commandLabelFor,
+  commandAliasesFor,
+  type AnyCommandId,
 } from './ribbon-commands.js';
+import { pluginDefaultKey } from './plugin-registry.js';
 import { availableRibbonCommandIds } from './ribbon-availability.js';
 
 // ── Warm-cache machinery (module-level, shared by the open palette and
@@ -266,7 +267,7 @@ export interface QuickCardSearchOptions {
   view: EditorView | null;
   paneEl: HTMLElement | null;
   /** Trigger a ribbon command by id (the palette's command source). */
-  runCommand: (id: RibbonCommandId) => void;
+  runCommand: (id: AnyCommandId) => void;
   /** Open a `.cmir` file by absolute path (the file source's Enter). */
   openFilePath: (path: string, name: string) => void;
   /** When true, selecting a header inside a file inserts a live zone
@@ -302,7 +303,7 @@ interface PaletteResult {
   /** Insert payload (quickcard / dropzone / fileobject). */
   sliceJson?: unknown;
   /** Command to run (command source). */
-  commandId?: RibbonCommandId;
+  commandId?: AnyCommandId;
   /** Boolean setting to flip in place (settingtoggle source). */
   toggleSettingKey?: keyof Settings;
   /** Enum/mode setting to advance to its next value (settingcycle source). */
@@ -379,8 +380,12 @@ function searchDropzoneSource(query: string): PaletteResult[] {
 }
 
 /** The current display keybinding for a command (first binding), or ''. */
-function commandKeyDisplay(id: RibbonCommandId): string {
-  const spec = settings.get('ribbonKeyOverrides')[id] ?? DEFAULT_RIBBON_KEYS[id];
+function commandKeyDisplay(id: AnyCommandId): string {
+  const spec =
+    settings.get('ribbonKeyOverrides')[id] ??
+    (DEFAULT_RIBBON_KEYS as Record<string, string | string[] | undefined>)[id] ??
+    pluginDefaultKey(id) ??
+    '';
   const first = Array.isArray(spec) ? spec[0] : spec;
   return first ? formatKeyForDisplay(first) : '';
 }
@@ -404,9 +409,9 @@ function searchCommandSource(query: string): PaletteResult[] {
   // hit (not in the label) sorts after label hits via the Infinity below.
   // Expand each label by the other words in any synonym group it touches (see
   // SYNONYM_GROUPS), so a query phrased with an equivalent word still matches.
-  const haystack = (id: RibbonCommandId): string => {
-    const aliases = RIBBON_COMMAND_ALIASES[id];
-    const label = RIBBON_COMMAND_LABELS[id].toLowerCase();
+  const haystack = (id: AnyCommandId): string => {
+    const aliases = commandAliasesFor(id);
+    const label = commandLabelFor(id).toLowerCase();
     const synonyms: string[] = [];
     for (const group of SYNONYM_GROUPS) {
       if (group.some((w) => label.includes(w))) {
@@ -427,19 +432,19 @@ function searchCommandSource(query: string): PaletteResult[] {
   const t0 = tokens[0];
   // First-token position within the *label* (not aliases) for ranking;
   // a label miss yields -1, which we treat as last so label hits win.
-  const rank = (id: RibbonCommandId): number => {
+  const rank = (id: AnyCommandId): number => {
     if (!t0) return 0;
-    const i = RIBBON_COMMAND_LABELS[id].toLowerCase().indexOf(t0);
+    const i = commandLabelFor(id).toLowerCase().indexOf(t0);
     return i === -1 ? Infinity : i;
   };
   matched.sort((a, b) => {
     const d = rank(a) - rank(b);
     if (d !== 0) return d;
-    return RIBBON_COMMAND_LABELS[a].toLowerCase().localeCompare(RIBBON_COMMAND_LABELS[b].toLowerCase());
+    return commandLabelFor(a).toLowerCase().localeCompare(commandLabelFor(b).toLowerCase());
   });
   return matched.map((id) => ({
     source: 'command' as const,
-    name: RIBBON_COMMAND_LABELS[id],
+    name: commandLabelFor(id),
     meta: commandKeyDisplay(id),
     matchedName: true,
     snippet: null,
@@ -762,7 +767,7 @@ class QuickCardSearchUI {
   private unsubscribe: (() => void) | null = null;
   private view: EditorView | null = null;
   private paneEl: HTMLElement | null = null;
-  private runCommand: (id: RibbonCommandId) => void = () => {};
+  private runCommand: (id: AnyCommandId) => void = () => {};
   private openFilePath: (path: string, name: string) => void = () => {};
   private transcludeMode = false;
   private docPath: string | null = null;

--- a/src/editor/reference-ui.ts
+++ b/src/editor/reference-ui.ts
@@ -11,10 +11,13 @@ import {
   DEFAULT_RIBBON_KEYS,
   RIBBON_COMMAND_LABELS,
   formatKeyForDisplay,
+  commandLabelFor,
+  effectivePluginDefaultKeys,
   type RibbonCommandId,
 } from './ribbon-commands.js';
 import { RIBBON_GROUPS } from './ribbon-groups.js';
 import { isRibbonCommandAvailable } from './ribbon-availability.js';
+import { pluginCommandIds } from './plugin-registry.js';
 import { settings } from './settings.js';
 import { setIcon } from './icons';
 
@@ -132,6 +135,52 @@ class ReferenceModal {
         const labelEl = document.createElement('span');
         labelEl.className = 'pmd-reference-label';
         labelEl.textContent = RIBBON_COMMAND_LABELS[id];
+        row.appendChild(labelEl);
+
+        rows.appendChild(row);
+      }
+
+      section.appendChild(rows);
+      body.appendChild(section);
+    }
+
+    // Registered plugin commands get their own section, appended after
+    // the static groups — reusing `effectivePluginDefaultKeys` so the
+    // printed keys match what actually dispatches (a plugin default
+    // that loses to a static key prints as unbound, not as a lie).
+    // Skipped entirely while no plugin has registered commands.
+    const pluginIds = pluginCommandIds();
+    if (pluginIds.length > 0) {
+      const section = document.createElement('section');
+      section.className = 'pmd-reference-group';
+
+      const heading = document.createElement('h3');
+      heading.className = 'pmd-reference-group-title';
+      heading.textContent = 'Plugins';
+      section.appendChild(heading);
+
+      const rows = document.createElement('div');
+      rows.className = 'pmd-reference-group-rows';
+
+      const overrides = settings.get('ribbonKeyOverrides');
+      for (const id of pluginIds) {
+        const row = document.createElement('div');
+        row.className = 'pmd-reference-row';
+
+        const keys = effectivePluginDefaultKeys(id, overrides);
+        const keyText = keys
+          .map((k) => formatKeyForDisplay(k))
+          .filter((s) => s.length > 0)
+          .join(' / ');
+
+        const keyEl = document.createElement('span');
+        keyEl.className = 'pmd-reference-key';
+        keyEl.textContent = keyText || '—';
+        row.appendChild(keyEl);
+
+        const labelEl = document.createElement('span');
+        labelEl.className = 'pmd-reference-label';
+        labelEl.textContent = commandLabelFor(id);
         row.appendChild(labelEl);
 
         rows.appendChild(row);

--- a/src/editor/ribbon-availability.ts
+++ b/src/editor/ribbon-availability.ts
@@ -19,7 +19,8 @@
  * this filtered one, so a hidden command's binding still blocks reuse.
  */
 
-import { RIBBON_COMMAND_IDS, type RibbonCommandId } from './ribbon-commands.js';
+import { RIBBON_COMMAND_IDS, type AnyCommandId, type RibbonCommandId } from './ribbon-commands.js';
+import { pluginCommandIds } from './plugin-registry.js';
 import { settings } from './settings.js';
 import { collabEnabled } from './collab/collab-gate.js';
 import { getElectronHost, isWindowsHost } from './host/index.js';
@@ -75,7 +76,8 @@ export function isRibbonCommandAvailable(id: RibbonCommandId): boolean {
   return true;
 }
 
-/** The currently-available command ids, in registry order. */
-export function availableRibbonCommandIds(): RibbonCommandId[] {
-  return RIBBON_COMMAND_IDS.filter(isRibbonCommandAvailable);
+/** The currently-available command ids, in registry order. Plugin
+ *  commands (registered = enabled) append after the static set. */
+export function availableRibbonCommandIds(): AnyCommandId[] {
+  return [...RIBBON_COMMAND_IDS.filter(isRibbonCommandAvailable), ...pluginCommandIds()];
 }

--- a/src/editor/ribbon-commands.ts
+++ b/src/editor/ribbon-commands.ts
@@ -6375,13 +6375,16 @@ export function buildRibbonKeymap(
   // never steals an already-bound key (static bindings win conflicts),
   // but an EXPLICIT user override rebinding a plugin command does win -
   // the user asked for it (the keybindings editor dislodges the loser).
+  // Collision is judged on the FOLDED key so a case-only variant
+  // ('Mod-Shift-D' vs static 'Mod-Shift-d') can't slip past.
+  const staticFolded = foldedStaticKeys(overrides);
   for (const id of pluginCommandIds()) {
     const explicit = overrides[id] != null;
     const spec = overrides[id] ?? pluginDefaultKey(id) ?? [];
     const cmd: Command = () => runPluginCommand(id);
     for (const key of keysArray(spec)) {
       if (!key) continue;
-      if (!explicit && out[key]) continue;
+      if (!explicit && (staticFolded.has(foldKeyString(key)) || out[key])) continue;
       out[key] = cmd;
     }
   }
@@ -6442,11 +6445,46 @@ export function ribbonKeyStringFor(e: KeyboardEvent): string {
  *  character — 'Mod-Shift-S' ≡ 'Mod-Shift-s'. Saved user overrides
  *  captured before ribbonKeyStringFor folded letters are stored
  *  uppercase, so lookups must fold both sides. */
-function foldKeyString(key: string): string {
+export function foldKeyString(key: string): string {
   const i = key.lastIndexOf('-');
   const tail = i < 0 ? key : key.slice(i + 1);
   if (tail.length !== 1) return key;
   return i < 0 ? key.toLowerCase() : key.slice(0, i) + '-' + tail.toLowerCase();
+}
+
+/** Folded forms of every key the static (non-plugin) commands resolve
+ *  to under `overrides`. The single source of truth for plugin-vs-static
+ *  collisions, shared by `buildRibbonKeymap` and
+ *  `effectivePluginDefaultKeys` so the two can't drift. */
+function foldedStaticKeys(
+  overrides: Partial<Record<string, string | string[]>>,
+): Set<string> {
+  const set = new Set<string>();
+  for (const id of RIBBON_COMMAND_IDS) {
+    const spec = overrides[id] ?? DEFAULT_RIBBON_KEYS[id];
+    for (const key of keysArray(spec)) {
+      if (key) set.add(foldKeyString(key));
+    }
+  }
+  return set;
+}
+
+/**
+ * The default keys a plugin command actually binds to, after static
+ * collisions are resolved — so display sites show what really
+ * dispatches. An explicit override wins outright (returned verbatim,
+ * empty entries dropped); otherwise each built-in default key is
+ * suppressed when its folded form already belongs to a static command.
+ */
+export function effectivePluginDefaultKeys(
+  id: AnyCommandId,
+  overrides: Partial<Record<string, string | string[]>> = {},
+): string[] {
+  if (overrides[id] != null) return keysArray(overrides[id]!).filter((k) => !!k);
+  const staticFolded = foldedStaticKeys(overrides);
+  return keysArray(pluginDefaultKey(id) ?? []).filter(
+    (k) => !!k && !staticFolded.has(foldKeyString(k)),
+  );
 }
 
 /**

--- a/src/editor/ribbon-commands.ts
+++ b/src/editor/ribbon-commands.ts
@@ -6384,6 +6384,8 @@ export function buildRibbonKeymap(
     const cmd: Command = () => runPluginCommand(id);
     for (const key of keysArray(spec)) {
       if (!key) continue;
+      // ponytail: plugin-vs-plugin collision (out[key]) still compares raw,
+      // unlike the folded static check; fold it too if two plugins ever collide
       if (!explicit && (staticFolded.has(foldKeyString(key)) || out[key])) continue;
       out[key] = cmd;
     }

--- a/src/editor/ribbon-commands.ts
+++ b/src/editor/ribbon-commands.ts
@@ -41,6 +41,14 @@ import { toggleMark } from 'prosemirror-commands';
 import { toggleReadingMarkerCommand } from './reading-marker.js';
 import { openFootnoteEditor } from './footnote-popover.js';
 import { flipQuoteDirection } from './flip-quote-direction.js';
+import {
+  isPluginCommandId,
+  pluginCommandIds,
+  pluginCommandLabel,
+  pluginCommandKeywords,
+  pluginDefaultKey,
+  runPluginCommand,
+} from './plugin-registry.js';
 import { schema } from '../schema/index.js';
 import { newHeadingId } from '../schema/ids.js';
 import {
@@ -6307,6 +6315,28 @@ function keysArray(spec: string | string[]): string[] {
   return Array.isArray(spec) ? spec : [spec];
 }
 
+/** A static ribbon id, or a runtime plugin command id. */
+export type AnyCommandId = RibbonCommandId | (string & {});
+
+/** Label for any command id - static table first, plugin registry
+ *  second, the raw id as a last resort. */
+export function commandLabelFor(id: AnyCommandId): string {
+  return (
+    (RIBBON_COMMAND_LABELS as Record<string, string>)[id] ??
+    pluginCommandLabel(id) ??
+    id
+  );
+}
+
+/** Palette search aliases for any command id - static table first,
+ *  plugin keywords second (empty when neither has any). */
+export function commandAliasesFor(id: AnyCommandId): readonly string[] {
+  return (
+    (RIBBON_COMMAND_ALIASES as Record<string, readonly string[] | undefined>)[id] ??
+    pluginCommandKeywords(id)
+  );
+}
+
 /**
  * Primary key for a command — the binding shown to the user (tooltips
  * etc.). Aliases (further entries in the array) exist for the user's
@@ -6329,7 +6359,7 @@ export function primaryKeyFor(
  * pass user-stored overrides here.
  */
 export function buildRibbonKeymap(
-  overrides: Partial<Record<RibbonCommandId, string | string[]>> = {},
+  overrides: Partial<Record<string, string | string[]>> = {},
   ctx: RibbonContext = DEFAULT_RIBBON_CONTEXT,
 ): Record<string, Command> {
   const out: Record<string, Command> = {};
@@ -6338,6 +6368,20 @@ export function buildRibbonKeymap(
     const cmd = commandFor(id, ctx);
     for (const key of keysArray(spec)) {
       if (!key) continue;
+      out[key] = cmd;
+    }
+  }
+  // Plugin commands bind after the static set. A plugin's DEFAULT key
+  // never steals an already-bound key (static bindings win conflicts),
+  // but an EXPLICIT user override rebinding a plugin command does win -
+  // the user asked for it (the keybindings editor dislodges the loser).
+  for (const id of pluginCommandIds()) {
+    const explicit = overrides[id] != null;
+    const spec = overrides[id] ?? pluginDefaultKey(id) ?? [];
+    const cmd: Command = () => runPluginCommand(id);
+    for (const key of keysArray(spec)) {
+      if (!key) continue;
+      if (!explicit && out[key]) continue;
       out[key] = cmd;
     }
   }
@@ -6351,10 +6395,11 @@ export function buildRibbonKeymap(
  * keys both follow.
  */
 export function getRibbonCommand(
-  id: RibbonCommandId,
+  id: AnyCommandId,
   ctx: RibbonContext = DEFAULT_RIBBON_CONTEXT,
 ): Command {
-  return commandFor(id, ctx);
+  if (isPluginCommandId(id)) return () => runPluginCommand(id);
+  return commandFor(id as RibbonCommandId, ctx);
 }
 
 /**
@@ -6414,11 +6459,21 @@ function foldKeyString(key: string): string {
  */
 export function ribbonCommandForKey(
   keyString: string,
-  overrides: Partial<Record<RibbonCommandId, string | string[]>> = {},
-): RibbonCommandId | null {
+  overrides: Partial<Record<string, string | string[]>> = {},
+): AnyCommandId | null {
   const folded = foldKeyString(keyString);
+  // An explicit override that rebinds a plugin command wins over a
+  // static DEFAULT key (mirrors buildRibbonKeymap above).
+  for (const id of pluginCommandIds()) {
+    const spec = overrides[id];
+    if (spec != null && keysArray(spec).some((k) => foldKeyString(k) === folded)) return id;
+  }
   for (const id of RIBBON_COMMAND_IDS) {
     const spec = overrides[id] ?? DEFAULT_RIBBON_KEYS[id];
+    if (keysArray(spec).some((k) => foldKeyString(k) === folded)) return id;
+  }
+  for (const id of pluginCommandIds()) {
+    const spec = overrides[id] ?? pluginDefaultKey(id) ?? [];
     if (keysArray(spec).some((k) => foldKeyString(k) === folded)) return id;
   }
   return null;

--- a/src/editor/settings-categories.ts
+++ b/src/editor/settings-categories.ts
@@ -31,6 +31,9 @@ export const CATEGORY_TABS: {
   // its settings are all electronOnly. Hide the whole tab on web rather than
   // show it empty. (Kept `id: 'pairing'` so stored settings/routes don't churn.)
   { id: 'pairing', label: 'Collaboration', electronOnly: true },
+  // Plugins are installed/loaded by the Electron main process, so the whole
+  // tab is desktop-only (hidden on web rather than shown empty).
+  { id: 'plugins', label: 'Plugins', electronOnly: true },
   // Accessibility intentionally lives at the far right — its
   // override-anything panel is a "last-resort" customization
   // surface, separated from the everyday tabs.

--- a/src/editor/settings-ui.ts
+++ b/src/editor/settings-ui.ts
@@ -69,7 +69,7 @@ import { applyTimerProfile } from './timer-profile.js';
 import { showToast } from './toast.js';
 import { setIcon, CUSTOM_BUTTON_ICONS, type IconName } from './icons';
 import { availableRibbonCommandIds } from './ribbon-availability.js';
-import { RIBBON_COMMAND_LABELS } from './ribbon-commands.js';
+import { RIBBON_COMMAND_LABELS, type RibbonCommandId } from './ribbon-commands.js';
 import { settingCommandOptions } from './setting-commands.js';
 import {
   FILE_OBJECT_KINDS,
@@ -2690,7 +2690,9 @@ function buildRibbonCustomButtonsEditor(): HTMLElement {
   const options: { value: string; label: string }[] = [
     ...settingCommandOptions().map((o) => ({ value: o.command, label: o.label })),
     ...availableRibbonCommandIds()
-      .filter((id) => RIBBON_COMMAND_LABELS[id])
+      // Static ribbon commands only: plugin ids (also returned by
+      // availableRibbonCommandIds now) aren't offered as custom buttons.
+      .filter((id): id is RibbonCommandId => id in RIBBON_COMMAND_LABELS)
       .map((id) => ({ value: id as string, label: RIBBON_COMMAND_LABELS[id] })),
   ].sort((a, b) => a.label.localeCompare(b.label));
 

--- a/src/editor/settings-ui.ts
+++ b/src/editor/settings-ui.ts
@@ -496,6 +496,17 @@ class SettingsModal {
         panel.appendChild(this.buildSettingsBackupSection());
         panel.appendChild(buildDocLinksSection());
       }
+      // Installed-plugins manager under the Plugins tab — install field,
+      // plugin rows, and the dev load-from-file row. Not settings rows, so
+      // it lives outside SETTING_METADATA (like General's info sections
+      // above), and loads lazily so the panel code stays off the settings
+      // open path — same style as the other heavy, on-demand panels.
+      if (id === 'plugins') {
+        const section = document.createElement('section');
+        section.className = 'pmd-plugins-panel';
+        panel.appendChild(section);
+        void import('./plugins-settings-ui.js').then((m) => m.renderPluginsPanel(section));
+      }
       this.dialog.appendChild(panel);
       panels[id] = panel;
     }

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -1736,7 +1736,8 @@ export type SettingsCategory =
   | 'editing'
   | 'shortcuts'
   | 'comments-ai'
-  | 'pairing';
+  | 'pairing'
+  | 'plugins';
 
 export type SettingCondition =
   | keyof Settings
@@ -3505,6 +3506,15 @@ export const SETTING_METADATA: SettingMeta[] = [
     electronOnly: true,
     dependsOn: 'pairingEnabled',
     aliases: ['relay token', 'relay password'],
+  },
+  {
+    key: 'pluginsEnabled',
+    label: 'Enable plugins',
+    description:
+      'Load installed third-party plugins at startup. Plugins run with full access to CardMirror and your documents - install only plugins whose author you trust. Takes effect on the next launch.',
+    kind: 'toggle',
+    category: 'plugins',
+    electronOnly: true,
   },
 ];
 

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -1353,6 +1353,10 @@ export interface Settings {
   cardCutterMorphologyShaving: boolean;
   /** Card-cutter: when the model may pose a clarifying question. */
   cardCutterClarifyingQuestions: 'when-ambiguous' | 'always' | 'never';
+  /** Plugins: master switch for the plugin system (the registry, boot
+   *  loading of enabled plugins, and the manage-plugins UI). Off by
+   *  default. Desktop only for v1. */
+  pluginsEnabled: boolean;
   /** Pairing: master switch for cross-machine card sharing (the send /
    *  receive pills + the background poller). Off by default. Desktop only
    *  for v1. */
@@ -1698,6 +1702,7 @@ const DEFAULTS: Settings = {
   cardCutterAcronymSplitting: 'off',
   cardCutterMorphologyShaving: false,
   cardCutterClarifyingQuestions: 'when-ambiguous',
+  pluginsEnabled: false,
   pairingEnabled: false,
   pairingPollSeconds: 30,
   pairingRelayUrl: '',
@@ -4319,6 +4324,7 @@ function sanitize(s: Settings): Settings {
       s.cardCutterClarifyingQuestions === 'always' || s.cardCutterClarifyingQuestions === 'never'
         ? s.cardCutterClarifyingQuestions
         : 'when-ambiguous',
+    pluginsEnabled: s.pluginsEnabled === true,
     pairingEnabled: s.pairingEnabled === true,
     pairingConnectedUntil: Number.isFinite(Number(s.pairingConnectedUntil))
       ? Math.max(0, Number(s.pairingConnectedUntil))

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -10,7 +10,6 @@
 
 import { isWordHighlightName, isHex6 } from './color-palette.js';
 import { sanitizeAcronymPattern, type AcronymPattern } from './acronym-patterns.js';
-import type { RibbonCommandId } from './ribbon-commands.js';
 import type { IconName } from './icons.js';
 import { getHost } from './host/index.js';
 import { DEFAULT_SPEECH_FILENAME_TEMPLATE } from './speech-filename-default.js';
@@ -1182,15 +1181,16 @@ export interface Settings {
    *  Editing → Acronym marking. */
   acronymPatterns: AcronymPattern[];
   /**
-   * User-supplied overrides for ribbon-command key bindings. Each
-   * entry maps a `RibbonCommandId` to its custom key spec — either a
+   * User-supplied overrides for command key bindings. Each entry maps
+   * a command id (a `RibbonCommandId` or a plugin command id) to its
+   * custom key spec - either a
    * single key string (e.g. `'F8'`, `'Mod-Shift-7'`) or an array for
    * multi-binding commands (e.g. `['F9', 'Mod-u']`). An empty string
    * or empty array means "explicitly unbound" (the command exists in
    * the menu / ribbon but has no key). Commands not present in this
    * map fall back to `DEFAULT_RIBBON_KEYS`.
    */
-  ribbonKeyOverrides: Partial<Record<RibbonCommandId, string | string[]>>;
+  ribbonKeyOverrides: Partial<Record<string, string | string[]>>;
   /** Up to 6 user-configured custom buttons, shown to the right of the
    *  comments buttons on the ribbon (empty = the section is hidden). */
   ribbonCustomButtons: RibbonCustomButton[];
@@ -4765,7 +4765,7 @@ function sanitizeShrinkProtections(raw: unknown): ShrinkProtection[] {
  *  lookup time. */
 function sanitizeRibbonKeyOverrides(
   raw: unknown,
-): Partial<Record<RibbonCommandId, string | string[]>> {
+): Partial<Record<string, string | string[]>> {
   if (!raw || typeof raw !== 'object') return {};
   const out: Partial<Record<string, string | string[]>> = {};
   for (const [k, v] of Object.entries(raw)) {
@@ -4776,7 +4776,7 @@ function sanitizeRibbonKeyOverrides(
       out[k] = cleaned;
     }
   }
-  return out as Partial<Record<RibbonCommandId, string | string[]>>;
+  return out;
 }
 
 /** Keep well-formed `{ command, icon }` custom-button entries, capped at

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -5813,6 +5813,72 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
   cursor: progress;
 }
 
+/* Plugins tab body — install field, installed-plugin rows, dev loader.
+   The widgets themselves reuse the settings classes (.pmd-settings-text,
+   .pmd-install-info-btn, .pmd-settings-toggle, .pmd-settings-section-title),
+   so only this panel's own layout lives here. */
+/* The panel is a wrapper element, so its leading header is a :first-child
+   and drops its own top border — the settings row above already drew one.
+   Restore the standard row-to-header gap the border-top rule would give. */
+.pmd-plugins-panel > .pmd-settings-section-title:first-child {
+  margin-top: 0;
+  padding-top: 0.75rem;
+}
+
+.pmd-plugins-install {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0.75rem;
+}
+.pmd-plugins-input {
+  /* Overrides .pmd-settings-text's fixed 12rem basis — the field is the
+     row's only flexible element, so it takes the leftover width. */
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.pmd-plugins-error {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--pmd-c-error-alt);
+}
+.pmd-plugins-error:empty {
+  display: none;
+}
+
+.pmd-plugins-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--pmd-c-divider-faint);
+}
+.pmd-plugins-row:last-child {
+  border-bottom: none;
+}
+/* The shared toggle is nudged down to sit level with a two-line settings
+   row's title; these rows are single-line and centred. */
+.pmd-plugins-row .pmd-settings-toggle {
+  margin-top: 0;
+}
+.pmd-plugins-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.pmd-plugins-dev {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+.pmd-plugins-dev p {
+  margin: 0;
+}
+
 .pmd-settings-row {
   padding: 0.75rem 0;
   border-bottom: 1px solid var(--pmd-c-divider-faint);

--- a/tests/desktop/_electron-stub.ts
+++ b/tests/desktop/_electron-stub.ts
@@ -5,19 +5,58 @@
 export const sentToRenderer: Array<{ channel: string; payload: any }> = [];
 export const ipcListeners = new Map<string, Array<(evt: unknown, ack: any) => void>>();
 
-const fakeWebContents = {
-  send: (channel: string, payload: any) => {
-    sentToRenderer.push({ channel, payload });
-  },
-};
-const makeWin = () => ({ webContents: fakeWebContents, isDestroyed: () => false });
+interface MockWinOpts {
+  url?: string;
+  sendThrows?: boolean;
+  destroyed?: boolean;
+  minimized?: boolean;
+}
 
-let mockFocusedWindow: ReturnType<typeof makeWin> | null = makeWin();
-let mockAllWindows: ReturnType<typeof makeWin>[] = [mockFocusedWindow];
+export interface MockWin {
+  webContents: { send: (channel: string, payload: any) => void; getURL: () => string };
+  isDestroyed: () => boolean;
+  isMinimized: () => boolean;
+  restore: () => void;
+  show: () => void;
+  focus: () => void;
+  __restored: boolean;
+  __shown: boolean;
+  __focused: boolean;
+}
 
-export function setMockFocusedWindow(win: ReturnType<typeof makeWin> | null): void {
+export function makeMockWindow(opts: MockWinOpts = {}): MockWin {
+  const win: MockWin = {
+    webContents: {
+      send: (channel: string, payload: any) => {
+        if (opts.sendThrows) throw new Error('render process gone');
+        sentToRenderer.push({ channel, payload });
+      },
+      getURL: () => opts.url ?? 'http://localhost/index.html',
+    },
+    isDestroyed: () => opts.destroyed ?? false,
+    isMinimized: () => opts.minimized ?? false,
+    restore: () => { win.__restored = true; },
+    show: () => { win.__shown = true; },
+    focus: () => { win.__focused = true; },
+    __restored: false,
+    __shown: false,
+    __focused: false,
+  };
+  return win;
+}
+
+const makeWin = makeMockWindow;
+
+let mockFocusedWindow: MockWin | null = makeWin();
+let mockAllWindows: MockWin[] = [mockFocusedWindow];
+
+export function setMockFocusedWindow(win: MockWin | null): void {
   mockFocusedWindow = win;
   mockAllWindows = win ? [win] : [];
+}
+
+export function setMockAllWindows(wins: MockWin[]): void {
+  mockAllWindows = wins;
 }
 
 export function resetElectronStub(userDataPath: string): void {

--- a/tests/desktop/bridge-handshake.test.ts
+++ b/tests/desktop/bridge-handshake.test.ts
@@ -96,6 +96,15 @@ describe('flowPost', () => {
   it('maps a missing app and a dead app to typed errors', async () => {
     expect(await flowPost('nope', '/x', {})).toEqual({ ok: false, error: 'no-such-app' });
     await writeFlowHandshake('dead', 1);
-    expect((await flowPost('dead', '/x', {})).ok).toBe(false);
+    expect(await flowPost('dead', '/x', {})).toEqual({ ok: false, error: 'app-not-running' });
+  });
+  it('maps a stalled body to timeout, not a hang', { timeout: 10_000 }, async () => {
+    const live = await listen((_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.write('{"ok":'); // headers + partial body, then stall
+    });
+    await writeFlowHandshake('stall', live.port);
+    expect(await flowPost('stall', '/x', {})).toEqual({ ok: false, error: 'timeout' });
+    live.close();
   });
 });

--- a/tests/desktop/bridge-handshake.test.ts
+++ b/tests/desktop/bridge-handshake.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+// The `electron` import inside bridge-handshake.ts resolves to
+// tests/desktop/_electron-stub.ts via the vitest alias in
+// vitest.config.ts, same as the other desktop-module tests.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as http from 'node:http';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  bridgeDirPath,
+  writeCardmirrorHandshake,
+  deleteCardmirrorHandshake,
+  scanFlowApps,
+  flowPost,
+  BRIDGE_TOKEN_HEADER,
+} from '../../apps/desktop/src/bridge-handshake.js';
+
+let dir: string;
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cm-bridge-'));
+  process.env['CARDMIRROR_BRIDGE_DIR'] = dir;
+});
+afterEach(async () => {
+  delete process.env['CARDMIRROR_BRIDGE_DIR'];
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+function listen(handler: http.RequestListener): Promise<{ port: number; close: () => void }> {
+  const { promise, resolve } = Promise.withResolvers<{ port: number; close: () => void }>();
+  const server = http.createServer(handler);
+  server.listen(0, '127.0.0.1', () => {
+    const addr = server.address() as { port: number };
+    resolve({ port: addr.port, close: () => server.close() });
+  });
+  return promise;
+}
+
+async function writeFlowHandshake(id: string, port: number, token = 'tok'): Promise<void> {
+  await fs.writeFile(
+    path.join(dir, `${id}.json`),
+    JSON.stringify({ schema: 1, app: id, appVersion: '1.0.0', kind: 'flow', port, token, pid: 1 }),
+  );
+}
+
+describe('handshake dir', () => {
+  it('honors the CARDMIRROR_BRIDGE_DIR override', () => {
+    expect(bridgeDirPath()).toBe(dir);
+  });
+  it('writes and deletes the cardmirror mirror file', async () => {
+    await writeCardmirrorHandshake(17699, 'secret');
+    const raw = JSON.parse(await fs.readFile(path.join(dir, 'cardmirror.json'), 'utf8'));
+    expect(raw).toMatchObject({ app: 'cardmirror', kind: 'editor', port: 17699, token: 'secret' });
+    await deleteCardmirrorHandshake();
+    await expect(fs.readFile(path.join(dir, 'cardmirror.json'))).rejects.toThrow();
+  });
+});
+
+describe('scanFlowApps', () => {
+  it('returns live flow apps only, with the token sent on ping', async () => {
+    let sawToken = '';
+    const live = await listen((req, res) => {
+      sawToken = String(req.headers[BRIDGE_TOKEN_HEADER.toLowerCase()] ?? '');
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await writeFlowHandshake('ebb', live.port, 'tok-live');
+    await writeFlowHandshake('dead', 1, 'tok-dead'); // nothing listens on port 1
+    await fs.writeFile(path.join(dir, 'broken.json'), '{not json');
+    await writeCardmirrorHandshake(17699, 's'); // kind editor — excluded
+    const apps = await scanFlowApps();
+    expect(apps.map((a) => a.id)).toEqual(['ebb']);
+    expect(sawToken).toBe('tok-live');
+    live.close();
+  });
+});
+
+describe('flowPost', () => {
+  it('POSTs with the token header and returns parsed JSON', async () => {
+    let got: unknown = null;
+    const live = await listen((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        got = { url: req.url, token: req.headers[BRIDGE_TOKEN_HEADER.toLowerCase()], body: JSON.parse(Buffer.concat(chunks).toString()) };
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ ok: true, sheet: '2AC' }));
+      });
+    });
+    await writeFlowHandshake('ebb', live.port, 'tok');
+    const res = await flowPost('ebb', '/flow/send', { mode: 'column' });
+    expect(res).toEqual({ ok: true, status: 200, body: { ok: true, sheet: '2AC' } });
+    expect(got).toMatchObject({ url: '/flow/send', token: 'tok', body: { mode: 'column' } });
+    live.close();
+  });
+  it('maps a missing app and a dead app to typed errors', async () => {
+    expect(await flowPost('nope', '/x', {})).toEqual({ ok: false, error: 'no-such-app' });
+    await writeFlowHandshake('dead', 1);
+    expect((await flowPost('dead', '/x', {})).ok).toBe(false);
+  });
+});

--- a/tests/desktop/bridge-handshake.test.ts
+++ b/tests/desktop/bridge-handshake.test.ts
@@ -104,12 +104,43 @@ describe('flowPost', () => {
     expect(await flowPost('badport', '/x', {})).toEqual({ ok: false, error: 'no-such-app' });
     expect(await flowPost('floatport', '/x', {})).toEqual({ ok: false, error: 'no-such-app' });
   });
-  it('ignores oversized handshake files', async () => {
-    await fs.writeFile(path.join(dir, 'big.json'), '"' + 'x'.repeat(70 * 1024) + '"');
+  it('ignores oversized handshake files even when otherwise valid', async () => {
+    let pinged = false;
+    const live = await listen((_req, res) => {
+      pinged = true;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ ok: true }));
+    });
+    // Valid flow handshake, live port, but padded past the 64 KiB cap.
+    await fs.writeFile(
+      path.join(dir, 'big.json'),
+      JSON.stringify({
+        schema: 1,
+        app: 'big',
+        appVersion: 'x'.repeat(70 * 1024),
+        kind: 'flow',
+        port: live.port,
+        token: 'tok',
+        pid: 1,
+      }),
+    );
     expect((await scanFlowApps()).map((a) => a.id)).not.toContain('big');
+    expect(pinged).toBe(false); // skipped before any ping
+    live.close();
   });
-  it('rejects uppercase app ids per the published contract', async () => {
+  it('rejects uppercase app ids even with a valid handshake on disk', async () => {
+    let pinged = false;
+    const live = await listen((_req, res) => {
+      pinged = true;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ ok: true }));
+    });
+    // A complete, live handshake at Ebb.json — only the uppercase id
+    // must reject it (the published contract is lowercase-only).
+    await writeFlowHandshake('Ebb', live.port, 'tok');
     expect(await flowPost('Ebb', '/x', {})).toEqual({ ok: false, error: 'no-such-app' });
+    expect(pinged).toBe(false);
+    live.close();
   });
   it('maps a stalled body to timeout, not a hang', { timeout: 10_000 }, async () => {
     const live = await listen((_req, res) => {

--- a/tests/desktop/bridge-handshake.test.ts
+++ b/tests/desktop/bridge-handshake.test.ts
@@ -98,6 +98,19 @@ describe('flowPost', () => {
     await writeFlowHandshake('dead', 1);
     expect(await flowPost('dead', '/x', {})).toEqual({ ok: false, error: 'app-not-running' });
   });
+  it('rejects out-of-range and non-integer ports', async () => {
+    await writeFlowHandshake('badport', 0); // helper writes port 0
+    await writeFlowHandshake('floatport', 1.5 as any);
+    expect(await flowPost('badport', '/x', {})).toEqual({ ok: false, error: 'no-such-app' });
+    expect(await flowPost('floatport', '/x', {})).toEqual({ ok: false, error: 'no-such-app' });
+  });
+  it('ignores oversized handshake files', async () => {
+    await fs.writeFile(path.join(dir, 'big.json'), '"' + 'x'.repeat(70 * 1024) + '"');
+    expect((await scanFlowApps()).map((a) => a.id)).not.toContain('big');
+  });
+  it('rejects uppercase app ids per the published contract', async () => {
+    expect(await flowPost('Ebb', '/x', {})).toEqual({ ok: false, error: 'no-such-app' });
+  });
   it('maps a stalled body to timeout, not a hang', { timeout: 10_000 }, async () => {
     const live = await listen((_req, res) => {
       res.setHeader('Content-Type', 'application/json');

--- a/tests/desktop/fast-paste-bridge.test.ts
+++ b/tests/desktop/fast-paste-bridge.test.ts
@@ -339,5 +339,26 @@ describe('fast-paste-bridge', () => {
       expect(r.status).toBe(200);
       expect(r.json).toEqual({ ok: false, error: 'doc-not-open', docTitle: 'Gone.docx' });
     });
+
+    it('restores a minimized window that acks ok', async () => {
+      const win = makeMockWindow({ minimized: true });
+      setMockAllWindows([win]);
+      const ep = bridge.getRunningEndpoint()!;
+      const source =
+        'cmsrc1.' +
+        Buffer.from(JSON.stringify({ docId: 'd', docTitle: 'Min.docx' })).toString('base64url');
+      const jumped = fetchJson({
+        method: 'POST', path: '/jump', port: ep.port, token: ep.token,
+        body: { source },
+      });
+      await new Promise((r) => setTimeout(r, 20));
+      const sent = sentToRenderer.find((s) => s.channel === 'external:jump')!;
+      const listeners = ipcListeners.get('external:jump-result') ?? [];
+      for (const l of listeners) l(null, { requestId: sent.payload.requestId, ok: true });
+      const r = await jumped;
+      expect(r.status).toBe(200);
+      expect(r.json).toEqual({ ok: true });
+      expect(win.__restored).toBe(true);
+    });
   });
 });

--- a/tests/desktop/fast-paste-bridge.test.ts
+++ b/tests/desktop/fast-paste-bridge.test.ts
@@ -85,7 +85,7 @@ describe('fast-paste-bridge', () => {
     );
     expect(data).toMatchObject({
       app: 'cardmirror',
-      schema: 1,
+      schema: 2,
       appVersion: 'TEST-1.2.3',
       port: ep!.port,
       token: ep!.token,
@@ -101,7 +101,7 @@ describe('fast-paste-bridge', () => {
       ok: true,
       app: 'cardmirror',
       appVersion: 'TEST-1.2.3',
-      schema: 1,
+      schema: 2,
       hasActiveDoc: true,
     });
   });
@@ -259,5 +259,51 @@ describe('fast-paste-bridge', () => {
     await expect(fs.access(file)).rejects.toBeTruthy();
     // Restart so afterEach can stop a server cleanly.
     await bridge.startFastPasteBridge();
+  });
+  describe('POST /jump', () => {
+    it('rejects a missing token', async () => {
+      const ep = bridge.getRunningEndpoint()!;
+      const r = await fetchJson({
+        method: 'POST', path: '/jump', port: ep.port,
+        body: { source: 'x' },
+      });
+      expect(r.status).toBe(403);
+    });
+
+    it('accepts the token in X-Bridge-Token', async () => {
+      const ep = bridge.getRunningEndpoint()!;
+      const r = await fetchJson({
+        method: 'GET', path: '/ping', port: ep.port,
+        headers: { 'x-bridge-token': ep.token },
+      });
+      expect(r.status).toBe(200);
+      expect((r.json as { schema: number }).schema).toBe(2);
+    });
+
+    it('400s on a body without a source string', async () => {
+      const ep = bridge.getRunningEndpoint()!;
+      const r = await fetchJson({
+        method: 'POST', path: '/jump', port: ep.port, token: ep.token,
+        body: {},
+      });
+      expect(r.status).toBe(400);
+    });
+
+    it('reports doc-not-open with the docTitle when no window matches', async () => {
+      // The stub's default window would swallow the jump broadcast
+      // and run out the ack timeout; clear it so getAllWindows()
+      // returns [] and the no-window path resolves immediately.
+      setMockFocusedWindow(null);
+      const ep = bridge.getRunningEndpoint()!;
+      const source =
+        'cmsrc1.' +
+        Buffer.from(JSON.stringify({ docId: 'd', docTitle: 'AT Cap K.docx' })).toString('base64url');
+      const r = await fetchJson({
+        method: 'POST', path: '/jump', port: ep.port, token: ep.token,
+        body: { source },
+      });
+      expect(r.status).toBe(200);
+      expect(r.json).toEqual({ ok: false, error: 'doc-not-open', docTitle: 'AT Cap K.docx' });
+    });
   });
 });

--- a/tests/desktop/fast-paste-bridge.test.ts
+++ b/tests/desktop/fast-paste-bridge.test.ts
@@ -8,6 +8,8 @@ import {
   ipcListeners,
   resetElectronStub,
   setMockFocusedWindow,
+  setMockAllWindows,
+  makeMockWindow,
 } from './_electron-stub.js';
 import * as bridge from '../../apps/desktop/src/fast-paste-bridge.js';
 
@@ -304,6 +306,38 @@ describe('fast-paste-bridge', () => {
       });
       expect(r.status).toBe(200);
       expect(r.json).toEqual({ ok: false, error: 'doc-not-open', docTitle: 'AT Cap K.docx' });
+    });
+
+    it('400s a source without the cmsrc1 prefix, with no broadcast', async () => {
+      const ep = bridge.getRunningEndpoint()!;
+      const source =
+        'x.' + Buffer.from(JSON.stringify({ docTitle: 'forged' })).toString('base64url');
+      const r = await fetchJson({
+        method: 'POST', path: '/jump', port: ep.port, token: ep.token,
+        body: { source },
+      });
+      expect(r.status).toBe(400);
+      expect(r.json).toEqual({ ok: false, error: 'bad-request' });
+      expect(r.json.docTitle).toBeUndefined();
+      // The bad prefix short-circuits before any window is asked to jump.
+      expect(sentToRenderer.some((s) => s.channel === 'external:jump')).toBe(false);
+    });
+
+    it('answers even when a window is destroyed mid-broadcast', async () => {
+      // Only window in the broadcast throws on send (render process gone);
+      // the dispatch guard must resolve not-mine instead of rejecting and
+      // hanging the /jump route.
+      setMockAllWindows([makeMockWindow({ sendThrows: true })]);
+      const ep = bridge.getRunningEndpoint()!;
+      const source =
+        'cmsrc1.' +
+        Buffer.from(JSON.stringify({ docId: 'd', docTitle: 'Gone.docx' })).toString('base64url');
+      const r = await fetchJson({
+        method: 'POST', path: '/jump', port: ep.port, token: ep.token,
+        body: { source },
+      });
+      expect(r.status).toBe(200);
+      expect(r.json).toEqual({ ok: false, error: 'doc-not-open', docTitle: 'Gone.docx' });
     });
   });
 });

--- a/tests/desktop/plugin-manager.test.ts
+++ b/tests/desktop/plugin-manager.test.ts
@@ -3,6 +3,7 @@ import {
   parseRepoRef,
   compareVersions,
   validateManifest,
+  checkInstallCollision,
 } from '../../apps/desktop/src/plugin-manager.js';
 
 describe('parseRepoRef', () => {
@@ -48,5 +49,25 @@ describe('validateManifest', () => {
     expect(validateManifest({ ...good, id: undefined }).ok).toBe(false);
     expect(validateManifest({ ...good, apiVersion: 99 }).ok).toBe(false);
     expect(validateManifest({ ...good, version: 7 }).ok).toBe(false);
+  });
+  it('rejects Windows reserved device ids', () => {
+    expect(validateManifest({ ...good, id: 'con' }).ok).toBe(false);
+    expect(validateManifest({ ...good, id: 'com1' }).ok).toBe(false);
+  });
+});
+
+describe('checkInstallCollision', () => {
+  const existing = { id: 'demo', name: 'Demo', version: '1.0.0', apiVersion: 1, repo: 'owner/demo' };
+  it('allows a same-repo reinstall (the update path)', () => {
+    expect(checkInstallCollision(existing, 'owner/demo')).toBeNull();
+  });
+  it('blocks a different repo claiming an installed id', () => {
+    expect(checkInstallCollision(existing, 'evil/demo')).toContain('already owns the id');
+  });
+  it('allows a fresh id with no existing install', () => {
+    expect(checkInstallCollision(undefined, 'owner/demo')).toBeNull();
+  });
+  it('blocks when the existing install has no stored repo', () => {
+    expect(checkInstallCollision({ ...existing, repo: undefined }, 'owner/demo')).toContain('already owns the id');
   });
 });

--- a/tests/desktop/plugin-manager.test.ts
+++ b/tests/desktop/plugin-manager.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseRepoRef,
+  compareVersions,
+  validateManifest,
+} from '../../apps/desktop/src/plugin-manager.js';
+
+describe('parseRepoRef', () => {
+  it('accepts owner/repo shorthand', () => {
+    expect(parseRepoRef('smodi/cardmirror-ebb')).toEqual({ owner: 'smodi', repo: 'cardmirror-ebb' });
+  });
+  it('accepts full GitHub URLs, with .git and trailing paths', () => {
+    expect(parseRepoRef('https://github.com/smodi/cardmirror-ebb')).toEqual({ owner: 'smodi', repo: 'cardmirror-ebb' });
+    expect(parseRepoRef('https://github.com/smodi/cardmirror-ebb.git')).toEqual({ owner: 'smodi', repo: 'cardmirror-ebb' });
+    expect(parseRepoRef('https://github.com/smodi/cardmirror-ebb/releases')).toEqual({ owner: 'smodi', repo: 'cardmirror-ebb' });
+  });
+  it('rejects everything else', () => {
+    expect(parseRepoRef('https://gitlab.com/a/b')).toBeNull();
+    expect(parseRepoRef('not a ref')).toBeNull();
+    expect(parseRepoRef('')).toBeNull();
+  });
+});
+
+describe('compareVersions', () => {
+  it('orders release triples', () => {
+    expect(compareVersions('1.2.0', '1.1.9')).toBeGreaterThan(0);
+    expect(compareVersions('0.1.0', '0.1.0')).toBe(0);
+  });
+  it('release beats its own prerelease; prereleases order numerically', () => {
+    expect(compareVersions('0.1.0', '0.1.0-beta.17')).toBeGreaterThan(0);
+    expect(compareVersions('0.1.0-beta.18', '0.1.0-beta.17')).toBeGreaterThan(0);
+    expect(compareVersions('0.1.0-beta.2', '0.1.0-beta.10')).toBeLessThan(0);
+  });
+});
+
+describe('validateManifest', () => {
+  const good = {
+    id: 'cardmirror-ebb',
+    name: 'ebb Flow Integration',
+    version: '0.1.0',
+    apiVersion: 1,
+  };
+  it('accepts a minimal valid manifest', () => {
+    expect(validateManifest(good)).toEqual({ ok: true, manifest: expect.objectContaining(good) });
+  });
+  it('rejects bad ids, missing fields, wrong apiVersion', () => {
+    expect(validateManifest({ ...good, id: '../evil' }).ok).toBe(false);
+    expect(validateManifest({ ...good, id: undefined }).ok).toBe(false);
+    expect(validateManifest({ ...good, apiVersion: 99 }).ok).toBe(false);
+    expect(validateManifest({ ...good, version: 7 }).ok).toBe(false);
+  });
+});

--- a/tests/editor/plugin-api.test.ts
+++ b/tests/editor/plugin-api.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPluginApi } from '../../src/editor/plugin-api.js';
+import { isPluginEnabled, setPluginEnabled } from '../../src/editor/plugins-store.js';
+
+const deps = {
+  appVersion: '0.1.0-test',
+  getView: () => null,
+  getDocIdentity: () => null,
+  ensureDocId: () => null,
+};
+
+beforeEach(() => localStorage.clear());
+
+describe('createPluginApi', () => {
+  it('extractSelection reports no-active-doc without a view', () => {
+    const api = createPluginApi('demo', deps);
+    expect(api.extractSelection()).toEqual({ ok: false, error: 'no-active-doc' });
+  });
+  it('jumpToSource rejects garbage tokens', async () => {
+    const api = createPluginApi('demo', deps);
+    expect(await api.jumpToSource('garbage')).toEqual({ ok: false, error: 'bad-request' });
+  });
+  it('flow methods degrade off-desktop', async () => {
+    const api = createPluginApi('demo', deps);
+    expect(await api.flowApps()).toEqual([]);
+    expect(await api.flowPost('ebb', '/x', {})).toEqual({ ok: false, error: 'unsupported' });
+  });
+  it('storage is per-plugin and JSON-durable', () => {
+    const a = createPluginApi('a', deps);
+    const b = createPluginApi('b', deps);
+    a.storage.set('k', { n: 1 });
+    expect(a.storage.get('k')).toEqual({ n: 1 });
+    expect(b.storage.get('k')).toBeUndefined();
+    expect(JSON.parse(localStorage.getItem('plugin:a')!)).toEqual({ k: { n: 1 } });
+  });
+});
+
+describe('plugins-store', () => {
+  it('defaults to disabled and persists the toggle', () => {
+    expect(isPluginEnabled('x')).toBe(false);
+    setPluginEnabled('x', true);
+    expect(isPluginEnabled('x')).toBe(true);
+    setPluginEnabled('x', false);
+    expect(isPluginEnabled('x')).toBe(false);
+  });
+});

--- a/tests/editor/plugin-api.test.ts
+++ b/tests/editor/plugin-api.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditorState, TextSelection } from 'prosemirror-state';
+import type { Node as PMNode } from 'prosemirror-model';
+import type { EditorView } from 'prosemirror-view';
+import { schema } from '../../src/schema/index.js';
 import { createPluginApi } from '../../src/editor/plugin-api.js';
+import { parseSourceToken } from '../../src/editor/plugin-source-token.js';
 import { isPluginEnabled, setPluginEnabled } from '../../src/editor/plugins-store.js';
 
 const deps = {
@@ -10,12 +15,56 @@ const deps = {
   ensureDocId: () => null,
 };
 
+/** State-backed view stand-in with a cursor at `pos` (extraction reads
+ *  view.state only). Mirrors the fakeView pattern in plugin-extract.test.ts. */
+function fakeView(doc: PMNode, pos: number): EditorView {
+  const state = EditorState.create({ doc });
+  const sel = TextSelection.create(state.doc, pos);
+  return { state: state.apply(state.tr.setSelection(sel)) } as unknown as EditorView;
+}
+
 beforeEach(() => localStorage.clear());
 
 describe('createPluginApi', () => {
   it('extractSelection reports no-active-doc without a view', () => {
     const api = createPluginApi('demo', deps);
     expect(api.extractSelection()).toEqual({ ok: false, error: 'no-active-doc' });
+  });
+  it('extractSelection does not mint a docId when extraction fails', () => {
+    // Body-only doc, cursor in the paragraph: no governing heading, so
+    // extraction fails BEFORE any mint. A pristine file must stay pristine.
+    const doc = schema.nodes['doc']!.createChecked(null, [
+      schema.nodes['paragraph']!.create(null, schema.text('just prose')),
+    ]);
+    const ensureDocId = vi.fn(() => 'minted-id');
+    const api = createPluginApi('demo', {
+      ...deps,
+      getView: () => fakeView(doc, 2),
+      getDocIdentity: () => ({ docId: null, docTitle: 'T' }),
+      ensureDocId,
+    });
+    const res = api.extractSelection();
+    expect(res.ok).toBe(false);
+    expect(ensureDocId).not.toHaveBeenCalled();
+  });
+  it('extractSelection mints once and stamps tokens on first success', () => {
+    const doc = schema.nodes['doc']!.createChecked(null, [
+      schema.nodes['block']!.create({ id: 'h-1' }, schema.text('A heading')),
+    ]);
+    const ensureDocId = vi.fn(() => 'minted-id');
+    const api = createPluginApi('demo', {
+      ...deps,
+      getView: () => fakeView(doc, 2),
+      getDocIdentity: () => ({ docId: null, docTitle: 'T' }),
+      ensureDocId,
+    });
+    const res = api.extractSelection();
+    if (!res.ok) throw new Error(res.error);
+    expect(ensureDocId).toHaveBeenCalledTimes(1);
+    expect(res.docId).toBe('minted-id');
+    for (const item of res.items) {
+      expect(parseSourceToken(item.source)!.docId).toBe('minted-id');
+    }
   });
   it('jumpToSource rejects garbage tokens', async () => {
     const api = createPluginApi('demo', deps);

--- a/tests/editor/plugin-api.test.ts
+++ b/tests/editor/plugin-api.test.ts
@@ -11,6 +11,7 @@ import { isPluginEnabled, setPluginEnabled } from '../../src/editor/plugins-stor
 const deps = {
   appVersion: '0.1.0-test',
   getView: () => null,
+  findViewForDocId: () => null,
   getDocIdentity: () => null,
   ensureDocId: () => null,
 };

--- a/tests/editor/plugin-commands.test.ts
+++ b/tests/editor/plugin-commands.test.ts
@@ -9,6 +9,7 @@ import {
   buildRibbonKeymap,
   getRibbonCommand,
   ribbonCommandForKey,
+  effectivePluginDefaultKeys,
   commandLabelFor,
   commandAliasesFor,
 } from '../../src/editor/ribbon-commands.js';
@@ -25,6 +26,18 @@ function registerDemo(run: () => void): void {
     apiVersion: 1,
     commands: [
       { id: 'demo.hello', label: 'Say Hello', keywords: ['greet'], defaultKey: 'Mod-Alt-9', run },
+    ],
+  });
+}
+
+function registerDemoWithKey(defaultKey: string): void {
+  installPluginRegistry(() => stubApi);
+  registerPluginDefinition({
+    id: 'demo',
+    name: 'Demo',
+    apiVersion: 1,
+    commands: [
+      { id: 'demo.hello', label: 'Say Hello', keywords: ['greet'], defaultKey, run: () => {} },
     ],
   });
 }
@@ -85,5 +98,23 @@ describe('plugin commands in the chokepoints', () => {
     }
     expect(run).not.toHaveBeenCalled();
     expect(ribbonCommandForKey('F4')).toBe('setPocket');
+  });
+  it('a plugin default differing only in case never steals a static key', () => {
+    // toggleReadingMarker's static default is 'Mod-Shift-d'.
+    registerDemoWithKey('Mod-Shift-D');
+    const map = buildRibbonKeymap({});
+    expect(map['Mod-Shift-D']).toBeUndefined();
+    expect(ribbonCommandForKey('Mod-Shift-D')).not.toBe('demo.hello');
+  });
+  it('a suppressed plugin default is not displayed as bound', () => {
+    // F4 is setPocket's static default — the plugin default loses.
+    registerDemoWithKey('F4');
+    expect(effectivePluginDefaultKeys('demo.hello', {})).toEqual([]);
+  });
+  it('an overridden plugin command displays the override only', () => {
+    registerDemoWithKey('Mod-Alt-9');
+    expect(effectivePluginDefaultKeys('demo.hello', { 'demo.hello': 'Mod-Alt-8' })).toEqual([
+      'Mod-Alt-8',
+    ]);
   });
 });

--- a/tests/editor/plugin-commands.test.ts
+++ b/tests/editor/plugin-commands.test.ts
@@ -62,4 +62,28 @@ describe('plugin commands in the chokepoints', () => {
     expect(buildRibbonKeymap(overrides)['Mod-Alt-9']).toBeUndefined();
     expect(ribbonCommandForKey('Mod-Alt-8', overrides)).toBe('demo.hello');
   });
+  it('a plugin defaultKey never steals a static DEFAULT key', () => {
+    const run = vi.fn();
+    installPluginRegistry(() => stubApi);
+    registerPluginDefinition({
+      id: 'demo',
+      name: 'Demo',
+      apiVersion: 1,
+      // F4 is setPocket's DEFAULT_RIBBON_KEYS binding — the collision case.
+      commands: [{ id: 'demo.steal', label: 'Steal F4', defaultKey: 'F4', run }],
+    });
+    const km = buildRibbonKeymap({});
+    expect(km['F4']).toBeDefined();
+    // Whatever F4 fires must not be the plugin command: the plugin
+    // Command always calls `run` and never throws (runPluginCommand
+    // swallows), while the static command may throw on a null state —
+    // irrelevant, only "did the plugin run" matters.
+    try {
+      km['F4']!(null as never, undefined, undefined);
+    } catch {
+      /* static command touched the (absent) editor state */
+    }
+    expect(run).not.toHaveBeenCalled();
+    expect(ribbonCommandForKey('F4')).toBe('setPocket');
+  });
 });

--- a/tests/editor/plugin-commands.test.ts
+++ b/tests/editor/plugin-commands.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  installPluginRegistry,
+  registerPluginDefinition,
+  resetPluginRegistryForTests,
+} from '../../src/editor/plugin-registry.js';
+import {
+  buildRibbonKeymap,
+  getRibbonCommand,
+  ribbonCommandForKey,
+  commandLabelFor,
+  commandAliasesFor,
+} from '../../src/editor/ribbon-commands.js';
+import { availableRibbonCommandIds } from '../../src/editor/ribbon-availability.js';
+import type { CardMirrorPluginApi } from '../../src/editor/plugin-api.js';
+
+const stubApi = {} as CardMirrorPluginApi;
+
+function registerDemo(run: () => void): void {
+  installPluginRegistry(() => stubApi);
+  registerPluginDefinition({
+    id: 'demo',
+    name: 'Demo',
+    apiVersion: 1,
+    commands: [
+      { id: 'demo.hello', label: 'Say Hello', keywords: ['greet'], defaultKey: 'Mod-Alt-9', run },
+    ],
+  });
+}
+
+afterEach(() => resetPluginRegistryForTests());
+
+describe('plugin commands in the chokepoints', () => {
+  it('appear in availableRibbonCommandIds', () => {
+    registerDemo(() => {});
+    expect(availableRibbonCommandIds()).toContain('demo.hello');
+  });
+  it('resolve labels and keywords through the fallback helpers', () => {
+    registerDemo(() => {});
+    expect(commandLabelFor('demo.hello')).toBe('Say Hello');
+    expect(commandAliasesFor('demo.hello')).toEqual(['greet']);
+    // Static ids keep working through the same helpers.
+    expect(typeof commandLabelFor('sendToFlowColumn')).toBe('string');
+  });
+  it('getRibbonCommand runs the plugin run fn', () => {
+    const run = vi.fn();
+    registerDemo(run);
+    const cmd = getRibbonCommand('demo.hello');
+    expect(cmd(null as never, undefined, undefined)).toBe(true);
+    expect(run).toHaveBeenCalled();
+  });
+  it('default keys land in the keymap and reverse-resolve', () => {
+    registerDemo(() => {});
+    expect(buildRibbonKeymap({})['Mod-Alt-9']).toBeDefined();
+    expect(ribbonCommandForKey('Mod-Alt-9')).toBe('demo.hello');
+  });
+  it('overrides rebind plugin commands', () => {
+    registerDemo(() => {});
+    const overrides = { 'demo.hello': 'Mod-Alt-8' };
+    expect(buildRibbonKeymap(overrides)['Mod-Alt-8']).toBeDefined();
+    expect(buildRibbonKeymap(overrides)['Mod-Alt-9']).toBeUndefined();
+    expect(ribbonCommandForKey('Mod-Alt-8', overrides)).toBe('demo.hello');
+  });
+});

--- a/tests/editor/plugin-extract.test.ts
+++ b/tests/editor/plugin-extract.test.ts
@@ -7,6 +7,7 @@ import type { EditorView } from 'prosemirror-view';
 import { schema, newHeadingId } from '../../src/schema/index.js';
 import { extractSelection } from '../../src/editor/plugin-extract.js';
 import { parseSourceToken } from '../../src/editor/plugin-source-token.js';
+import { resolveDescriptor } from '../../src/editor/learn-anchor.js';
 
 const IDENT = { docId: 'doc-1', docTitle: 'Test.docx' };
 
@@ -29,6 +30,23 @@ function paragraph(text: string): PMNode {
 }
 function card(...children: PMNode[]): PMNode {
   return schema.nodes['card']!.createChecked(null, children);
+}
+function analyticUnit(...children: PMNode[]): PMNode {
+  return schema.nodes['analytic_unit']!.createChecked(null, children);
+}
+function selfRef(sourceHeadingId: string, children: PMNode[]): PMNode {
+  return schema.nodes['self_ref']!.create(
+    { source_heading_id: sourceHeadingId, source_label: '↳ Mirror' },
+    children,
+  );
+}
+/** First document position of the first node of `type`, or -1. */
+function posOf(doc: PMNode, type: string): number {
+  let found = -1;
+  doc.descendants((n, p) => {
+    if (found < 0 && n.type.name === type) found = p;
+  });
+  return found;
 }
 function makeDoc(children: PMNode[]): PMNode {
   return schema.nodes['doc']!.createChecked(null, children);
@@ -99,5 +117,95 @@ describe('extractSelection', () => {
     const paraStart = doc.content.size - doc.child(2).nodeSize;
     const res = extractSelection(fakeView(doc, paraStart + 1, paraStart + 6), IDENT);
     expect(res).toEqual({ ok: false, error: 'empty-selection' });
+  });
+
+  it('never emits self_ref mirrored content', () => {
+    const srcId = newHeadingId();
+    // A live view mirrors the block above it; its child is a derived copy of
+    // the same text. Without the guard the mirror emits 'AT: Framework' twice.
+    const doc = makeDoc([
+      heading('block', 'AT: Framework', srcId),
+      card(heading('tag', 'Perm solves')),
+      selfRef(srcId, [heading('block', 'AT: Framework')]),
+    ]);
+    const res = extractSelection(fakeView(doc, 1, doc.content.size - 1), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    const framework = res.items.filter((i) => i.text === 'AT: Framework');
+    expect(framework.length).toBe(1);
+  });
+
+  it('emits analytic nodes with their own heading id', () => {
+    const anId = newHeadingId();
+    const doc = makeDoc([analyticUnit(heading('analytic', 'A1', anId), undertag('detail'))]);
+    const res = extractSelection(fakeView(doc, 1, doc.content.size - 1), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.items.map((i) => i.kind)).toEqual(['analytic', 'undertag']);
+    const ut = res.items.find((i) => i.kind === 'undertag')!;
+    expect(parseSourceToken(ut.source)!.headingId).toBe(anId);
+  });
+
+  it('attributes a top-level undertag to the nearest preceding heading', () => {
+    const bId = newHeadingId();
+    const doc = makeDoc([heading('block', 'Section', bId), undertag('loose note')]);
+    const res = extractSelection(fakeView(doc, 1, doc.content.size - 1), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    const ut = res.items.find((i) => i.kind === 'undertag')!;
+    expect(parseSourceToken(ut.source)!.headingId).toBe(bId);
+  });
+
+  it('attributes a mid-card selection with the tag outside the range', () => {
+    const tId = newHeadingId();
+    const doc = makeDoc([card(heading('tag', 'Tag here', tId), undertag('mid detail'))]);
+    const utPos = posOf(doc, 'undertag');
+    // Select only inside the undertag text — the tag sits before sel.from.
+    const res = extractSelection(fakeView(doc, utPos + 2, utPos + 6), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.items.map((i) => i.kind)).toEqual(['undertag']);
+    expect(parseSourceToken(res.items[0]!.source)!.headingId).toBe(tId);
+  });
+
+  it('anchors resolve back to the item text', () => {
+    const doc = sampleDoc();
+    const res = extractSelection(fakeView(doc, 1, doc.content.size - 1), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    const block = res.items.find((i) => i.kind === 'block')!;
+    const anchor = parseSourceToken(block.source)!.anchor;
+    expect(anchor).not.toBeNull();
+    const resolved = resolveDescriptor(doc, anchor!);
+    expect(resolved).not.toBeNull();
+    const text = doc.textBetween(resolved!.from, resolved!.to, ' ');
+    expect(text).toContain('AT: Framework');
+  });
+
+  it('collapsed cursor in a block section stops at the next same-level heading', () => {
+    const aId = newHeadingId();
+    const bId = newHeadingId();
+    const doc = makeDoc([
+      heading('block', 'Block A', aId),
+      card(heading('tag', 'A tag')),
+      heading('block', 'Block B', bId),
+      card(heading('tag', 'B tag')),
+    ]);
+    // Cursor inside the 'Block A' heading.
+    const res = extractSelection(fakeView(doc, 2), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    const texts = res.items.map((i) => i.text);
+    expect(texts).toContain('Block A');
+    expect(texts).toContain('A tag');
+    expect(texts).not.toContain('Block B');
+    expect(texts).not.toContain('B tag');
+  });
+
+  it('a one-character graze emits the whole item', () => {
+    const doc = makeDoc([
+      card(heading('tag', 'First tag')),
+      heading('block', 'Grazed heading'),
+    ]);
+    const blockPos = posOf(doc, 'block');
+    // Selection ends one char into the block heading; it emits in full.
+    const res = extractSelection(fakeView(doc, 1, blockPos + 2), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    const grazed = res.items.find((i) => i.kind === 'block');
+    expect(grazed?.text).toBe('Grazed heading');
   });
 });

--- a/tests/editor/plugin-extract.test.ts
+++ b/tests/editor/plugin-extract.test.ts
@@ -1,0 +1,103 @@
+// tests/editor/plugin-extract.test.ts
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { EditorState, TextSelection } from 'prosemirror-state';
+import type { Node as PMNode } from 'prosemirror-model';
+import type { EditorView } from 'prosemirror-view';
+import { schema, newHeadingId } from '../../src/schema/index.js';
+import { extractSelection } from '../../src/editor/plugin-extract.js';
+import { parseSourceToken } from '../../src/editor/plugin-source-token.js';
+
+const IDENT = { docId: 'doc-1', docTitle: 'Test.docx' };
+
+function heading(type: string, text: string, id = newHeadingId()): PMNode {
+  return schema.nodes[type]!.create({ id }, schema.text(text));
+}
+function undertag(text: string): PMNode {
+  return schema.nodes['undertag']!.create(null, schema.text(text));
+}
+function citePara(citeText: string, rest = ''): PMNode {
+  const content = [schema.text(citeText, [schema.marks['cite_mark']!.create()])];
+  if (rest) content.push(schema.text(rest));
+  return schema.nodes['cite_paragraph']!.create(null, content);
+}
+function cardBody(text: string): PMNode {
+  return schema.nodes['card_body']!.create(null, schema.text(text));
+}
+function paragraph(text: string): PMNode {
+  return schema.nodes['paragraph']!.create(null, schema.text(text));
+}
+function card(...children: PMNode[]): PMNode {
+  return schema.nodes['card']!.createChecked(null, children);
+}
+function makeDoc(children: PMNode[]): PMNode {
+  return schema.nodes['doc']!.createChecked(null, children);
+}
+
+/** Minimal view stand-in: extraction reads state only. */
+function fakeView(doc: PMNode, from: number, to = from): EditorView {
+  const state = EditorState.create({ doc });
+  const sel =
+    to === from
+      ? TextSelection.create(state.doc, from)
+      : TextSelection.create(state.doc, from, to);
+  // Extraction only touches view.state; a full EditorView needs a DOM mount.
+  return { state: state.apply(state.tr.setSelection(sel)) } as unknown as EditorView;
+}
+
+const tagId = newHeadingId();
+const blockId = newHeadingId();
+function sampleDoc(): PMNode {
+  return makeDoc([
+    heading('block', 'AT: Framework', blockId),
+    card(
+      heading('tag', 'Perm solves', tagId),
+      undertag('extend: do both'),
+      citePara('Smith 24', ' - Prof at X, Journal.'),
+      cardBody('Long card body prose that must never leave.'),
+    ),
+    paragraph('a loose paragraph'),
+  ]);
+}
+
+describe('extractSelection', () => {
+  it('collapsed cursor in the card extracts the card as typed items, no body', () => {
+    const doc = sampleDoc();
+    // position inside the tag text: block node = pos 0..block.nodeSize
+    const inTag = doc.nodeSize - doc.child(1).nodeSize - doc.child(2).nodeSize - 2 + 3;
+    const res = extractSelection(fakeView(doc, inTag), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.items.map((i) => i.kind)).toEqual(['tag', 'undertag', 'cite']);
+    expect(res.items[2]!.text).toBe('Smith 24');
+    expect(res.items.some((i) => i.text.includes('never leave'))).toBe(false);
+  });
+  it('attributes undertag and cite to the parent tag heading id', () => {
+    const doc = sampleDoc();
+    const res = extractSelection(fakeView(doc, 3, doc.content.size - 2), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    const byKind = Object.fromEntries(res.items.map((i) => [i.kind, i]));
+    expect(parseSourceToken(byKind['block']!.source)!.headingId).toBe(blockId);
+    expect(parseSourceToken(byKind['tag']!.source)!.headingId).toBe(tagId);
+    expect(parseSourceToken(byKind['undertag']!.source)!.headingId).toBe(tagId);
+    expect(parseSourceToken(byKind['cite']!.source)!.headingId).toBe(tagId);
+    expect(parseSourceToken(byKind['tag']!.source)!.docTitle).toBe('Test.docx');
+  });
+  it('explicit selection wins and skips loose paragraphs', () => {
+    const doc = sampleDoc();
+    const res = extractSelection(fakeView(doc, 1, doc.content.size - 1), IDENT);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.items.map((i) => i.kind)).toEqual(['block', 'tag', 'undertag', 'cite']);
+  });
+  it('cursor above all headings errors instead of guessing', () => {
+    const doc = makeDoc([paragraph('intro'), heading('block', 'B')]);
+    const res = extractSelection(fakeView(doc, 2), IDENT);
+    expect(res).toEqual({ ok: false, error: 'no-heading-at-cursor' });
+  });
+  it('selection with only body content yields empty-selection', () => {
+    const doc = sampleDoc();
+    // select inside the loose trailing paragraph only
+    const paraStart = doc.content.size - doc.child(2).nodeSize;
+    const res = extractSelection(fakeView(doc, paraStart + 1, paraStart + 6), IDENT);
+    expect(res).toEqual({ ok: false, error: 'empty-selection' });
+  });
+});

--- a/tests/editor/plugin-jump.test.ts
+++ b/tests/editor/plugin-jump.test.ts
@@ -165,4 +165,27 @@ describe('installPluginJumpHost', () => {
       docTitle: 'T',
     });
   });
+
+  it('refuses to land inside a transclusion_ref mirror', () => {
+    const mirror = schema.nodes['transclusion_ref']!.create(
+      { source_heading_id: 'src', source_label: 'L' },
+      [heading('block', 'Mirror only quote')],
+    );
+    const transclusionDoc = schema.nodes['doc']!.createChecked(null, [
+      heading('block', 'Real'),
+      mirror,
+    ]);
+    const view = makeView(transclusionDoc);
+    const token = mintSourceToken({
+      docId: 'd1',
+      docTitle: 'T',
+      headingId: newHeadingId(), // absent — force the anchor fallback
+      anchor: { quote: 'Mirror only quote', prefix: '', suffix: '', approxPos: 0 },
+    });
+    expect(jumpToTokenInView(view, 'd1', token)).toEqual({
+      ok: false,
+      error: 'not-found',
+      docTitle: 'T',
+    });
+  });
 });

--- a/tests/editor/plugin-jump.test.ts
+++ b/tests/editor/plugin-jump.test.ts
@@ -3,14 +3,42 @@ import { describe, expect, it } from 'vitest';
 import { EditorState } from 'prosemirror-state';
 import { schema, newHeadingId } from '../../src/schema/index.js';
 import { jumpToTokenInView } from '../../src/editor/plugin-jump.js';
+import { installPluginJumpHost } from '../../src/editor/plugin-jump-host.js';
 import { mintSourceToken } from '../../src/editor/plugin-source-token.js';
+
+/** Minimal stand-in for the preload jump bridge (`window.electronAPI`).
+ *  Captures the single registered handler so a test can fire a request,
+ *  and records every ack the host sends back. */
+function installStubBridge() {
+  let handler: ((req: { requestId: string; source: string }) => void) | null = null;
+  const acks: { requestId: string; ok: boolean; error?: string }[] = [];
+  (window as any).electronAPI = {
+    onExternalJumpRequest(h: (req: { requestId: string; source: string }) => void) {
+      handler = h;
+      return () => {
+        handler = null;
+      };
+    },
+    sendExternalJumpResult(result: { requestId: string; ok: boolean; error?: string }) {
+      acks.push(result);
+    },
+  };
+  return {
+    fire: (source: string) => handler?.({ requestId: 'r1', source }),
+    acks,
+  };
+}
 
 function heading(type: string, text: string, id = newHeadingId()) {
   return schema.nodes[type]!.create({ id }, schema.text(text));
 }
 function makeView(doc: any) {
   let state = EditorState.create({ doc });
+  // Detached DOM so `scrollToHeadingId` runs querySelector (finds nothing,
+  // no `[data-id]` rendered) and select() falls back to tr.scrollIntoView.
+  const dom = document.createElement('div');
   return {
+    dom,
     get state() {
       return state;
     },
@@ -68,5 +96,49 @@ describe('jumpToTokenInView', () => {
   it('reports bad-request for garbage tokens', () => {
     const view = makeView(doc);
     expect(jumpToTokenInView(view, 'd1', 'garbage')).toEqual({ ok: false, error: 'bad-request' });
+  });
+});
+
+describe('installPluginJumpHost', () => {
+  it('acks bad-request for garbage even with no view', () => {
+    const bridge = installStubBridge();
+    installPluginJumpHost({ findViewForDocId: () => null });
+    bridge.fire('garbage');
+    expect(bridge.acks).toEqual([{ requestId: 'r1', ok: false, error: 'bad-request' }]);
+  });
+
+  it('resolves in a non-focused pane view via findViewForDocId', () => {
+    const bridge = installStubBridge();
+    const viewA = makeView(doc); // wrong doc, never returned
+    const viewB = makeView(doc);
+    installPluginJumpHost({
+      findViewForDocId: (docId) => (docId === 'dB' ? viewB : docId === 'dA' ? viewA : null),
+    });
+    const token = mintSourceToken({ docId: 'dB', docTitle: 'B', headingId: id, anchor: null });
+    bridge.fire(token);
+    expect(bridge.acks).toEqual([{ requestId: 'r1', ok: true }]);
+    expect(viewB.state.doc.resolve(viewB.state.selection.from).parent.textContent).toBe(
+      'Target heading',
+    );
+  });
+
+  it('refuses to land inside a self_ref mirror', () => {
+    const mirror = schema.nodes['self_ref']!.create(
+      { source_heading_id: 'src', source_label: 'L' },
+      [heading('block', 'Mirror only quote')],
+    );
+    const selfRefDoc = schema.nodes['doc']!.createChecked(null, [heading('block', 'Real'), mirror]);
+    const view = makeView(selfRefDoc);
+    const token = mintSourceToken({
+      docId: 'd1',
+      docTitle: 'T',
+      headingId: newHeadingId(), // absent — force the anchor fallback
+      anchor: { quote: 'Mirror only quote', prefix: '', suffix: '', approxPos: 0 },
+    });
+    expect(jumpToTokenInView(view, 'd1', token)).toEqual({
+      ok: false,
+      error: 'not-found',
+      docTitle: 'T',
+    });
   });
 });

--- a/tests/editor/plugin-jump.test.ts
+++ b/tests/editor/plugin-jump.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { EditorState } from 'prosemirror-state';
+import { schema, newHeadingId } from '../../src/schema/index.js';
+import { jumpToTokenInView } from '../../src/editor/plugin-jump.js';
+import { mintSourceToken } from '../../src/editor/plugin-source-token.js';
+
+function heading(type: string, text: string, id = newHeadingId()) {
+  return schema.nodes[type]!.create({ id }, schema.text(text));
+}
+function makeView(doc: any) {
+  let state = EditorState.create({ doc });
+  return {
+    get state() {
+      return state;
+    },
+    dispatch(tr: any) {
+      state = state.apply(tr);
+    },
+    focus() {},
+  } as any;
+}
+
+const id = newHeadingId();
+const doc = schema.nodes['doc']!.createChecked(null, [
+  heading('block', 'One'),
+  heading('block', 'Target heading', id),
+]);
+
+describe('jumpToTokenInView', () => {
+  it('jumps to a heading by UUID', () => {
+    const view = makeView(doc);
+    const token = mintSourceToken({ docId: 'd1', docTitle: 'T', headingId: id, anchor: null });
+    expect(jumpToTokenInView(view, 'd1', token)).toEqual({ ok: true });
+    expect(view.state.doc.resolve(view.state.selection.from).parent.textContent).toBe(
+      'Target heading',
+    );
+  });
+  it('falls back to the text anchor when the UUID is gone', () => {
+    const view = makeView(doc);
+    const token = mintSourceToken({
+      docId: 'd1',
+      docTitle: 'T',
+      headingId: newHeadingId(), // not in the doc
+      anchor: { quote: 'Target heading', prefix: '', suffix: '', approxPos: 5 },
+    });
+    expect(jumpToTokenInView(view, 'd1', token)).toEqual({ ok: true });
+  });
+  it("reports not-mine for another doc's token", () => {
+    const view = makeView(doc);
+    const token = mintSourceToken({ docId: 'other', docTitle: 'O', headingId: id, anchor: null });
+    expect(jumpToTokenInView(view, 'd1', token)).toBe('not-mine');
+  });
+  it('reports not-found with the docTitle when nothing resolves', () => {
+    const view = makeView(doc);
+    const token = mintSourceToken({
+      docId: 'd1',
+      docTitle: 'T',
+      headingId: newHeadingId(),
+      anchor: { quote: 'absent text zzz', prefix: '', suffix: '', approxPos: 0 },
+    });
+    expect(jumpToTokenInView(view, 'd1', token)).toEqual({
+      ok: false,
+      error: 'not-found',
+      docTitle: 'T',
+    });
+  });
+  it('reports bad-request for garbage tokens', () => {
+    const view = makeView(doc);
+    expect(jumpToTokenInView(view, 'd1', 'garbage')).toEqual({ ok: false, error: 'bad-request' });
+  });
+});

--- a/tests/editor/plugin-jump.test.ts
+++ b/tests/editor/plugin-jump.test.ts
@@ -122,6 +122,30 @@ describe('installPluginJumpHost', () => {
     );
   });
 
+  it('raises a background stacked doc so the jump lands in a visible view', () => {
+    const bridge = installStubBridge();
+    // Model a slot stack: vA visible, vB stacked-but-hidden. The shell's
+    // findViewForDocId raises the matching record before returning it, so
+    // the host selects in what the user actually sees.
+    const vA = makeView(doc);
+    const vB = makeView(doc);
+    let visible = vA;
+    installPluginJumpHost({
+      findViewForDocId: (docId) => {
+        if (docId !== 'dB') return null;
+        visible = vB; // showRecord equivalent: raise the background record
+        return vB;
+      },
+    });
+    const token = mintSourceToken({ docId: 'dB', docTitle: 'B', headingId: id, anchor: null });
+    bridge.fire(token);
+    expect(bridge.acks).toEqual([{ requestId: 'r1', ok: true }]);
+    expect(visible).toBe(vB); // the hidden doc was raised
+    expect(vB.state.doc.resolve(vB.state.selection.from).parent.textContent).toBe(
+      'Target heading',
+    );
+  });
+
   it('refuses to land inside a self_ref mirror', () => {
     const mirror = schema.nodes['self_ref']!.create(
       { source_heading_id: 'src', source_label: 'L' },

--- a/tests/editor/plugin-registry.test.ts
+++ b/tests/editor/plugin-registry.test.ts
@@ -55,6 +55,13 @@ describe('plugin registry', () => {
     expect(registerPluginDefinition(def()).ok).toBe(true);
     expect(registerPluginDefinition(def()).ok).toBe(false);
   });
+  it('rejects duplicate command ids within one definition', () => {
+    installPluginRegistry(() => stubApi);
+    const d = def();
+    d.commands.push({ ...d.commands[0]! });
+    expect(registerPluginDefinition(d).ok).toBe(false);
+    expect(pluginCommandIds()).toEqual([]);
+  });
   it('runs a command with the per-plugin api and survives a throwing run', () => {
     installPluginRegistry(() => stubApi);
     const run = vi.fn(() => {

--- a/tests/editor/plugin-registry.test.ts
+++ b/tests/editor/plugin-registry.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  installPluginRegistry,
+  registerPluginDefinition,
+  pluginCommandIds,
+  pluginCommandLabel,
+  pluginDefaultKey,
+  runPluginCommand,
+  registeredPlugins,
+  resetPluginRegistryForTests,
+  type PluginDefinition,
+} from '../../src/editor/plugin-registry.js';
+import type { CardMirrorPluginApi } from '../../src/editor/plugin-api.js';
+
+const stubApi = { showToast: () => {} } as unknown as CardMirrorPluginApi;
+
+function def(over: Partial<PluginDefinition> = {}): PluginDefinition {
+  return {
+    id: 'demo',
+    name: 'Demo',
+    apiVersion: 1,
+    commands: [
+      { id: 'demo.hello', label: 'Say Hello', keywords: ['greet'], defaultKey: 'Mod-Alt-h', run: () => {} },
+    ],
+    ...over,
+  };
+}
+
+afterEach(() => resetPluginRegistryForTests());
+
+describe('plugin registry', () => {
+  it('registers via the window global and exposes commands', () => {
+    installPluginRegistry(() => stubApi);
+    window.__registerCardMirrorPlugin!(def());
+    expect(pluginCommandIds()).toEqual(['demo.hello']);
+    expect(pluginCommandLabel('demo.hello')).toBe('Say Hello');
+    expect(pluginDefaultKey('demo.hello')).toBe('Mod-Alt-h');
+    expect(registeredPlugins()).toEqual([{ id: 'demo', name: 'Demo' }]);
+  });
+  it('rejects an unknown apiVersion', () => {
+    installPluginRegistry(() => stubApi);
+    const res = registerPluginDefinition(def({ apiVersion: 2 }));
+    expect(res.ok).toBe(false);
+    expect(pluginCommandIds()).toEqual([]);
+  });
+  it('rejects command ids without the plugin-id prefix', () => {
+    installPluginRegistry(() => stubApi);
+    const bad = def();
+    bad.commands[0]!.id = 'other.hello';
+    expect(registerPluginDefinition(bad).ok).toBe(false);
+  });
+  it('rejects duplicate plugin ids', () => {
+    installPluginRegistry(() => stubApi);
+    expect(registerPluginDefinition(def()).ok).toBe(true);
+    expect(registerPluginDefinition(def()).ok).toBe(false);
+  });
+  it('runs a command with the per-plugin api and survives a throwing run', () => {
+    installPluginRegistry(() => stubApi);
+    const run = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const d = def();
+    d.commands[0]!.run = run;
+    registerPluginDefinition(d);
+    expect(runPluginCommand('demo.hello')).toBe(true);
+    expect(run).toHaveBeenCalledWith(stubApi);
+    expect(runPluginCommand('missing.cmd')).toBe(false);
+  });
+});

--- a/tests/editor/plugin-registry.test.ts
+++ b/tests/editor/plugin-registry.test.ts
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/editor/toast.js', () => ({ showToast: vi.fn() }));
+
+import { showToast } from '../../src/editor/toast.js';
 import {
   installPluginRegistry,
   registerPluginDefinition,
@@ -73,5 +77,40 @@ describe('plugin registry', () => {
     expect(runPluginCommand('demo.hello')).toBe(true);
     expect(run).toHaveBeenCalledWith(stubApi);
     expect(runPluginCommand('missing.cmd')).toBe(false);
+  });
+  it('rejects non-string keywords and defaultKey types', () => {
+    installPluginRegistry(() => stubApi);
+    const k = def();
+    (k.commands[0] as any).keywords = 42;
+    expect(registerPluginDefinition(k).ok).toBe(false);
+    const d = def();
+    (d.commands[0] as any).defaultKey = 42;
+    expect(registerPluginDefinition(d).ok).toBe(false);
+    expect(pluginCommandIds()).toEqual([]);
+  });
+  it('rejects a malformed plugin id and a missing name', () => {
+    installPluginRegistry(() => stubApi);
+    expect(registerPluginDefinition(def({ id: 'a.b' } as any)).ok).toBe(false);
+    expect(registerPluginDefinition(def({ name: '' } as any)).ok).toBe(false);
+  });
+  it('is immune to getter-swapped command arrays', () => {
+    installPluginRegistry(() => stubApi);
+    const clean = [{ id: 'demo.ok', label: 'Ok', run: () => {} }];
+    const dirty = [{ id: 'other.hijack', label: 'Bad', run: () => {} }];
+    let reads = 0;
+    const d: any = { id: 'demo', name: 'Demo', apiVersion: 1 };
+    Object.defineProperty(d, 'commands', { get: () => (reads++ === 0 ? clean : dirty) });
+    registerPluginDefinition(d);
+    expect(pluginCommandIds().includes('other.hijack')).toBe(false);
+  });
+  it('toasts when an async run rejects', async () => {
+    installPluginRegistry(() => stubApi);
+    const d = def();
+    d.commands[0]!.run = () => Promise.reject(new Error('boom'));
+    registerPluginDefinition(d);
+    expect(runPluginCommand('demo.hello')).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(showToast).toHaveBeenCalledWith(expect.stringContaining('Demo'));
   });
 });

--- a/tests/editor/plugin-registry.test.ts
+++ b/tests/editor/plugin-registry.test.ts
@@ -54,10 +54,20 @@ describe('plugin registry', () => {
     bad.commands[0]!.id = 'other.hello';
     expect(registerPluginDefinition(bad).ok).toBe(false);
   });
-  it('rejects duplicate plugin ids', () => {
+  it('re-registering the same definition is a no-op success', () => {
     installPluginRegistry(() => stubApi);
     expect(registerPluginDefinition(def()).ok).toBe(true);
-    expect(registerPluginDefinition(def()).ok).toBe(false);
+    expect(registerPluginDefinition(def()).ok).toBe(true);
+    expect(pluginCommandIds()).toEqual(['demo.hello']);
+    expect(registeredPlugins()).toEqual([{ id: 'demo', name: 'Demo' }]);
+  });
+  it('re-registering with different commands still rejects', () => {
+    installPluginRegistry(() => stubApi);
+    expect(registerPluginDefinition(def()).ok).toBe(true);
+    const d2 = def();
+    d2.commands.push({ id: 'demo.extra', label: 'Extra', run: () => {} });
+    expect(registerPluginDefinition(d2).ok).toBe(false);
+    expect(pluginCommandIds()).toEqual(['demo.hello']);
   });
   it('rejects duplicate command ids within one definition', () => {
     installPluginRegistry(() => stubApi);

--- a/tests/editor/plugin-registry.test.ts
+++ b/tests/editor/plugin-registry.test.ts
@@ -103,6 +103,16 @@ describe('plugin registry', () => {
     registerPluginDefinition(d);
     expect(pluginCommandIds().includes('other.hijack')).toBe(false);
   });
+  it('is immune to a stateful per-field getter swapping id after validation', () => {
+    installPluginRegistry(() => stubApi);
+    let reads = 0;
+    const c: any = { label: 'Ok', run: () => {} };
+    Object.defineProperty(c, 'id', { get: () => (reads++ === 0 ? 'demo.ok' : 'other.hijack') });
+    const d: any = { id: 'demo', name: 'Demo', apiVersion: 1, commands: [c] };
+    registerPluginDefinition(d);
+    expect(pluginCommandIds().includes('other.hijack')).toBe(false);
+    expect(pluginCommandIds().includes('demo.ok')).toBe(true);
+  });
   it('toasts when an async run rejects', async () => {
     installPluginRegistry(() => stubApi);
     const d = def();

--- a/tests/editor/plugin-source-token.test.ts
+++ b/tests/editor/plugin-source-token.test.ts
@@ -36,4 +36,18 @@ describe('source token', () => {
     const bare = 'cmsrc1.' + Buffer.from(JSON.stringify({ docTitle: 'x' })).toString('base64url');
     expect(parseSourceToken(bare)).toBeNull();
   });
+  it('drops a malformed anchor but keeps the rest of the payload', () => {
+    const mint = (anchor: unknown): string =>
+      'cmsrc1.' +
+      Buffer.from(
+        JSON.stringify({ docId: 'doc-123', docTitle: 't', headingId: null, anchor }),
+      ).toString('base64url');
+    const expected = { docId: 'doc-123', docTitle: 't', headingId: null, anchor: null };
+    // Inner fields are validated, not cast: a null quote fails the check.
+    expect(
+      parseSourceToken(mint({ quote: null, prefix: 'a', suffix: 'b', approxPos: 1 })),
+    ).toEqual(expected);
+    // A valid-JSON scalar is not an object at all.
+    expect(parseSourceToken(mint(42))).toEqual(expected);
+  });
 });

--- a/tests/editor/plugin-source-token.test.ts
+++ b/tests/editor/plugin-source-token.test.ts
@@ -1,0 +1,39 @@
+// tests/editor/plugin-source-token.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  mintSourceToken,
+  parseSourceToken,
+  type SourcePayload,
+} from '../../src/editor/plugin-source-token.js';
+
+const payload: SourcePayload = {
+  docId: 'doc-123',
+  docTitle: 'AT Cap K — «weird» título.docx',
+  headingId: 'a1b2c3d4-0000-0000-0000-000000000000',
+  anchor: { quote: 'Perm solves', prefix: 'before ', suffix: ' after', approxPos: 42 },
+};
+
+describe('source token', () => {
+  it('round-trips a payload, unicode included', () => {
+    const token = mintSourceToken(payload);
+    expect(token.startsWith('cmsrc1.')).toBe(true);
+    expect(parseSourceToken(token)).toEqual(payload);
+  });
+  it('round-trips null headingId and null anchor', () => {
+    const p: SourcePayload = { docId: 'd', docTitle: '', headingId: null, anchor: null };
+    expect(parseSourceToken(mintSourceToken(p))).toEqual(p);
+  });
+  it('rejects a wrong prefix', () => {
+    const token = mintSourceToken(payload).replace(/^cmsrc1/, 'cmsrc9');
+    expect(parseSourceToken(token)).toBeNull();
+  });
+  it('rejects garbage and non-strings', () => {
+    expect(parseSourceToken('cmsrc1.!!!not-base64!!!')).toBeNull();
+    expect(parseSourceToken('no-dot-here')).toBeNull();
+    expect(parseSourceToken(undefined as unknown as string)).toBeNull();
+  });
+  it('rejects a payload without docId', () => {
+    const bare = 'cmsrc1.' + Buffer.from(JSON.stringify({ docTitle: 'x' })).toString('base64url');
+    expect(parseSourceToken(bare)).toBeNull();
+  });
+});

--- a/tests/editor/plugin-source-token.test.ts
+++ b/tests/editor/plugin-source-token.test.ts
@@ -63,10 +63,14 @@ describe('source token', () => {
     const mk = (anchor: unknown) =>
       'cmsrc1.' +
       Buffer.from(JSON.stringify({ docId: 'd', docTitle: 't', anchor })).toString('base64url');
-    const bad = parseSourceToken(mk({ quote: 'q', prefix: '', suffix: '', approxPos: NaN }));
-    expect(bad!.anchor).toBeNull();
-    const inf = parseSourceToken(mk({ quote: 'q', prefix: '', suffix: '', approxPos: 1e999 }));
-    expect(inf!.anchor).toBeNull();
+    // Infinity: JSON.stringify would convert to null, so use raw JSON with literal exponent.
+    // JSON.parse('{"x":1e999}').x === Infinity is the real attack vector.
+    const rawInf =
+      'cmsrc1.' +
+      Buffer.from('{"docId":"d","docTitle":"t","anchor":{"quote":"q","prefix":"","suffix":"","approxPos":1e999}}').toString(
+        'base64url',
+      );
+    expect(parseSourceToken(rawInf)!.anchor).toBeNull();
     const junk = parseSourceToken(
       mk({ quote: 'q', prefix: '', suffix: '', approxPos: 2, extra: 'x'.repeat(64) }),
     );

--- a/tests/editor/plugin-source-token.test.ts
+++ b/tests/editor/plugin-source-token.test.ts
@@ -50,4 +50,28 @@ describe('source token', () => {
     // A valid-JSON scalar is not an object at all.
     expect(parseSourceToken(mint(42))).toEqual(expected);
   });
+  it('round-trips astral-plane text', () => {
+    const p: SourcePayload = {
+      docId: 'd',
+      docTitle: 'Fire 🔥 doc',
+      headingId: null,
+      anchor: { quote: '🧊❤️‍🔥 quote', prefix: '𝔭', suffix: '𐐷', approxPos: 1 },
+    };
+    expect(parseSourceToken(mintSourceToken(p))).toEqual(p);
+  });
+  it('rejects a non-finite approxPos and strips unknown anchor fields', () => {
+    const mk = (anchor: unknown) =>
+      'cmsrc1.' +
+      Buffer.from(JSON.stringify({ docId: 'd', docTitle: 't', anchor })).toString('base64url');
+    const bad = parseSourceToken(mk({ quote: 'q', prefix: '', suffix: '', approxPos: NaN }));
+    expect(bad!.anchor).toBeNull();
+    const inf = parseSourceToken(mk({ quote: 'q', prefix: '', suffix: '', approxPos: 1e999 }));
+    expect(inf!.anchor).toBeNull();
+    const junk = parseSourceToken(
+      mk({ quote: 'q', prefix: '', suffix: '', approxPos: 2, extra: 'x'.repeat(64) }),
+    );
+    expect(junk!.anchor).toEqual({ quote: 'q', prefix: '', suffix: '', approxPos: 2 });
+    const missing = parseSourceToken(mk({ quote: 'q', prefix: '', approxPos: 2 }));
+    expect(missing!.anchor).toBeNull();
+  });
 });

--- a/tests/editor/plugins-settings-ui.test.ts
+++ b/tests/editor/plugins-settings-ui.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/editor/toast.js', () => ({ showToast: vi.fn() }));
+vi.mock('../../src/editor/text-prompt.js', () => ({ confirmDialog: vi.fn() }));
+vi.mock('../../src/editor/settings.js', () => ({ settings: { get: () => true } }));
+vi.mock('../../src/editor/host/index.js', () => ({
+  getElectronHost: () => ({
+    pluginList: () => Promise.resolve([{ id: 'demo', name: 'Demo', version: '1.0.0' }]),
+  }),
+}));
+
+import { renderPluginsPanel } from '../../src/editor/plugins-settings-ui.js';
+
+/** Wait out the panel's initial `refresh()` microtask. */
+const settled = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe('plugins settings panel styling', () => {
+  it('dresses its widgets in the shared settings classes', async () => {
+    window.__registerCardMirrorPlugin = (() => ({ ok: true })) as never;
+    const el = document.createElement('div');
+    renderPluginsPanel(el);
+    await settled();
+
+    expect(el.querySelector('.pmd-plugins-input')!.classList).toContain('pmd-settings-text');
+    // Every button in the panel — install, per-plugin actions, dev loader —
+    // uses the settings button style rather than the bare UA control.
+    const buttons = [...el.querySelectorAll('button')];
+    expect(buttons.length).toBeGreaterThan(2);
+    expect(buttons.every((b) => b.classList.contains('pmd-install-info-btn'))).toBe(true);
+    expect(el.querySelector('.pmd-plugins-row input')!.classList).toContain('pmd-settings-toggle');
+    expect(el.querySelectorAll('.pmd-settings-section-title').length).toBe(3);
+  });
+
+  it('renders the gated message as a styled placeholder, not bare text', () => {
+    window.__registerCardMirrorPlugin = undefined;
+    const el = document.createElement('div');
+    renderPluginsPanel(el);
+    expect(el.querySelector('.pmd-settings-empty')!.textContent).toBe(
+      'Restart CardMirror to activate plugins.',
+    );
+  });
+});


### PR DESCRIPTION
Adds plugin support to CardMirror.

Plugins are Github repos which publish a `cardmirror-plugin.json` manifest and a built `plugin.js` file. They can be installed from the settings menu in a new 'plugins' tab, and updated from there.

Commands that plugins register show up in the command ribbon and the keybindings editor.

Plugins get a narrow surface `src/editor/plugin-api.ts`:
- typed extraction of the current selection / heading
- storage
- doc info
- jump to source

Plugins can store a reference token and then ask CardMirror to navigate back to the source in the document.

Apps can announce a local HTTP endpoint in a shared cardmirror-bridge directory, with a per-session token. CardMirror serves `/ping`, `/insert`, and `/jump` (for inverse search).

Full plugin API spec in `reference-docs/cardmirror-plugin-api.md`.