### PR TITLE
Allow faste-paste inserts to apply text roles

### DIFF
--- a/apps/desktop/src/fast-paste-bridge.ts
+++ b/apps/desktop/src/fast-paste-bridge.ts
@@ -145,11 +145,25 @@ function readRequestBody(req: http.IncomingMessage, maxBytes = 4 * 1024 * 1024):
   });
 }
 
-function normalizeRole(value: unknown): 'card' | 'cite' | 'inline' {
-  if (value === 'cite') return 'cite';
-  if (value === 'inline') return 'inline';
+/** Roles the renderer's insert primitive understands
+ *  (`src/editor/external-insert.ts` — keep the two in step). The heading
+ *  levels come from the outline (`src/editor/headings.ts`); a client that
+ *  sends one gets that style applied, so the relay must not flatten them. */
+const INSERT_ROLES = new Set([
+  'pocket',
+  'hat',
+  'block',
+  'tag',
+  'analytic',
+  'body',
+  'card',
+  'cite',
+  'inline',
+]);
+
+function normalizeRole(value: unknown): string {
   // Unknown values degrade to `card` per §10.
-  return 'card';
+  return typeof value === 'string' && INSERT_ROLES.has(value) ? value : 'card';
 }
 
 function focusedRenderTarget(): BrowserWindow | null {

--- a/src/editor/external-insert-host.ts
+++ b/src/editor/external-insert-host.ts
@@ -93,6 +93,7 @@ function handle(req: InsertRequest, opts: ExternalInsertHostOpts): InsertResult 
     }
     const tr = buildExternalInsertTransaction(view.state, {
       text: req.text,
+      role: req.role,
       newParagraph: req.newParagraph,
     });
     if (!tr) {

--- a/src/editor/external-insert.ts
+++ b/src/editor/external-insert.ts
@@ -26,18 +26,85 @@
  *   - `newParagraph: false` — `tr.insertText(text)` at the current
  *     selection. Plain inline characters, no marks, no new block.
  *
+ *   - a HEADING role (`pocket` / `hat` / `block` / `tag` /
+ *     `analytic`) — one heading node per line, snapped to the
+ *     outline slot a drag would drop it at. See below.
+ *
  * No equation-marker handling (§4.4) in v1 — the spec lets v1
  * insert the placeholder as plain body text.
  */
 
-import { Fragment, Slice } from 'prosemirror-model';
+import { Fragment, Slice, type Node as PMNode } from 'prosemirror-model';
 import { type EditorState, type Transaction } from 'prosemirror-state';
+import { newHeadingId } from '../schema/ids.js';
+import { nearestValidInsertPos } from './insert-position.js';
 
-export type ExternalInsertRole = 'card' | 'cite' | 'inline';
+/**
+ * What the sender wants the text to become. `pocket` / `hat` / `block` /
+ * `tag` / `analytic` are the outline's heading levels (`./headings.ts`);
+ * `body` / `card` / `cite` all land as body paragraphs, and `inline` as
+ * bare characters.
+ */
+export type ExternalInsertRole =
+  | 'pocket'
+  | 'hat'
+  | 'block'
+  | 'tag'
+  | 'analytic'
+  | 'body'
+  | 'card'
+  | 'cite'
+  | 'inline';
 
 export interface ExternalInsertOpts {
   text: string;
+  /** Omitted means `card` — body paragraphs, the pre-role behavior. */
+  role?: ExternalInsertRole;
   newParagraph: boolean;
+}
+
+/**
+ * The container a heading level needs around it to be schema-legal at the
+ * doc root. Pocket / hat / block stand alone; `tag` is only ever a card's
+ * first child and `analytic` only ever an analytic_unit's, which is why
+ * sending one of those inserts a whole (single-heading) card or unit.
+ */
+const HEADING_CONTAINER: Record<string, 'card' | 'analytic_unit' | undefined> = {
+  pocket: undefined,
+  hat: undefined,
+  block: undefined,
+  tag: 'card',
+  analytic: 'analytic_unit',
+};
+
+function isHeadingRole(role: ExternalInsertRole): boolean {
+  // hasOwn, not `in`: the role comes off the wire, and `in` would answer
+  // true for every Object.prototype key.
+  return Object.hasOwn(HEADING_CONTAINER, role);
+}
+
+/** One heading node (in its required container) per line, or null when the
+ *  schema doesn't carry the types — same defensive rail as the body path. */
+function buildHeadingNodes(
+  state: EditorState,
+  role: ExternalInsertRole,
+  lines: string[],
+): PMNode[] | null {
+  const headingType = state.schema.nodes[role];
+  if (!headingType) return null;
+  const containerName = HEADING_CONTAINER[role];
+  const containerType = containerName ? state.schema.nodes[containerName] : undefined;
+  if (containerName && !containerType) return null;
+  return lines.map((line) => {
+    // Heading nodes carry a stable id (schema/ids.ts); one built without it
+    // is invisible to the nav pane, so stamp it here rather than relying on
+    // the load-time repair walk.
+    const heading = headingType.create(
+      { id: newHeadingId() },
+      line ? state.schema.text(line) : null,
+    );
+    return containerType ? containerType.create(null, heading) : heading;
+  });
 }
 
 /** Build the insertion transaction for an external `/insert` call.
@@ -49,6 +116,19 @@ export function buildExternalInsertTransaction(
   opts: ExternalInsertOpts,
 ): Transaction | null {
   const { text, newParagraph } = opts;
+  const role = opts.role ?? 'card';
+
+  if (isHeadingRole(role)) {
+    // A heading is never inline, so the role outranks `newParagraph`.
+    const nodes = buildHeadingNodes(state, role, text.split(/\r\n|\r|\n/));
+    if (!nodes) return null;
+    const content = Fragment.fromArray(nodes);
+    // Dropping a doc-level object at a raw caret inside a card makes PM split
+    // the card and leave a phantom blank-tag sibling behind; snap to the
+    // outline slot a drag would use instead (mirrors the receive-pill insert).
+    const at = nearestValidInsertPos(state.doc, state.selection.head, content);
+    return state.tr.insert(at, content);
+  }
 
   if (!newParagraph) {
     // Inline mode: drop the text into the current selection as

--- a/tests/desktop/fast-paste-bridge.test.ts
+++ b/tests/desktop/fast-paste-bridge.test.ts
@@ -242,6 +242,21 @@ describe('fast-paste-bridge', () => {
     await inserted;
   });
 
+  it.each(['pocket', 'hat', 'block', 'tag', 'analytic', 'body'])(
+    'heading role "%s" reaches the renderer unflattened',
+    async (role) => {
+      const ep = bridge.getRunningEndpoint()!;
+      const inserted = fetchJson({
+        method: 'POST', path: '/insert', port: ep.port, token: ep.token,
+        body: { text: 'X', role, newParagraph: true },
+      });
+      await new Promise((r) => setTimeout(r, 20));
+      expect(sentToRenderer[0]!.payload.role).toBe(role);
+      fireRendererAck({ requestId: sentToRenderer[0]!.payload.requestId, ok: true });
+      await inserted;
+    },
+  );
+
   it('no focused window → no-target-doc returned without renderer round-trip', async () => {
     setMockFocusedWindow(null);
     const ep = bridge.getRunningEndpoint()!;

--- a/tests/editor/external-insert.test.ts
+++ b/tests/editor/external-insert.test.ts
@@ -207,6 +207,75 @@ describe('buildExternalInsertTransaction — newParagraph=true (card / cite)', (
   });
 });
 
+describe('buildExternalInsertTransaction — heading roles', () => {
+  // Cursor mid-body of the doc's only card, for every case below.
+  function stateInCard() {
+    const doc = makeDoc([cardWith(tag('TAG'), cardBody('hello world'))]);
+    return makeState(doc).apply(
+      makeState(doc).tr.setSelection(
+        TextSelection.create(doc, findPos(doc, (n) => n.isText && n.text === 'hello world', 6)),
+      ),
+    );
+  }
+
+  function shapeAfter(role: any, text = 'X') {
+    const state = stateInCard();
+    const tr = buildExternalInsertTransaction(state, { text, role, newParagraph: true });
+    expect(tr).not.toBeNull();
+    return shapeOf(state.apply(tr!).doc);
+  }
+
+  it('analytic — lands in its own analytic_unit, leaving the card whole', () => {
+    expect(shapeAfter('analytic')).toEqual([
+      'card[tag("TAG"), card_body("hello world")]',
+      'analytic_unit[analytic("X")]',
+    ]);
+  });
+
+  it('tag — lands as a new card headed by that tag', () => {
+    expect(shapeAfter('tag')).toEqual([
+      'card[tag("TAG"), card_body("hello world")]',
+      'card[tag("X")]',
+    ]);
+  });
+
+  it.each(['pocket', 'hat', 'block'])('%s — lands as a bare doc-level heading', (role) => {
+    expect(shapeAfter(role)).toEqual([
+      'card[tag("TAG"), card_body("hello world")]',
+      `${role}("X")`,
+    ]);
+  });
+
+  it('one heading per line', () => {
+    expect(shapeAfter('analytic', 'first\nsecond')).toEqual([
+      'card[tag("TAG"), card_body("hello world")]',
+      'analytic_unit[analytic("first")]',
+      'analytic_unit[analytic("second")]',
+    ]);
+  });
+
+  it('stamps a heading id — an id-less heading is invisible to the nav pane', () => {
+    const state = stateInCard();
+    const tr = buildExternalInsertTransaction(state, {
+      text: 'X',
+      role: 'block',
+      newParagraph: true,
+    });
+    const ids: unknown[] = [];
+    state.apply(tr!).doc.descendants((n: any) => {
+      if (n.type.name === 'block') ids.push(n.attrs['id']);
+    });
+    expect(ids).toHaveLength(1);
+    expect(typeof ids[0]).toBe('string');
+  });
+
+  it('body / omitted role still build body paragraphs', () => {
+    const expected = ['card[tag("TAG"), card_body("hello "), card_body("Xworld")]'];
+    expect(shapeAfter('body')).toEqual(expected);
+    expect(shapeAfter(undefined)).toEqual(expected);
+  });
+});
+
 describe('buildExternalInsertTransaction — newParagraph=false (inline)', () => {
   it('inserts text at cursor with no block break', () => {
     const doc = makeDoc([


### PR DESCRIPTION
Currently, an /insert call carried a role, but nothing used it. Clients couldn't send text as "Tags" or "Analytics".

The relay now passes the five outline heading levels + body text. The role is optional and defaults to `card`.

The insert primitive builds one heading per line and wraps each one in its schema container: a card for a tag, an analytic_unit for an analytic. Pocket, hat and block stay bare. Each heading gets a fresh id, because the nav pane cannot see a heading without one.

A doc-level object at a raw caret inside a card makes ProseMirror split that card and leave a blank-tag sibling. The heading path asks nearestValidInsertPos for the outline slot a drag would use, the same way the receive pill inserts a card.

Assisted-by: Claude Code:claude-opus-5