### PR TITLE
Add command to reformat all citations in document with AI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -492,9 +492,12 @@ user-facing source of truth. The notable design points:
 **The cleanup family.** A few of Verbatim's cleanup commands are shipped —
 Convert Analytics to Tags, Convert Cited Analytics to Tags, Fix
 Formatting Gaps, Remove Hyperlinks, and Select Similar Formatting. The
-rest (AutoNumberTags, DeNumberTags, ReformatAllCites, FixFakeTags,
-ConvertToDefaultStyles, …) map cleanly to schema transforms but aren't
-planned right now.
+rest (AutoNumberTags, DeNumberTags, FixFakeTags, ConvertToDefaultStyles,
+…) map cleanly to schema transforms but aren't planned right now.
+ReformatAllCites is covered instead by `reformatAllCites` (§14, AI):
+reformatting a citation needs judgment, not a pattern rewrite, so it
+drives the AI cite creator over every `cite_paragraph` rather than
+being a schema transform.
 
 ## 14. Images and AI
 
@@ -511,6 +514,18 @@ surface. Shipped:
 
 - **`aiCreateCite` (Mod-Shift-X)** formats a selection into a
   Verbatim-style citation with `cite_mark` on the extracted tokens.
+- **`reformatAllCites`** (unbound) drives `aiCreateCite`'s prompt, parser
+  and transaction builder over every `cite_paragraph` in the document —
+  one request and one undo step per cite, behind a request-count confirm
+  (`reformat-all-cites.ts`). It holds ONE lease at a time, not one per
+  cite: a whole-doc lease would lock out typing for the entire run, and N
+  live leases would make every keystroke run N region diffs in
+  `coordinatorBlocks`. Positions are never cached either — it walks a
+  document cursor and re-scans the live doc for the next cite each
+  iteration, which survives the rewritten cite's length change, user
+  edits elsewhere, and a cite the classifier demotes to `card_body` when
+  no token could be marked (any of which would invalidate a precomputed
+  position list or an ordinal index).
 - **`aiAskAboutSelection` (Mod-Shift-Q)** starts an AI comment thread
   with the surrounding card as context; `@AI` in a thread re-invokes it.
 - **`aiGenerateAltText`** and **`aiGenerateTable`** (right-click an image)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ changes in each release, written for users of the editor. For
 in-depth rationale and implementation context behind each entry,
 see `DETAILED_CHANGELOG.md`.
 
+## 0.1.0-beta.28 — Unreleased
+
+### Added
+
+- **Reformat every cite in a document with AI.** The AI cite formatter
+  (Mod-Shift-X) now has a whole-document version: **Reformat Every Cite
+  in Document (AI)**, found in Search Everything (try "reformat all
+  cites") and rebindable under Settings → Keyboard. It rewrites every
+  cite in the open document through the same formatter, one at a time.
+  Because that's one AI request per cite, it asks first and tells you
+  exactly how many requests it will make. You can keep working
+  elsewhere in the document while it runs, each cite is its own undo
+  step, **Esc** stops the pass, and a summary at the end reports what
+  was reformatted and what needs a look.
+
 ## 0.1.0-beta.27 — 2026-07-30
 
 ### Added
@@ -30,7 +45,6 @@ see `DETAILED_CHANGELOG.md`.
   searching inside a dived-into file, right-clicking a result clears
   the query and reveals that hit in the file's outline — ancestors
   expanded, the row selected and pinned to the top of the list.
-
 - **`cardmirror-read`: a tiny companion tool for reading files without
   the app.** A single-file command-line utility (in
   `packaging/cardmirror-read/`, one `curl` to get) that turns a

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -5,6 +5,54 @@ behavior, rationale, and (where useful) the implementation context
 behind a change. For a shorter, jargon-free summary of what's new
 in each release, see `CHANGELOG.md`.
 
+## 0.1.0-beta.28 — Unreleased
+
+- **Reformat Every Cite in Document (AI)** (new
+  `src/editor/ai/reformat-all-cites.ts`; ribbon `reformatAllCites`,
+  unbound by default, in the AI group; wired in `index.ts` /
+  `ribbon-groups.ts`). Runs the existing `aiCreateCite` pipeline — same
+  prompt, `parseCiteResponse`, `buildCiteTransaction` — over every
+  `cite_paragraph` in the open document, one at a time. Nothing about
+  per-cite behavior is re-implemented; this is the driver. Design points,
+  all forced by "one model request per cite, on a doc that can hold
+  hundreds":
+  - **Confirm first.** A short dialog states the exact request count
+    ("2 cites … that is 2 model requests"), that each cite is its own
+    undo step, and that Esc stops the pass. Declining touches nothing.
+  - **One lease at a time, not one per cite.** A whole-document lease
+    would block the user from typing for the entire run; N live leases
+    would make every keystroke run N `leaseTouched` region diffs in
+    `coordinatorBlocks`. The pass claims and releases per cite, so the
+    rest of the doc stays editable and a cite another AI op already
+    holds is skipped (counted, not failed).
+  - **No cached positions.** The pass walks a document cursor and asks
+    the LIVE doc for the next `cite_paragraph` each iteration. A
+    precomputed position list or an ordinal index breaks on three real
+    cases: the rewritten cite changing length, a user edit elsewhere
+    during the run, and a rewrite the cite classifier DEMOTES to
+    `card_body` because no token could be located (cite-ness is the
+    mark). All three are covered by tests.
+  - **One transaction per cite**, so partial progress survives a failure
+    and a bad cite undoes on its own. A single failed cite doesn't abort
+    the pass; an `auth`/`model` `LlmError` does (it would otherwise
+    repeat identically for every remaining cite).
+  - **Progress and stop.** The activity pill narrates "Cite N of M · Esc
+    to stop"; Escape sets a cancel flag checked between cites (the
+    request in flight still lands) and stands down while a modal is open
+    so it can't swallow a dialog's Escape. One end-of-run summary toast
+    tallies reformatted / failed / skipped / left-unstyled — the
+    per-cite unstyled toast from `applyCiteToSelection` would be a toast
+    storm across a document, so the pass calls `buildCiteTransaction`
+    directly and reads `CITE_TOKENS_MARKED_META` itself.
+  Smoke-tested in the browser against a stubbed provider: the palette
+  finds it by "reformat all cites", the confirm text pluralizes
+  correctly (1 cite / 2 cites), both cites were rewritten in place with
+  `cite_mark` intact, undo stepped back one cite at a time, and Escape
+  mid-flight stopped after one request with "Reformatted 1 of 2 cites ·
+  stopped." Docs: MANUAL.md §13 AI table + the Verbatim-users note (the
+  "ReformatAllCites isn't in CardMirror" claim was stale),
+  ARCHITECTURE.md §13/§14, PROJECT.md status.
+
 ## 0.1.0-beta.27 — 2026-07-30
 
 - **File-index service (utilityProcess) + off-thread warm parsing.** The

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -631,8 +631,10 @@ for pulling a key phrase up into an undertag. A Settings → Editing toggle,
 **"Extract Undertag: wrap in quotes"** (off by default), controls whether
 the excerpt is quoted.
 
-Verbatim's other bulk cleanup macros (AutoNumberTags, ReformatAllCites,
+Verbatim's other bulk cleanup macros (AutoNumberTags,
 ConvertToDefaultStyles, and the rest) aren't in CardMirror.
+ReformatAllCites has an AI counterpart — see **Reformat Every Cite**
+under [AI features](#13-ai-features).
 
 ### Repair paragraph integrity
 
@@ -1500,6 +1502,7 @@ control is hidden, and AI features gray out cleanly when you're offline.
 | Feature | How to run it | What it does |
 |---------|---------------|--------------|
 | **Format Cite** | Mod-Shift-X on a selection | Turns a pasted citation or URL into a properly styled cite, with the cite mark on the author and date. |
+| **Reformat Every Cite** | Search Everything → "reformat all cites" (unbound; assign a key in Settings → Keyboard) | Runs **Format Cite** over every cite in the open document, one at a time. Because that is one model request per cite, a confirmation first tells you how many requests it will make. Each cite is its own undo step, **Esc** stops the pass after the cite in flight, and a summary reports how many were reformatted, failed, or were left unstyled. |
 | **Repair Text** | Mod-Shift-R on a selection | Fixes OCR / PDF extraction errors (dropped ligatures, `rn`/`m`, mid-word hyphenation, run-together words) without changing the wording. Corrections apply in place, one at a time with a highlight; the whole repair is a single undo. |
 | **Repair Formatting** | Mod-Alt-R on a selection | Normalizes an imported card's formatting to Verbatim's four-layer scheme (underline / emphasis / highlighting / background color) — fixing bold or italics standing in for emphasis, direct underlining, bold-underline, and underlining lost to an unsupported style. It never changes your text. |
 | **Translate** | Mod-Shift-T on a selection | Translates the selection and copies it to the clipboard, leaving your document unchanged. Uses your AI provider when AI is on; otherwise falls back to a free, keyless backend, so it works even with AI off. |
@@ -2590,10 +2593,15 @@ revision metadata.
 ### Notes for Verbatim users
 
 - Several of Verbatim's bulk cleanup macros — AutoNumberTags,
-  DeNumberTags, ReformatAllCites, FixFakeTags, ConvertToDefaultStyles, and
-  similar — aren't in CardMirror, and aren't currently planned. The
-  cleanup commands that are here: Convert Analytics to Tags, Fix
-  Formatting Gaps, Remove Hyperlinks, and Select Similar Formatting.
+  DeNumberTags, FixFakeTags, ConvertToDefaultStyles, and similar —
+  aren't in CardMirror, and aren't currently planned. The cleanup
+  commands that are here: Convert Analytics to Tags, Fix Formatting
+  Gaps, Remove Hyperlinks, and Select Similar Formatting.
+- ReformatAllCites has an AI-driven counterpart: **Reformat Every Cite**
+  rewrites every cite in the document through the AI cite formatter
+  (see [AI features](#13-ai-features)). It reads the citation and
+  reformats it, rather than pattern-matching the old text the way the
+  Verbatim macro does.
 - **OCR**, **caselist** upload, **Tabroom** integration, and **vTub**
   don't exist in CardMirror yet.
 - CardMirror is pageless (like Word's Web Layout); it round-trips page

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -51,7 +51,8 @@ the F-key formatting commands · cards, analytics, tables, and images ·
 read mode · send-to-speech · drag-and-drop reordering · the three-slot
 multi-doc workspace · command-palette file search and find/replace ·
 spaced-repetition flashcards · AI cite/alt-text/table/comment features
-(comments, notes, and ask-AI work on images too) · AI OCR/PDF text repair
+(comments, notes, and ask-AI work on images too; cite formatting also
+runs whole-document behind a confirm) · AI OCR/PDF text repair
 (diff-based, animated, single undo) · selection translation
 (MyMemory keyless / Anthropic / Google, AI-optional) · editor spellcheck ·
 autosave and crash recovery · desktop auto-update · encrypted card sharing ·
@@ -61,9 +62,10 @@ views + editable linked copies) · display-only card numbering.
 **Planned** (rationale in `ARCHITECTURE.md`): Verbatim Flow integration ·
 numbered/bulleted lists · per-type display-spacing ·
 fuller screen-reader support and accessibility presets. The
-remaining Verbatim cleanup macros (AutoNumberTags, ReformatAllCites,
+remaining Verbatim cleanup macros (AutoNumberTags,
 ConvertToDefaultStyles, …) aren't planned, though several cleanup
-commands already ship.
+commands already ship — and ReformatAllCites has an AI counterpart in
+**Reformat Every Cite**.
 
 **Out of scope:** section/page layout, footnotes, revision-ID metadata,
 non-heading bookmarks, localization. The importer drops these; the

--- a/src/editor/ai/reformat-all-cites.ts
+++ b/src/editor/ai/reformat-all-cites.ts
@@ -197,9 +197,15 @@ async function reformatAllCites(
     activity?.setStage('Stopping after this cite…');
   });
   let cursor = 0;
+  // Ordinal for the progress readout. Bumped only for paragraphs the
+  // pass actually takes on, so it stays in step with `total`, which
+  // counts non-empty cites only. A blank `cite_paragraph` sitting ahead
+  // of real ones must not burn a number, or the readout reads "Cite 3
+  // of 2".
+  let n = 0;
 
   try {
-    for (let n = 1; !s.cancelled; n++) {
+    while (!s.cancelled) {
       const target = nextCiteParagraph(view.state.doc, cursor);
       if (!target) break;
       // Advance past this paragraph BEFORE any await: a `continue` from
@@ -207,6 +213,7 @@ async function reformatAllCites(
       // the rewrite lands.
       cursor = target.to;
       if (!target.text) continue;
+      n++;
 
       const lease = claimRegion(view, { from: target.from, to: target.to }, { label: 'cite' });
       if (!lease) {

--- a/src/editor/ai/reformat-all-cites.ts
+++ b/src/editor/ai/reformat-all-cites.ts
@@ -1,0 +1,272 @@
+/**
+ * Reformat Every Cite (AI) — the whole-document sweep built on top of
+ * the single-selection cite creator (`cite-creator.ts`).
+ *
+ * Every `cite_paragraph` in the doc is fed to the same prompt, the same
+ * parser and the same transaction builder the `aiCreateCite` command
+ * uses, one paragraph at a time. Nothing about the per-cite behaviour is
+ * re-implemented here; this module is the *driver*:
+ *
+ *   - **Confirm first.** One model request per cite means real money and
+ *     real minutes, so the pass never starts without an explicit OK that
+ *     states the request count.
+ *   - **Sequential, one lease at a time.** A lease per in-flight cite
+ *     (never all of them at once): a whole-doc lease would lock the user
+ *     out of typing for the entire run, and holding N leases would make
+ *     every keystroke run N region-diffs in `coordinatorBlocks`.
+ *   - **Re-scan between cites instead of caching positions.** The pass
+ *     walks forward with a document cursor and asks the *live* doc for
+ *     the next cite each iteration. That survives user edits elsewhere,
+ *     the length change of the cite we just rewrote, and the case where
+ *     a rewritten paragraph loses its `cite_mark` and gets demoted out
+ *     of `cite_paragraph` by the classifier — all of which would
+ *     invalidate a precomputed position list or an ordinal index.
+ *   - **One transaction per cite.** Partial progress survives a failure
+ *     mid-pass, and a bad cite can be undone on its own. The flip side
+ *     (N undo steps) is called out in the confirm text.
+ *   - **Escape stops it.** The pass checks a cancel flag between cites;
+ *     the request already in flight still lands.
+ */
+
+import type { EditorView } from 'prosemirror-view';
+import type { Node as PMNode } from 'prosemirror-model';
+import { settings } from '../settings.js';
+import { callLlm, LlmError, activeApiKey } from './llm.js';
+import { AiActivity } from './ai-activity.js';
+import { claimRegion } from './edit-coordinator.js';
+import { showConfirm } from '../confirm-dialog.js';
+import { isAnyOverlayOpen } from '../overlay-stack.js';
+import { showToast } from '../toast.js';
+import {
+  DEFAULT_AI_CITE_PROMPT,
+  CITE_TOKENS_MARKED_META,
+  buildCiteTransaction,
+  parseCiteResponse,
+  resolveCitePrompt,
+} from './cite-creator.js';
+
+/** One cite paragraph to reformat. `from`/`to` bound its INLINE content
+ *  (not the node), so the range handed to the cite builder is exactly
+ *  what a user selection over the paragraph's text would be — no
+ *  adjacent content, hence no own-paragraph split on apply. */
+export interface CiteTarget {
+  /** Position of the `cite_paragraph` node itself. */
+  pos: number;
+  from: number;
+  to: number;
+  /** The paragraph's text, trimmed. Empty for a blank cite line. */
+  text: string;
+}
+
+function targetFor(node: PMNode, pos: number): CiteTarget {
+  return {
+    pos,
+    from: pos + 1,
+    to: pos + node.nodeSize - 1,
+    text: node.textContent.trim(),
+  };
+}
+
+/** Every non-empty `cite_paragraph` in the doc, in document order. Used
+ *  for the up-front count in the confirm prompt; the pass itself
+ *  re-scans as it goes (see `nextCiteParagraph`). */
+export function collectCiteParagraphs(doc: PMNode): CiteTarget[] {
+  const out: CiteTarget[] = [];
+  doc.descendants((node, pos) => {
+    if (node.type.name !== 'cite_paragraph') return true;
+    const t = targetFor(node, pos);
+    if (t.text) out.push(t);
+    // Cite paragraphs are textblocks — nothing inside to visit.
+    return false;
+  });
+  return out;
+}
+
+/** The first `cite_paragraph` at or after `cursor`, read from the LIVE
+ *  doc. The pass advances `cursor` past each paragraph it handles, and a
+ *  handled paragraph always starts strictly before the new cursor, so
+ *  this never returns the same paragraph twice — including when the
+ *  rewritten cite is longer or shorter than the original. */
+export function nextCiteParagraph(doc: PMNode, cursor: number): CiteTarget | null {
+  let found: CiteTarget | null = null;
+  doc.descendants((node, pos) => {
+    if (found) return false;
+    if (node.type.name !== 'cite_paragraph') return true;
+    if (pos >= cursor) found = targetFor(node, pos);
+    return false;
+  });
+  return found;
+}
+
+/** Outcome tallies, so the summary toast can be honest about what
+ *  happened across a long run. Exported for the tests. */
+export interface ReformatAllCitesSummary {
+  /** Cites rewritten in the doc. */
+  done: number;
+  /** Cites whose request or apply failed (each logged to the console). */
+  failed: number;
+  /** Cites skipped because another AI edit held the range. */
+  skipped: number;
+  /** Rewritten cites whose author/date token found no home, so the
+   *  paragraph carries no `cite_mark` and reads as body text. */
+  unstyled: number;
+  /** Whether the user stopped the pass with Escape. */
+  cancelled: boolean;
+}
+
+function summaryMessage(s: ReformatAllCitesSummary, total: number): string {
+  const parts = [`Reformatted ${s.done} of ${total} cite${total === 1 ? '' : 's'}`];
+  if (s.failed) parts.push(`${s.failed} failed`);
+  if (s.skipped) parts.push(`${s.skipped} skipped (busy)`);
+  if (s.unstyled) parts.push(`${s.unstyled} left unstyled — F8 the author/date`);
+  if (s.cancelled) parts.push('stopped');
+  return parts.join(' · ') + '.';
+}
+
+/** Escape-to-stop, installed only while a pass runs. Stands down while a
+ *  modal is open so it can't swallow a dialog's own Escape. */
+function installCancelKey(onCancel: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  const onKey = (e: KeyboardEvent): void => {
+    if (e.key !== 'Escape' || isAnyOverlayOpen()) return;
+    e.preventDefault();
+    e.stopPropagation();
+    onCancel();
+  };
+  window.addEventListener('keydown', onKey, true);
+  return () => window.removeEventListener('keydown', onKey, true);
+}
+
+// --------------------------- command ----------------------------
+
+/** Entry point — fires on the `reformatAllCites` ribbon command. The
+ *  returned promise settles when the whole pass is done (the ribbon hook
+ *  voids it; the tests await it). */
+export async function runReformatAllCites(view: EditorView): Promise<void> {
+  if (!settings.get('aiFeaturesEnabled')) {
+    showToast('AI features are disabled — enable them in Settings.');
+    return;
+  }
+  const apiKey = activeApiKey();
+  if (!apiKey) {
+    showToast('Set an API key in Settings to use AI features.');
+    return;
+  }
+  const total = collectCiteParagraphs(view.state.doc).length;
+  if (total === 0) {
+    showToast('No cites in this document.');
+    return;
+  }
+
+  const systemPrompt = resolveCitePrompt(
+    settings.get('aiCitePrompt').trim() || DEFAULT_AI_CITE_PROMPT,
+  );
+
+  const ok = await showConfirm({
+    title: 'Reformat every cite with AI?',
+    message:
+      `${total} cite${total === 1 ? '' : 's'} in this document will be sent to the AI ` +
+      `one at a time and rewritten in place.\n\n` +
+      `That is ${total} model request${total === 1 ? '' : 's'}, so it costs ${total} ` +
+      `call${total === 1 ? '' : 's'} against your API key and can take a while. ` +
+      `Each cite is its own undo step, and Escape stops the pass.`,
+    confirmLabel: `Reformat ${total} cite${total === 1 ? '' : 's'}`,
+    cancelLabel: 'Cancel',
+  });
+  if (!ok) return;
+  await reformatAllCites(view, apiKey, systemPrompt, total);
+}
+
+async function reformatAllCites(
+  view: EditorView,
+  apiKey: string,
+  systemPrompt: string,
+  total: number,
+): Promise<void> {
+  const s: ReformatAllCitesSummary = {
+    done: 0,
+    failed: 0,
+    skipped: 0,
+    unstyled: 0,
+    cancelled: false,
+  };
+  let activity: AiActivity | null = null;
+  const removeCancelKey = installCancelKey(() => {
+    if (s.cancelled) return;
+    s.cancelled = true;
+    activity?.setStage('Stopping after this cite…');
+  });
+  let cursor = 0;
+
+  try {
+    for (let n = 1; !s.cancelled; n++) {
+      const target = nextCiteParagraph(view.state.doc, cursor);
+      if (!target) break;
+      // Advance past this paragraph BEFORE any await: a `continue` from
+      // here must not re-find it. Corrected to the post-edit end once
+      // the rewrite lands.
+      cursor = target.to;
+      if (!target.text) continue;
+
+      const lease = claimRegion(view, { from: target.from, to: target.to }, { label: 'cite' });
+      if (!lease) {
+        s.skipped++;
+        continue;
+      }
+      try {
+        const range = { from: target.from, to: target.to };
+        if (activity) activity.setRange(range);
+        else {
+          activity = new AiActivity(view, range, 'selection');
+          activity.start();
+        }
+        activity.setStage(`Cite ${n} of ${total} · Esc to stop`);
+
+        const reply = await callLlm({
+          apiKey,
+          system: systemPrompt,
+          messages: [{ role: 'user', content: target.text }],
+        });
+        const parsed = parseCiteResponse(reply.text);
+        // Apply at the lease's CURRENT bounds — user edits elsewhere in
+        // the doc during the request have shifted them.
+        const region = lease.region();
+        if (!region) {
+          console.warn(`[cite-all] cite ${n}: range no longer in the document`);
+          s.failed++;
+          continue;
+        }
+        // `buildCiteTransaction` rather than `applyCiteToSelection`: the
+        // latter toasts per unstyled cite, which across a whole document
+        // is a toast storm. Tally instead and report once at the end.
+        const tr = buildCiteTransaction(view.state, region.from, region.to, parsed);
+        if (!tr) {
+          s.failed++;
+          continue;
+        }
+        lease.apply(tr);
+        if (parsed.tokens.length > 0 && tr.getMeta(CITE_TOKENS_MARKED_META) === 0) s.unstyled++;
+        s.done++;
+        const after = lease.region();
+        if (after) cursor = after.to;
+      } catch (e) {
+        const msg = e instanceof LlmError ? e.message : e instanceof Error ? e.message : String(e);
+        console.warn(`[cite-all] cite ${n} failed: ${msg}`);
+        s.failed++;
+        // Auth / model / config failures repeat on every remaining cite;
+        // stop rather than burning the whole document down on them.
+        if (e instanceof LlmError && (e.kind === 'auth' || e.kind === 'model')) {
+          showToast(`Reformat cites: ${msg}`);
+          break;
+        }
+      } finally {
+        lease.release();
+      }
+    }
+  } finally {
+    removeCancelKey();
+    activity?.stop();
+  }
+
+  showToast(summaryMessage(s, total), { durationMs: 5000 });
+}

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -146,6 +146,7 @@ import { commentsPlugin, commentsKey, loadThreads, getCommentsState, gcOrphanThr
 import { scheduleIdle, cancelIdle, type IdleHandle } from './idle-scheduler.js';
 import { CommentsColumn, addCommentToSelection, FC_PREFIX, AI_PREFIX, NOTE_PREFIX } from './comments-ui.js';
 import { runAiCreateCite } from './ai/cite-creator.js';
+import { runReformatAllCites } from './ai/reformat-all-cites.js';
 import { runTranslate } from './translate.js';
 import { runRepairText } from './ai/repair-text.js';
 import { runRepairFormatting } from './ai/repair-formatting.js';
@@ -1595,6 +1596,10 @@ const ribbonContext: RibbonContext = {
   aiCreateCite: () => {
     if (!view) return;
     runAiCreateCite(view);
+  },
+  reformatAllCites: () => {
+    if (!view) return;
+    void runReformatAllCites(view);
   },
   translate: () => {
     if (!view) return;

--- a/src/editor/ribbon-commands.ts
+++ b/src/editor/ribbon-commands.ts
@@ -4265,6 +4265,7 @@ export type RibbonCommandId =
   | 'addNoteToSelection'
   | 'aiAskAboutSelection'
   | 'aiCreateCite'
+  | 'reformatAllCites'
   | 'translate'
   | 'repairText'
   | 'repairFormatting'
@@ -4483,6 +4484,7 @@ export const RIBBON_COMMAND_IDS: RibbonCommandId[] = [
   'addNoteToSelection',
   'aiAskAboutSelection',
   'aiCreateCite',
+  'reformatAllCites',
   'translate',
   'repairText',
   'repairFormatting',
@@ -4657,6 +4659,7 @@ export const RIBBON_COMMAND_LABELS: Record<RibbonCommandId, string> = {
   addNoteToSelection: 'Add Note to Selection',
   aiAskAboutSelection: 'Ask AI About Selection',
   aiCreateCite: 'Format Cite From Selection (AI)',
+  reformatAllCites: 'Reformat Every Cite in Document (AI)',
   translate: 'Translate Selection to Clipboard (AI)',
   repairText: 'Repair OCR/PDF Text (AI)',
   repairFormatting: 'Repair Formatting (AI)',
@@ -4818,6 +4821,7 @@ export const RIBBON_COMMAND_ALIASES: Partial<Record<RibbonCommandId, readonly st
   regrow: ['unshrink', 'regrow', 'restore text size', 'unshrink card text'],
   smartShrink: ['smart shrink', 'deep shrink'],
   aiAskAboutSelection: ['question'],
+  reformatAllCites: ['reformat all cites', 'reformat cites', 'all cites', 'every cite', 'bulk cite'],
   pasteAsText: ['paste without formatting', 'paste unformatted', 'paste text'],
   pasteCondensed: ['paste condense', 'paste merge', 'paste flatten', 'paste no paragraphs', 'destructive paste'],
   removeHyperlinks: ['remove links', 'unlink'], // "delete …" via the delete/remove synonym group
@@ -4977,6 +4981,10 @@ export const DEFAULT_RIBBON_KEYS: Record<RibbonCommandId, string | string[]> = {
   addNoteToSelection: 'Mod-Shift-n',
   aiAskAboutSelection: 'Mod-Shift-q',
   aiCreateCite: 'Mod-Shift-x',
+  // Deliberately unbound: one model request per cite in the document is
+  // far too expensive to sit behind a stray chord. Bind it in Settings →
+  // Keyboard shortcuts if you want one.
+  reformatAllCites: '',
   translate: 'Mod-Shift-t',
   repairText: 'Mod-Shift-r',
   repairFormatting: 'Mod-Alt-r',
@@ -5206,6 +5214,9 @@ export interface RibbonContext {
   addNoteToSelection: () => void;
   aiAskAboutSelection: () => void;
   aiCreateCite: () => void;
+  /** Confirm, then run the cite creator over every cite paragraph in the
+   *  document — one model request each. */
+  reformatAllCites: () => void;
   /** Translate the selection and copy the result to the clipboard. */
   translate: () => void;
   /** Repair OCR / PDF text errors in the selection in place. */
@@ -5379,6 +5390,7 @@ const DEFAULT_RIBBON_CONTEXT: RibbonContext = {
   addNoteToSelection: () => {},
   aiAskAboutSelection: () => {},
   aiCreateCite: () => {},
+  reformatAllCites: () => {},
   translate: () => {},
   repairText: () => {},
   repairFormatting: () => {},
@@ -5643,6 +5655,14 @@ function commandFor(id: RibbonCommandId, ctx: RibbonContext): Command {
         if (state.selection.empty) return false;
         if (!dispatch) return true;
         ctx.aiCreateCite();
+        return true;
+      };
+    case 'reformatAllCites':
+      // Whole-document scope — no selection needed, and the run itself
+      // reports when the doc has no cites to reformat.
+      return (_state, dispatch) => {
+        if (!dispatch) return true;
+        ctx.reformatAllCites();
         return true;
       };
     case 'translate':

--- a/src/editor/ribbon-groups.ts
+++ b/src/editor/ribbon-groups.ts
@@ -228,7 +228,14 @@ export const RIBBON_GROUPS: RibbonGroup[] = [
   },
   {
     title: 'AI',
-    commands: ['aiAskAboutSelection', 'aiCreateCite', 'translate', 'repairText', 'repairFormatting'],
+    commands: [
+      'aiAskAboutSelection',
+      'aiCreateCite',
+      'reformatAllCites',
+      'translate',
+      'repairText',
+      'repairFormatting',
+    ],
   },
   {
     title: 'Flow',

--- a/tests/editor/reformat-all-cites.test.ts
+++ b/tests/editor/reformat-all-cites.test.ts
@@ -23,6 +23,7 @@ import { schema, newHeadingId } from '../../src/schema/index.js';
 import { settings } from '../../src/editor/settings.js';
 import { editCoordinatorPlugin, claimRegion } from '../../src/editor/ai/edit-coordinator.js';
 import { citeClassifierPlugin } from '../../src/editor/cite-classifier-plugin.js';
+import { AiActivity } from '../../src/editor/ai/ai-activity.js';
 import { LlmError, type LlmRequest, type LlmReply } from '../../src/editor/ai/llm.js';
 import type { ConfirmOptions } from '../../src/editor/confirm-dialog.js';
 import type { ToastOptions } from '../../src/editor/toast.js';
@@ -296,6 +297,32 @@ describe('runReformatAllCites', () => {
     expect(view.state.doc.child(0).child(1).textContent).toBe('Rewritten, no locatable token.');
     expect(citeTexts(view.state.doc)).toEqual(['Jones 23, NEW B.', 'Lee 22, NEW C.']);
     expect(summary()).toContain('1 left unstyled');
+  });
+
+  it('numbers the progress readout over sent cites, not loop turns', async () => {
+    // A blank `cite_paragraph` is skipped without a request, but it is
+    // also absent from `total` (collectCiteParagraphs drops it). If the
+    // ordinal counted loop turns, every cite after the blank one would
+    // read past the total — "Cite 3 of 2".
+    const view = fakeView(
+      doc(
+        card(tag('A'), schema.nodes['cite_paragraph']!.create(), cite('Smith 24', ', a')),
+        card(tag('B'), cite('Jones 23', ', b')),
+      ),
+    );
+    callLlm.mockImplementation(
+      replyPerLastname({ Smith: 'Smith 24, NEW A.', Jones: 'Jones 23, NEW B.' }),
+    );
+    const setStage = vi.spyOn(AiActivity.prototype, 'setStage');
+
+    await runReformatAllCites(view);
+
+    const progress = setStage.mock.calls
+      .map(([s]) => s)
+      .filter((s): s is string => typeof s === 'string' && s.startsWith('Cite '));
+    setStage.mockRestore();
+    expect(progress).toEqual(['Cite 1 of 2 · Esc to stop', 'Cite 2 of 2 · Esc to stop']);
+    expect(sentTexts()).toEqual(['Smith 24, a', 'Jones 23, b']);
   });
 
   it('skips a cite another AI edit already holds, and still does the rest', async () => {

--- a/tests/editor/reformat-all-cites.test.ts
+++ b/tests/editor/reformat-all-cites.test.ts
@@ -1,0 +1,348 @@
+// @vitest-environment jsdom
+/**
+ * Reformat Every Cite (AI) — the whole-document sweep over the cite
+ * creator.
+ *
+ * The load-bearing invariant is the cursor walk: the pass re-scans the
+ * LIVE doc for the next `cite_paragraph` each iteration instead of
+ * caching positions, because a rewritten cite changes length and can
+ * even stop being a `cite_paragraph` (the classifier demotes a cite
+ * whose author/date token found no home). Both cases would break a
+ * precomputed position list or an ordinal index, and both are covered
+ * here — every cite is visited exactly once, none twice, none skipped.
+ *
+ * `runReformatAllCites` returns the pass promise, so every assertion
+ * below awaits the real completion instead of a timer.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EditorState } from 'prosemirror-state';
+import type { Node as PMNode } from 'prosemirror-model';
+import type { EditorView } from 'prosemirror-view';
+import { schema, newHeadingId } from '../../src/schema/index.js';
+import { settings } from '../../src/editor/settings.js';
+import { editCoordinatorPlugin, claimRegion } from '../../src/editor/ai/edit-coordinator.js';
+import { citeClassifierPlugin } from '../../src/editor/cite-classifier-plugin.js';
+import { LlmError, type LlmRequest, type LlmReply } from '../../src/editor/ai/llm.js';
+import type { ConfirmOptions } from '../../src/editor/confirm-dialog.js';
+import type { ToastOptions } from '../../src/editor/toast.js';
+import {
+  collectCiteParagraphs,
+  nextCiteParagraph,
+  runReformatAllCites,
+} from '../../src/editor/ai/reformat-all-cites.js';
+
+const callLlm = vi.fn<(req: LlmRequest) => Promise<LlmReply>>();
+const showConfirm = vi.fn<(opts: ConfirmOptions) => Promise<boolean>>();
+const showToast = vi.fn<(message: string, opts?: ToastOptions) => void>();
+
+vi.mock('../../src/editor/ai/llm.js', async (importOriginal) => ({
+  // Keep the real LlmError / settings-driven helpers; swap the network call
+  // and the key lookup.
+  ...(await importOriginal<typeof import('../../src/editor/ai/llm.js')>()),
+  callLlm: (req: LlmRequest) => callLlm(req),
+  activeApiKey: () => 'test-key',
+}));
+vi.mock('../../src/editor/confirm-dialog.js', () => ({
+  showConfirm: (opts: ConfirmOptions) => showConfirm(opts),
+}));
+vi.mock('../../src/editor/toast.js', () => ({
+  showToast: (...args: Parameters<typeof showToast>) => showToast(...args),
+}));
+
+const tag = (t: string) => schema.nodes['tag']!.create({ id: newHeadingId() }, schema.text(t));
+const body = (t: string) => schema.nodes['card_body']!.create(null, schema.text(t));
+const citeMark = schema.marks['cite_mark']!.create();
+/** A cite paragraph: `marked` is the substring wearing `cite_mark` — the
+ *  classifier keys cite-ness off the mark, so an unmarked paragraph
+ *  wouldn't stay a `cite_paragraph`. */
+const cite = (marked: string, rest: string) =>
+  schema.nodes['cite_paragraph']!.create(null, [
+    schema.text(marked, [citeMark]),
+    schema.text(rest),
+  ]);
+const card = (...kids: PMNode[]) => schema.nodes['card']!.create(null, kids);
+const doc = (...kids: PMNode[]) => schema.nodes['doc']!.createChecked(null, kids);
+
+/** Minimal EditorView stand-in — the pass touches `.state`, `.dispatch`,
+ *  `.isDestroyed` and (through the activity cues) `.dom`. dispatch runs
+ *  the real apply pipeline so the coordinator's filterTransaction and the
+ *  cite classifier both fire. */
+interface FakeView {
+  state: EditorState;
+  isDestroyed: boolean;
+  dom: HTMLElement;
+  dispatch(tr: unknown): void;
+}
+function fakeView(d: PMNode): EditorView & FakeView {
+  const v: FakeView = {
+    state: EditorState.create({
+      doc: d,
+      plugins: [editCoordinatorPlugin, citeClassifierPlugin],
+    }),
+    isDestroyed: false,
+    dom: document.createElement('div'),
+    dispatch(tr) {
+      // A fake view only ever receives transactions from the code under
+      // test, which builds them off this very state.
+      const step = tr as Parameters<EditorState['apply']>[0];
+      v.state = v.state.apply(step);
+    },
+  };
+  // Deliberate stand-in: the pass reads four members, and the DOM-facing
+  // cues degrade to no-ops without real geometry (`rangeRect` returns
+  // null when `coordsAtPos` isn't there).
+  return v as unknown as EditorView & FakeView;
+}
+
+function reply(citeText: string, tokens: string[]): LlmReply {
+  return { text: `[[CITE]]\n${citeText}\n[[TOKENS]]\n${tokens.join('\n')}\n[[END]]` };
+}
+
+/** Every cite_paragraph's text in the doc, in order. */
+function citeTexts(d: PMNode): string[] {
+  const out: string[] = [];
+  d.descendants((n) => {
+    if (n.type.name !== 'cite_paragraph') return true;
+    out.push(n.textContent);
+    return false;
+  });
+  return out;
+}
+
+/** The user text of every request the pass made, in order. */
+function sentTexts(): string[] {
+  return callLlm.mock.calls.map(([req]) => {
+    const content = req.messages[0]!.content;
+    return typeof content === 'string' ? content : '';
+  });
+}
+
+/** The pass's end-of-run summary toast. */
+function summary(): string | undefined {
+  return showToast.mock.calls.map(([m]) => m).find((m) => m.startsWith('Reformatted'));
+}
+
+/** Route each request to a canned reply, keyed by the lastname the sent
+ *  cite starts with. Every fixture cite is `Lastname NN, …` and every
+ *  reply keeps that head, so the [[TOKENS]] line is its first two words.
+ *  Throws on an unexpected request — a cite sent twice or out of order
+ *  must fail the test, not silently reuse a reply. */
+function replyPerLastname(replies: Record<string, string>) {
+  return async (req: LlmRequest): Promise<LlmReply> => {
+    const content = req.messages[0]!.content;
+    const sent = typeof content === 'string' ? content : '';
+    const lastname = Object.keys(replies).find((k) => sent.startsWith(k));
+    if (!lastname) throw new Error(`unexpected request: ${sent}`);
+    const citeText = replies[lastname]!;
+    return reply(citeText, [citeText.split(' ').slice(0, 2).join(' ')]);
+  };
+}
+
+beforeEach(() => {
+  callLlm.mockReset();
+  showConfirm.mockReset();
+  showToast.mockReset();
+  showConfirm.mockResolvedValue(true);
+  settings.set('aiFeaturesEnabled', true);
+  settings.set('aiCitePrompt', '');
+});
+
+describe('collectCiteParagraphs', () => {
+  it('finds every cite paragraph in document order, across containers', () => {
+    const d = doc(
+      card(tag('A'), cite('Smith 24', ', first'), body('body')),
+      schema.nodes['analytic_unit']!.create(null, [
+        schema.nodes['analytic']!.create({ id: newHeadingId() }, schema.text('AN')),
+        cite('Jones 23', ', second'),
+      ]),
+      cite('Lee 22', ', third'),
+    );
+    expect(collectCiteParagraphs(d).map((t) => t.text)).toEqual([
+      'Smith 24, first',
+      'Jones 23, second',
+      'Lee 22, third',
+    ]);
+  });
+
+  it('skips a blank cite paragraph — there is nothing to reformat', () => {
+    const d = doc(
+      card(tag('A'), schema.nodes['cite_paragraph']!.create(), cite('Smith 24', ', x')),
+    );
+    expect(collectCiteParagraphs(d).map((t) => t.text)).toEqual(['Smith 24, x']);
+  });
+
+  it('reports inline content bounds, not node bounds', () => {
+    const d = doc(cite('Smith 24', ', x'));
+    const t = collectCiteParagraphs(d)[0]!;
+    expect(t.from).toBe(t.pos + 1);
+    expect(d.textBetween(t.from, t.to)).toBe('Smith 24, x');
+  });
+});
+
+describe('nextCiteParagraph', () => {
+  const d = doc(cite('Smith 24', ', one'), body('x'), cite('Jones 23', ', two'));
+  const targets = collectCiteParagraphs(d);
+
+  it('returns the first cite at or after the cursor', () => {
+    expect(nextCiteParagraph(d, 0)!.text).toBe('Smith 24, one');
+    expect(nextCiteParagraph(d, targets[0]!.to)!.text).toBe('Jones 23, two');
+  });
+
+  it('returns null once the cursor is past the last cite', () => {
+    expect(nextCiteParagraph(d, targets[1]!.to)).toBeNull();
+  });
+});
+
+describe('runReformatAllCites', () => {
+  it('does not even confirm when the document has no cites', async () => {
+    await runReformatAllCites(fakeView(doc(card(tag('A'), body('no cites here')))));
+    expect(showConfirm).not.toHaveBeenCalled();
+    expect(callLlm).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith('No cites in this document.');
+  });
+
+  it('refuses to run with AI features off', async () => {
+    settings.set('aiFeaturesEnabled', false);
+    await runReformatAllCites(fakeView(doc(card(tag('A'), cite('Smith 24', ', a')))));
+    expect(showConfirm).not.toHaveBeenCalled();
+    expect(callLlm).not.toHaveBeenCalled();
+  });
+
+  it('states the request count in the confirm prompt and runs nothing if declined', async () => {
+    showConfirm.mockResolvedValue(false);
+    const view = fakeView(
+      doc(card(tag('A'), cite('Smith 24', ', a')), card(tag('B'), cite('Jones 23', ', b'))),
+    );
+    await runReformatAllCites(view);
+
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+    const opts = showConfirm.mock.calls[0]![0];
+    expect(opts.message).toContain('2 cites');
+    expect(opts.message).toContain('2 model requests');
+    expect(opts.confirmLabel).toBe('Reformat 2 cites');
+    expect(callLlm).not.toHaveBeenCalled();
+    expect(citeTexts(view.state.doc)).toEqual(['Smith 24, a', 'Jones 23, b']);
+  });
+
+  it('sends each cite once and rewrites it in place', async () => {
+    const view = fakeView(
+      doc(
+        card(tag('A'), cite('Smith 24', ', old a'), body('body a')),
+        card(tag('B'), cite('Jones 23', ', old b')),
+      ),
+    );
+    callLlm.mockImplementation(
+      replyPerLastname({
+        Smith: 'Smith 24, NEW A, Journal.',
+        Jones: 'Jones 23, NEW B, Journal.',
+      }),
+    );
+
+    await runReformatAllCites(view);
+
+    expect(sentTexts()).toEqual(['Smith 24, old a', 'Jones 23, old b']);
+    expect(citeTexts(view.state.doc)).toEqual([
+      'Smith 24, NEW A, Journal.',
+      'Jones 23, NEW B, Journal.',
+    ]);
+    // No stray paragraph split off the cite, and body text is untouched.
+    expect(view.state.doc.firstChild!.childCount).toBe(3);
+    expect(view.state.doc.firstChild!.child(2).textContent).toBe('body a');
+    expect(summary()).toBe('Reformatted 2 of 2 cites.');
+  });
+
+  it('keeps walking when a rewrite GROWS the cite — no cite is revisited', async () => {
+    // Growth is what a cached-position walk gets wrong: rewriting the
+    // first cite pushes every later cite forward in the doc.
+    const long = ', '.padEnd(200, 'x');
+    const view = fakeView(
+      doc(card(tag('A'), cite('Smith 24', ', a')), card(tag('B'), cite('Jones 23', ', b'))),
+    );
+    callLlm.mockImplementation(
+      replyPerLastname({ Smith: `Smith 24${long}`, Jones: `Jones 23${long}` }),
+    );
+
+    await runReformatAllCites(view);
+
+    expect(sentTexts()).toEqual(['Smith 24, a', 'Jones 23, b']);
+    expect(citeTexts(view.state.doc)).toEqual([`Smith 24${long}`, `Jones 23${long}`]);
+  });
+
+  it('keeps walking when a rewrite is DEMOTED out of cite_paragraph', async () => {
+    // A token the model can't locate in its own cite leaves the paragraph
+    // unmarked, so the classifier turns it into card_body. An ordinal
+    // index over cite_paragraphs would then shift and skip a cite.
+    const view = fakeView(
+      doc(
+        card(tag('A'), cite('Smith 24', ', a')),
+        card(tag('B'), cite('Jones 23', ', b')),
+        card(tag('C'), cite('Lee 22', ', c')),
+      ),
+    );
+    callLlm.mockImplementation(async (req) => {
+      const content = req.messages[0]!.content;
+      const text = typeof content === 'string' ? content : '';
+      if (text.startsWith('Smith')) return reply('Rewritten, no locatable token.', ['Nobody 99']);
+      if (text.startsWith('Jones')) return reply('Jones 23, NEW B.', ['Jones 23']);
+      return reply('Lee 22, NEW C.', ['Lee 22']);
+    });
+
+    await runReformatAllCites(view);
+
+    expect(sentTexts()).toEqual(['Smith 24, a', 'Jones 23, b', 'Lee 22, c']);
+    // The demoted paragraph is body text now; the other two stay cites.
+    expect(view.state.doc.child(0).child(1).type.name).toBe('card_body');
+    expect(view.state.doc.child(0).child(1).textContent).toBe('Rewritten, no locatable token.');
+    expect(citeTexts(view.state.doc)).toEqual(['Jones 23, NEW B.', 'Lee 22, NEW C.']);
+    expect(summary()).toContain('1 left unstyled');
+  });
+
+  it('skips a cite another AI edit already holds, and still does the rest', async () => {
+    const view = fakeView(
+      doc(card(tag('A'), cite('Smith 24', ', a')), card(tag('B'), cite('Jones 23', ', b'))),
+    );
+    const held = collectCiteParagraphs(view.state.doc)[0]!;
+    expect(claimRegion(view, { from: held.from, to: held.to }, { label: 'other' })).not.toBeNull();
+    callLlm.mockImplementation(replyPerLastname({ Jones: 'Jones 23, NEW B.' }));
+
+    await runReformatAllCites(view);
+
+    expect(sentTexts()).toEqual(['Jones 23, b']);
+    expect(citeTexts(view.state.doc)).toEqual(['Smith 24, a', 'Jones 23, NEW B.']);
+    expect(summary()).toContain('1 skipped (busy)');
+  });
+
+  it('a single failed cite does not abort the pass', async () => {
+    const view = fakeView(
+      doc(card(tag('A'), cite('Smith 24', ', a')), card(tag('B'), cite('Jones 23', ', b'))),
+    );
+    callLlm.mockImplementation(async (req) => {
+      const content = req.messages[0]!.content;
+      if (typeof content === 'string' && content.startsWith('Smith')) throw new Error('boom');
+      return reply('Jones 23, NEW B.', ['Jones 23']);
+    });
+
+    await runReformatAllCites(view);
+
+    expect(callLlm).toHaveBeenCalledTimes(2);
+    expect(citeTexts(view.state.doc)).toEqual(['Smith 24, a', 'Jones 23, NEW B.']);
+    expect(summary()).toContain('1 failed');
+  });
+
+  it('stops the whole pass on an auth failure instead of repeating it per cite', async () => {
+    const view = fakeView(
+      doc(
+        card(tag('A'), cite('Smith 24', ', a')),
+        card(tag('B'), cite('Jones 23', ', b')),
+        card(tag('C'), cite('Lee 22', ', c')),
+      ),
+    );
+    callLlm.mockRejectedValue(new LlmError('bad key', 401, 'auth'));
+
+    await runReformatAllCites(view);
+
+    expect(callLlm).toHaveBeenCalledTimes(1);
+    expect(summary()).toBe('Reformatted 0 of 3 cites · 1 failed.');
+  });
+});


### PR DESCRIPTION
Currently, the format cite with AI command only accepts a selection / one citation. A common workflow for debaters: updating backfiles, adhering to a new team's style guide, etc. is mass reformatting citations in a document.

This adds a command that runs every citation in the currently open document through the same AI reformat cite function using the pre-existing prompt and API settings.

The user is shown a 'confirm' message when the command is run, and upon confirmation each cite is parsed sequentially. Users can hit 'esc' to cancel the run at any time.