### PR TITLE
Read mode can keep each paragraph on its own line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ changes in each release, written for users of the editor. For
 in-depth rationale and implementation context behind each entry,
 see `DETAILED_CHANGELOG.md`.
 
+## 0.1.0-beta.30 — Unreleased
+
+### Added
+
+- **Read mode can keep your paragraphs apart.** Read mode has always
+  run a card's highlighted text together into one continuous block.
+  The new **Read mode: preserve paragraph integrity** setting
+  (Settings → General → Editor behavior) puts each body paragraph back
+  on its own line, so what you read follows the shape of the document.
+  Paragraphs with nothing highlighted in them still vanish outright —
+  you never get a blank line where a skipped paragraph used to be. Off
+  by default, and display-only: nothing about the document changes,
+  the same way the rest of read mode works. (PR #33, thanks to
+  [Cora](https://github.com/coralynnkc).)
+
 ## 0.1.0-beta.29 — 2026-08-05
 
 ### Added
@@ -56,16 +71,6 @@ see `DETAILED_CHANGELOG.md`.
   Receive pill — and documents arriving when you join a session — now
   fold in the nav pane to your current outline depth instead of
   landing fully expanded.
-
-- **Read mode can keep your paragraphs apart.** Read mode has always
-  run a card's highlighted text together into one continuous block.
-  The new **Read mode: preserve paragraph integrity** setting
-  (Settings → General → Editor behavior) puts each body paragraph back
-  on its own line, so what you read follows the shape of the document.
-  Paragraphs with nothing highlighted in them still vanish outright —
-  you never get a blank line where a skipped paragraph used to be. Off
-  by default, and display-only: nothing about the document changes,
-  the same way the rest of read mode works.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ see `DETAILED_CHANGELOG.md`.
   fold in the nav pane to your current outline depth instead of
   landing fully expanded.
 
+- **Read mode can keep your paragraphs apart.** Read mode has always
+  run a card's highlighted text together into one continuous block.
+  The new **Read mode: preserve paragraph integrity** setting
+  (Settings → General → Editor behavior) puts each body paragraph back
+  on its own line, so what you read follows the shape of the document.
+  Paragraphs with nothing highlighted in them still vanish outright —
+  you never get a blank line where a skipped paragraph used to be. Off
+  by default, and display-only: nothing about the document changes,
+  the same way the rest of read mode works.
+
 ### Changed
 
 - **The comments panel got a visual tune-up** (private notes and AI

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -163,6 +163,35 @@ in each release, see `CHANGELOG.md`.
   frame or the arriving doc update heals it) and every other peer
   still renders; the peer stays in the roster.
 
+- **Read-mode paragraph integrity** (new `readModeParagraphIntegrity`
+  setting; `style.css`, `index.ts`, `multi-pane-shell.ts`). Read mode
+  fuses a card's body paragraphs into one flow via `display: contents`
+  on `.pmd-card-body` — the paragraphs' boxes leave layout entirely and
+  their kept runs become inline siblings of the tag/cite. Readers who
+  navigate by the document's shape had no way back. The setting stamps
+  `pmd-rm-para-integrity` on the editor host (single-doc) or the pane
+  element (multi-doc, beside the existing `pmd-rm-no-emphasis-borders`)
+  and restores `display: block` to `.pmd-card-body` and to table cell
+  paragraphs — the table's container chain deliberately stays
+  `contents`, so only the cell paragraphs come back as lines, not the
+  table's boxes. Paragraphs holding no read-aloud text are hidden
+  outright by `:not(:has(.pmd-rm-keep))`, or every un-highlighted
+  paragraph would leave a blank line, which is worse than the fusing
+  the setting exists to fix. Display-only, mirroring the condense
+  setting of the same name; off by default.
+
+  Fixed alongside: the single-doc settings subscriber routed read-mode
+  display-preference changes through `applyReadMode(s.readMode)`. Under
+  multi-doc, `settings.readMode` stays `false` while a pane reads (read
+  mode is per-pane), so flipping either display preference dispatched
+  toggle-OFF into the focused pane's view — its hide decorations went
+  away while the pane element kept `pmd-read-mode`, i.e. read mode
+  suddenly showing every word of every card. The subscriber now skips
+  the block entirely under `multiDocActive`; the shell's own subscriber
+  re-stamps the classes per pane, which is all a display preference
+  needs. Reachable before this release via **Hide all emphasis borders
+  in read mode**.
+
 ## 0.1.0-beta.28 — 2026-08-05
 
 - **Reformat Every Cite in Document (AI)** (new

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -5,6 +5,38 @@ behavior, rationale, and (where useful) the implementation context
 behind a change. For a shorter, jargon-free summary of what's new
 in each release, see `CHANGELOG.md`.
 
+## 0.1.0-beta.30 — Unreleased
+
+- **Read-mode paragraph integrity** (new `readModeParagraphIntegrity`
+  setting; `style.css`, `index.ts`, `multi-pane-shell.ts`). Read mode
+  fuses a card's body paragraphs into one flow via `display: contents`
+  on `.pmd-card-body` — the paragraphs' boxes leave layout entirely and
+  their kept runs become inline siblings of the tag/cite. Readers who
+  navigate by the document's shape had no way back. The setting stamps
+  `pmd-rm-para-integrity` on the editor host (single-doc) or the pane
+  element (multi-doc, beside the existing `pmd-rm-no-emphasis-borders`)
+  and restores `display: block` to `.pmd-card-body` and to table cell
+  paragraphs — the table's container chain deliberately stays
+  `contents`, so only the cell paragraphs come back as lines, not the
+  table's boxes. Paragraphs holding no read-aloud text are hidden
+  outright by `:not(:has(.pmd-rm-keep))`, or every un-highlighted
+  paragraph would leave a blank line, which is worse than the fusing
+  the setting exists to fix. Display-only, mirroring the condense
+  setting of the same name; off by default. (PR #33, thanks to
+  [Cora](https://github.com/coralynnkc).)
+
+  Fixed alongside: the single-doc settings subscriber routed read-mode
+  display-preference changes through `applyReadMode(s.readMode)`. Under
+  multi-doc, `settings.readMode` stays `false` while a pane reads (read
+  mode is per-pane), so flipping either display preference dispatched
+  toggle-OFF into the focused pane's view — its hide decorations went
+  away while the pane element kept `pmd-read-mode`, i.e. read mode
+  suddenly showing every word of every card. The subscriber now skips
+  the block entirely under `multiDocActive`; the shell's own subscriber
+  re-stamps the classes per pane, which is all a display preference
+  needs. Reachable before this release via **Hide all emphasis borders
+  in read mode**.
+
 ## 0.1.0-beta.29 — 2026-08-05
 
 - **Comments travel with the clipboard** (new
@@ -162,35 +194,6 @@ in each release, see `CHANGELOG.md`.
   try/catch: the unresolvable peer's cursor is skipped (their next
   frame or the arriving doc update heals it) and every other peer
   still renders; the peer stays in the roster.
-
-- **Read-mode paragraph integrity** (new `readModeParagraphIntegrity`
-  setting; `style.css`, `index.ts`, `multi-pane-shell.ts`). Read mode
-  fuses a card's body paragraphs into one flow via `display: contents`
-  on `.pmd-card-body` — the paragraphs' boxes leave layout entirely and
-  their kept runs become inline siblings of the tag/cite. Readers who
-  navigate by the document's shape had no way back. The setting stamps
-  `pmd-rm-para-integrity` on the editor host (single-doc) or the pane
-  element (multi-doc, beside the existing `pmd-rm-no-emphasis-borders`)
-  and restores `display: block` to `.pmd-card-body` and to table cell
-  paragraphs — the table's container chain deliberately stays
-  `contents`, so only the cell paragraphs come back as lines, not the
-  table's boxes. Paragraphs holding no read-aloud text are hidden
-  outright by `:not(:has(.pmd-rm-keep))`, or every un-highlighted
-  paragraph would leave a blank line, which is worse than the fusing
-  the setting exists to fix. Display-only, mirroring the condense
-  setting of the same name; off by default.
-
-  Fixed alongside: the single-doc settings subscriber routed read-mode
-  display-preference changes through `applyReadMode(s.readMode)`. Under
-  multi-doc, `settings.readMode` stays `false` while a pane reads (read
-  mode is per-pane), so flipping either display preference dispatched
-  toggle-OFF into the focused pane's view — its hide decorations went
-  away while the pane element kept `pmd-read-mode`, i.e. read mode
-  suddenly showing every word of every card. The subscriber now skips
-  the block entirely under `multiDocActive`; the shell's own subscriber
-  re-stamps the classes per pane, which is all a display preference
-  needs. Reachable before this release via **Hide all emphasis borders
-  in read mode**.
 
 ## 0.1.0-beta.28 — 2026-08-05
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2024,6 +2024,13 @@ headers shown inside each tab.
   gesture.
 - **Jump to doc top when read mode toggles** — when on, toggling read
   mode scrolls to the top and puts the cursor at the start.
+- **Read mode: preserve paragraph integrity** — when on, read mode keeps
+  each body paragraph on its own line instead of flowing a card's
+  paragraphs together into one block. Body paragraphs with nothing
+  read-aloud in them still disappear completely, so you never get blank
+  lines. Off by default. Display-only, like the rest of read mode — the
+  document isn't touched (that's what
+  [Condense](#condense-pilcrows-and-case) does).
 
 **Word counts**
 

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -3583,6 +3583,7 @@ let lastKeyboardMacros = settings.get('keyboardMacros');
 // make every settings change lag on big docs.
 let lastReadMode = settings.get('readMode');
 let lastReadModeBorders = settings.get('hideEmphasisBordersInReadMode');
+let lastReadModeParaIntegrity = settings.get('readModeParagraphIntegrity');
 let lastMarkUnread = settings.get('markUnreadAfterMarker');
 let lastNumberingDisplay = numberingDisplaySig();
 
@@ -3635,9 +3636,22 @@ settings.subscribe((s) => {
   applyUnboldCites(s.unboldCites);
   applyTimerPosition(s.timerPosition);
   applyCursorBlink(s.disableCursorBlink);
-  if (s.readMode !== lastReadMode || s.hideEmphasisBordersInReadMode !== lastReadModeBorders) {
+  // Multi-doc owns read mode per-pane: `settings.readMode` stays false
+  // there even while a pane is reading, so routing a display-preference
+  // change through `applyReadMode(s.readMode)` would dispatch
+  // toggle-OFF into the focused pane's view — stripping its hide
+  // decorations while the pane element keeps `pmd-read-mode`, i.e. read
+  // mode showing every word of every card. The shell's own subscriber
+  // re-stamps these classes per pane instead.
+  if (
+    !multiDocActive &&
+    (s.readMode !== lastReadMode ||
+      s.hideEmphasisBordersInReadMode !== lastReadModeBorders ||
+      s.readModeParagraphIntegrity !== lastReadModeParaIntegrity)
+  ) {
     lastReadMode = s.readMode;
     lastReadModeBorders = s.hideEmphasisBordersInReadMode;
+    lastReadModeParaIntegrity = s.readModeParagraphIntegrity;
     applyReadMode(s.readMode);
   }
   // Nudge the mark-unread plugin to rebuild when its toggle flips (diff-gated
@@ -4766,6 +4780,10 @@ function applyReadMode(on: boolean): void {
     'pmd-rm-no-emphasis-borders',
     on && settings.get('hideEmphasisBordersInReadMode'),
   );
+  editorEl.classList.toggle(
+    'pmd-rm-para-integrity',
+    on && settings.get('readModeParagraphIntegrity'),
+  );
   if (!multiDocActive) refreshReadModeBtn();
   if (view) {
     // Read mode keeps the editor EDITABLE so the caret stays placeable
@@ -4794,12 +4812,14 @@ export function applyReadModeToTarget(
   targetView: EditorView,
   on: boolean,
   hideEmphasisBorders: boolean,
+  readParagraphIntegrity: boolean,
 ): void {
   const anchor = settings.get('jumpToDocTopOnReadModeToggle')
     ? null
     : captureViewportAnchor(targetView, { readMode: true });
   hostEl.classList.toggle('pmd-read-mode', on);
   hostEl.classList.toggle('pmd-rm-no-emphasis-borders', on && hideEmphasisBorders);
+  hostEl.classList.toggle('pmd-rm-para-integrity', on && readParagraphIntegrity);
   // Stay editable so the caret is placeable; edits are blocked by the
   // read-mode plugin's filterTransaction.
   targetView.setProps({ editable: () => true });

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -1443,17 +1443,22 @@ class MultiPaneShell {
       // `settings.readMode` here. Otherwise toggling read mode in
       // one pane would force every other open doc into the same
       // state.
-      // The `pmd-rm-no-emphasis-borders` flag IS settings-driven
-      // (it's a display preference, not per-doc), so when it
-      // changes we re-stamp the class on every currently-read-
-      // mode'd pane to match.
+      // The `pmd-rm-no-emphasis-borders` and `pmd-rm-para-integrity`
+      // flags ARE settings-driven (display preferences, not per-doc),
+      // so when they change we re-stamp the classes on every
+      // currently-read-mode'd pane to match.
       const hideEmphasisBorders = s.hideEmphasisBordersInReadMode;
+      const readParagraphIntegrity = s.readModeParagraphIntegrity;
       for (const id of SLOT_IDS) {
         for (const rec of this.slots[id].stack) {
           if (rec.readMode) {
             rec.editorEl.classList.toggle(
               'pmd-rm-no-emphasis-borders',
               hideEmphasisBorders,
+            );
+            rec.editorEl.classList.toggle(
+              'pmd-rm-para-integrity',
+              readParagraphIntegrity,
             );
           }
         }
@@ -2110,6 +2115,7 @@ class MultiPaneShell {
       rec.view,
       rec.readMode,
       settings.get('hideEmphasisBordersInReadMode'),
+      settings.get('readModeParagraphIntegrity'),
     );
     // setActiveView is the path that drives `refreshReadModeBtn`,
     // so we route through it to keep the ribbon button in sync.

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -853,6 +853,13 @@ export interface Settings {
    *  the ones around hidden text). Some users prefer the cleanest look
    *  in read mode regardless of what's emphasized. */
   hideEmphasisBordersInReadMode: boolean;
+  /** When true, read mode keeps each body paragraph on its own line
+   *  instead of flowing a card's paragraphs together as one continuous
+   *  run. The display-only counterpart of the condense setting of the
+   *  same name (`paragraphIntegrity`) — that one rewrites the doc, this
+   *  one only changes what read mode draws. Off by default: the single
+   *  continuous flow is what most people want at the podium. */
+  readModeParagraphIntegrity: boolean;
   /** When true, tint every run of card body text that falls AFTER a
    *  reading-position marker red, a visual record of what you didn't reach
    *  in a round. Bounded per-card; display-only (a decoration, never a doc
@@ -1649,6 +1656,7 @@ const DEFAULTS: Settings = {
   autosaveEnabled: false,
   readMode: false,
   hideEmphasisBordersInReadMode: false,
+  readModeParagraphIntegrity: false,
   markUnreadAfterMarker: false,
   defaultZoomPct: 100,
   chromeScalePct: 100,
@@ -2032,6 +2040,16 @@ export const SETTING_METADATA: SettingMeta[] = [
     kind: 'toggle',
     category: 'general',
     section: 'Editor behavior',
+  },
+  {
+    key: 'readModeParagraphIntegrity',
+    label: 'Read mode: preserve paragraph integrity',
+    description:
+      'When on, read mode keeps each body paragraph on its own line instead of flowing a card\'s paragraphs together into one block of text. Body paragraphs with nothing read-aloud in them still collapse away entirely, so no blank lines appear. Off by default — display-only, exactly like the rest of read mode (the document is untouched).',
+    kind: 'toggle',
+    category: 'general',
+    section: 'Editor behavior',
+    aliases: ['paragraph breaks', 'paragraph integrity', 'separate lines', 'read mode paragraphs'],
   },
   // ─── General ────────────────────────────────────────────────────
   {
@@ -4132,6 +4150,7 @@ function sanitize(s: Settings): Settings {
     autosaveEnabled: !!s.autosaveEnabled,
     readMode: !!s.readMode,
     hideEmphasisBordersInReadMode: !!s.hideEmphasisBordersInReadMode,
+    readModeParagraphIntegrity: !!s.readModeParagraphIntegrity,
     markUnreadAfterMarker: !!s.markUnreadAfterMarker,
     // A legacy persisted `zoomPct` is deliberately ignored — live body
     // zoom is transient; documents open at this default.

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -5375,6 +5375,37 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
   display: contents;
 }
 
+/* Optional setting: keep the document's paragraph breaks in read mode
+   (settings.readModeParagraphIntegrity → `pmd-rm-para-integrity` on
+   the editor host). The `display: contents` rules above are what fuse a
+   card's paragraphs — and its table cells — into one continuous run;
+   restoring `display: block` puts each source paragraph back on its own
+   line. The container chain (tableWrapper → table → tbody → tr → cell)
+   deliberately stays `contents`, so the table's boxes remain out of
+   layout and only its cell paragraphs come back as lines.
+
+   Paragraphs holding no read-aloud text must still collapse away, or
+   the reader gets a blank line for every un-highlighted paragraph — far
+   worse than the fusing this setting is fixing. `:has(.pmd-rm-keep)` is
+   the test: the plugin tags every visible text node with that class
+   (including a dropped reading marker), so "no kept child" is exactly
+   "nothing shows here".
+   `:is(#editor, .pmd-pane-editor)` takes an id's specificity, which is
+   what lifts these over the `display: contents` rules above in both the
+   single-doc and per-pane surfaces. */
+:is(#editor, .pmd-pane-editor).pmd-read-mode.pmd-rm-para-integrity
+  :is(.pmd-card, .pmd-analytic-unit) > .pmd-card-body,
+:is(#editor, .pmd-pane-editor).pmd-read-mode.pmd-rm-para-integrity
+  :is(.pmd-card, .pmd-analytic-unit) .tableWrapper :is(td, th) > p {
+  display: block;
+}
+:is(#editor, .pmd-pane-editor).pmd-read-mode.pmd-rm-para-integrity
+  :is(.pmd-card, .pmd-analytic-unit) > .pmd-card-body:not(:has(.pmd-rm-keep)),
+:is(#editor, .pmd-pane-editor).pmd-read-mode.pmd-rm-para-integrity
+  :is(.pmd-card, .pmd-analytic-unit) .tableWrapper :is(td, th) > p:not(:has(.pmd-rm-keep)) {
+  display: none;
+}
+
 /* Inline-level visibility: each text node is wrapped (via the
    read-mode plugin) in a span with `pmd-rm-keep` or `pmd-rm-hide`.
    Pure display: none / inline rule — no specificity tricks because


### PR DESCRIPTION
Read mode fuses a card's body paragraphs into one continuous flow via `display: contents` on `.pmd-card-body` — the paragraphs' boxes leave layout entirely and their kept runs become inline siblings of the tag/cite. Readers who navigate by the document's shape had no way back.

## The setting

**Read mode: preserve paragraph integrity** — Settings → General → Editor behavior, **off by default**. Named after the condense setting of the same name, since this is its display-only counterpart: nothing about the document changes.

It stamps `pmd-rm-para-integrity` on the editor host (single-doc) or the pane element (multi-doc, beside the existing `pmd-rm-no-emphasis-borders`) and restores `display: block` to `.pmd-card-body` and to table cell paragraphs. The table's container chain deliberately stays `contents`, so only the cell paragraphs come back as lines — the table's boxes stay out of layout.

Paragraphs holding no read-aloud text are hidden outright by `:not(:has(.pmd-rm-keep))`. Without that, every un-highlighted paragraph would leave a blank line, which is worse than the fusing the setting exists to fix.

Being `kind: 'toggle'` in the registry, it also picks up a command-palette toggle for free.

## Bug fixed alongside

The single-doc settings subscriber routed read-mode display-preference changes through `applyReadMode(s.readMode)`. Under multi-doc, `settings.readMode` stays `false` while a pane is reading (read mode is per-pane), so flipping either display preference dispatched toggle-**OFF** into the focused pane's view — its hide decorations went away while the pane element kept `pmd-read-mode`, i.e. read mode suddenly showing every word of every card.

The subscriber now skips that block under `multiDocActive`; the shell's own subscriber re-stamps the classes per pane, which is all a display preference needs.

This is pre-existing and reachable on `main` today via **Hide all emphasis borders in read mode** — the new setting just made it easy to hit, which is how I caught it.

## Verification

Click-tested in the three-pane web build at each step:

- setting on → each highlighted paragraph on its own line, the fully-unhighlighted paragraph gone with no gap
- setting off → the old single fused run
- live toggling in both directions while read mode stays on, decorations intact

`tests/editor` passes (2323 tests), `tsc --noEmit` clean, `check:links` clean.

Docs updated: `MANUAL.md`, `CHANGELOG.md`, `DETAILED_CHANGELOG.md`.