### PR TITLE
Nav pane follows the cursor; fix the highlight lost on a level change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ changes in each release, written for users of the editor. For
 in-depth rationale and implementation context behind each entry,
 see `DETAILED_CHANGELOG.md`.
 
+## Unreleased
+
+### Added
+
+- **The outline can keep your place when you change its depth.** The
+  navigation pane's **1 · 2 · 3 · 4** buttons rebuild the outline, which
+  has always scrolled it back to the top of the document — so switching
+  depth halfway through a file meant finding your way back. Turn on
+  **Keep your place when the navigation depth changes** (Settings →
+  General → Workspace, off by default) and the section your cursor is in
+  stays at the top of the outline across the switch. If that section is
+  hidden at the new depth, the outline anchors on its nearest visible
+  parent instead. Nothing but the outline's scroll position moves: your
+  cursor, your selection, and the document are untouched.
+
 ## 1.1.0 — 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,28 @@ see `DETAILED_CHANGELOG.md`.
 
 ### Added
 
-- **The outline can keep your place when you change its depth.** The
-  navigation pane's **1 · 2 · 3 · 4** buttons rebuild the outline, which
-  has always scrolled it back to the top of the document — so switching
-  depth halfway through a file meant finding your way back. Turn on
-  **Keep your place when the navigation depth changes** (Settings →
-  General → Workspace, off by default) and the section your cursor is in
-  stays at the top of the outline across the switch. If that section is
-  hidden at the new depth, the outline anchors on its nearest visible
-  parent instead. Nothing but the outline's scroll position moves: your
-  cursor, your selection, and the document are untouched.
+- **The navigation pane can follow your place in the document.** Turn on
+  **Navigation pane follows the cursor** (Settings → General →
+  Workspace, off by default) and the outline scrolls to keep the section
+  you're in visible. Moving the cursor into a different section brings
+  that heading into view; changing depth with the **1 · 2 · 3 · 4**
+  buttons — which rebuilds the outline and has always scrolled it back
+  to the top of the document — instead keeps the section you were in at
+  the top. If that section is hidden at the current depth, the outline
+  follows its nearest visible parent. The pane only moves when the
+  heading would otherwise be off-screen, so typing within one section,
+  or scrolling the outline by hand, leaves it alone. Nothing but the
+  outline's scroll position moves: your cursor, your selection, and the
+  document are untouched.
+
+### Fixed
+
+- **Changing the outline depth no longer loses the "you are here"
+  highlight.** The navigation pane highlights the heading your cursor is
+  in, but clicking the **1 · 2 · 3 · 4** buttons rebuilt the outline
+  without restoring it — so whenever the new depth hid your heading, the
+  highlight simply vanished and nothing showed where you were. It now
+  falls back to the nearest visible parent, the same as everywhere else.
 
 ## 1.1.0 — 2026-08-18
 

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -7,53 +7,85 @@ in each release, see `CHANGELOG.md`.
 
 ## Unreleased
 
-### Added: nav pane keeps your place across a level change
+### Fixed: a level change dropped the caret highlight
 
-`navKeepPlaceOnLevelChange` (General → Workspace, **off by default**,
-`kind: 'toggle'` so it also gets a command-palette toggle). Every level
-change routes through `setMaxLevel` — the header's 1–4 buttons and the
-context menu's "Show heading level N" alike — which re-renders the
-outline, and the render clears the list, dropping the scroll offset to
-0. With the flag on, `setMaxLevel` notes an anchor before the rebuild
-and re-applies the scroll after it.
+Pre-existing, and the reason the feature below was worth building. Every
+rebuild of `liEntries` has to be followed by a positional resync —
+`setCaretHeading` re-resolved against the rows that now exist — which is
+why the editor runs one after its debounced `update()`. `setMaxLevel`
+rebuilds the list and never did. `selectedIds` kept the caret heading's
+id, but when the new depth collapsed that heading away no rendered row
+carried it, so `render`'s selected-class pass matched nothing and the
+outline lost its "you are here" entirely.
 
-The anchor is the heading whose section holds the cursor. The nav pane
-had no such notion (caret tracking only ever lit a row), so it's derived
-here: an ancestor walk out from `selection.$from` first — a cursor in a
-card or analytic unit belongs to that wrapper's own tag/analytic head,
-which lives *inside* the wrapper — then a backwards scan across the
-doc's top-level siblings, since pocket/hat/block sections are positional
-spans, not structural ones (the `findEnclosingContainer` idiom from
-`live-read-time.ts`, but every heading type counts, because every one of
-them is a row the user can be parked on). Resolving as finely as the tag
-is deliberate: at level 4 the card under the cursor is its own row, and
-it's the row the user is looking at.
+`setMaxLevel` now resyncs after the render, unconditionally — this is a
+bug fix, not part of the setting. It resolves the way every other caret
+consumer does (largest rendered `entry.pos <= caret pos`), which lands
+on the deepest rendered ancestor when the exact heading is gone. Passed
+as a positional resync, so an explicit nav multi-select survives a depth
+change the same way it survives a rebuild.
 
-The anchoring heading needn't have a row at the new level — it may have
-collapsed under a shallower parent — so the post-render pass takes the
-last rendered row at or before it (`liEntries` is filled in document
-order), the same deepest-rendered-ancestor rule the find-hit and caret
-decorations resolve by, and sets `scrollTop` to that row's offset within
-the list, clamped to the scrollable range. Scroll only: the editor
-selection, the nav multi-selection, and the collapsed set are all left
-alone. No view, no doc, an empty outline, or a cursor ahead of the first
-heading all fall through to today's behavior (top). `scrollToTop()`, the
-doc-load reset, is untouched — a freshly opened document still starts at
-the top of its outline.
+### Added: the nav pane can follow the cursor
+
+`navFollowCursor` (General → Workspace, **off by default**, `kind:
+'toggle'` so it also gets a command-palette toggle). `setCaretHeading`
+has always resolved and highlighted the caret's row while explicitly
+declining to scroll to it — "that'd dominate scroll behavior for users
+who scroll the editor freely. Add later if it turns out to be desired."
+This is that later; the concern is answered by *when* it scrolls rather
+than by leaving it out.
+
+The scroll target is whichever row currently carries the highlight, read
+back off the DOM rather than re-derived from the doc. That's the point:
+`setCaretHeading` already owns the resolution, and a scroll that
+disagreed with the visible highlight would be worse than no scroll. (The
+first cut of this change re-derived the caret's heading with its own
+ancestor walk and doc-level sibling scan — ~60 lines reaching the same
+answer by a second route, now deleted.)
+
+Two modes:
+
+- **`'nearest'`** — caret movement. Runs only where `setCaretHeading`
+  has established the highlight moved to a *different* row (every
+  no-change path returns before it), and then only if that row is
+  off-screen, scrolling the minimum distance to reveal it. So typing
+  inside one section never moves the pane, and an outline the user
+  scrolled by hand stays put until the caret actually leaves the visible
+  span. Positional resyncs are excluded outright — the caret didn't
+  move, the doc changed under it, and yanking the pane after a
+  drag-reorder or a debounced rebuild is exactly the behavior the
+  original note was guarding against.
+- **`'top'`** — level change, where `render()` has already destroyed the
+  scroll offset. There is no position left to preserve, so the row is
+  pinned to the top of the viewport and the section the user was reading
+  heads the list.
+
+`offsetTop` is measured from the nearest positioned ancestor, which is
+the panel (`position: fixed`) — `.pmd-nav-list` is an unpositioned flex
+child — so the list's own offset comes off to get a content-relative
+coordinate; both are scroll-independent. Results clamp to the scrollable
+range. Scroll only: the editor selection, the nav multi-selection, and
+the collapsed set are all left alone. No view, no doc, an empty outline,
+or a caret ahead of the first heading all fall through to doing nothing.
+`scrollToTop()`, the doc-load reset, is untouched — a freshly opened
+document still starts at the top of its outline.
 
 Both surfaces inherit it: the single-doc panel and each pane's panel in
 the three-pane shell attach a view at construction, and the mobile shell
 reuses the single-doc instance.
 
-Tests (`tests/editor/nav-keep-place.test.ts`) stub the geometry jsdom
+Tests (`tests/editor/nav-follow-cursor.test.ts`) stub the geometry jsdom
 doesn't have — rows `ROW_H` apart, a fixed viewport — and assert the
-offset the panel computes, including the bottom clamp and the
-collapsed-away fallback. The flag-OFF reset can't be observed directly:
-jsdom stores `scrollTop` as a plain number and never re-clamps it when
-the list is emptied, so the browser's "wipe the list, lose the offset"
-doesn't happen there. Those cases assert instead that the panel never
-writes `scrollTop`, which is exactly the pre-existing behavior a real
-browser turns into a snap-to-top.
+offsets the panel computes: the bottom clamp, the collapsed-away
+fallback, the minimum-distance reveal, and the two guarantees that keep
+following from fighting the user (an already-visible row isn't touched;
+moving within one section doesn't scroll). The highlight fix is asserted
+with the setting off, where it belongs. The flag-OFF scroll reset can't
+be observed directly: jsdom stores `scrollTop` as a plain number and
+never re-clamps it when the list is emptied, so the browser's "wipe the
+list, lose the offset" doesn't happen there. Those cases assert instead
+that the panel never writes `scrollTop`, which is exactly the
+pre-existing behavior a real browser turns into a snap-to-top.
 
 ## 1.1.0 — 2026-08-18
 

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -5,6 +5,56 @@ behavior, rationale, and (where useful) the implementation context
 behind a change. For a shorter, jargon-free summary of what's new
 in each release, see `CHANGELOG.md`.
 
+## Unreleased
+
+### Added: nav pane keeps your place across a level change
+
+`navKeepPlaceOnLevelChange` (General → Workspace, **off by default**,
+`kind: 'toggle'` so it also gets a command-palette toggle). Every level
+change routes through `setMaxLevel` — the header's 1–4 buttons and the
+context menu's "Show heading level N" alike — which re-renders the
+outline, and the render clears the list, dropping the scroll offset to
+0. With the flag on, `setMaxLevel` notes an anchor before the rebuild
+and re-applies the scroll after it.
+
+The anchor is the heading whose section holds the cursor. The nav pane
+had no such notion (caret tracking only ever lit a row), so it's derived
+here: an ancestor walk out from `selection.$from` first — a cursor in a
+card or analytic unit belongs to that wrapper's own tag/analytic head,
+which lives *inside* the wrapper — then a backwards scan across the
+doc's top-level siblings, since pocket/hat/block sections are positional
+spans, not structural ones (the `findEnclosingContainer` idiom from
+`live-read-time.ts`, but every heading type counts, because every one of
+them is a row the user can be parked on). Resolving as finely as the tag
+is deliberate: at level 4 the card under the cursor is its own row, and
+it's the row the user is looking at.
+
+The anchoring heading needn't have a row at the new level — it may have
+collapsed under a shallower parent — so the post-render pass takes the
+last rendered row at or before it (`liEntries` is filled in document
+order), the same deepest-rendered-ancestor rule the find-hit and caret
+decorations resolve by, and sets `scrollTop` to that row's offset within
+the list, clamped to the scrollable range. Scroll only: the editor
+selection, the nav multi-selection, and the collapsed set are all left
+alone. No view, no doc, an empty outline, or a cursor ahead of the first
+heading all fall through to today's behavior (top). `scrollToTop()`, the
+doc-load reset, is untouched — a freshly opened document still starts at
+the top of its outline.
+
+Both surfaces inherit it: the single-doc panel and each pane's panel in
+the three-pane shell attach a view at construction, and the mobile shell
+reuses the single-doc instance.
+
+Tests (`tests/editor/nav-keep-place.test.ts`) stub the geometry jsdom
+doesn't have — rows `ROW_H` apart, a fixed viewport — and assert the
+offset the panel computes, including the bottom clamp and the
+collapsed-away fallback. The flag-OFF reset can't be observed directly:
+jsdom stores `scrollTop` as a plain number and never re-clamps it when
+the list is emptied, so the browser's "wipe the list, lose the offset"
+doesn't happen there. Those cases assert instead that the panel never
+writes `scrollTop`, which is exactly the pre-existing behavior a real
+browser turns into a snap-to-top.
+
 ## 1.1.0 — 2026-08-18
 
 ### Added: guided UI tour (spotlight onboarding)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -268,7 +268,10 @@ mirrors Word's Navigation Pane, but does more:
   change; what depth a **newly opened** document starts at is the
   **Default navigation depth** setting (Settings → General), Block by
   default. Clicking the already-active level re-collapses any manual
-  expansions.
+  expansions. Changing depth normally returns the outline to the top of
+  the document; turn on **Keep your place when the navigation depth
+  changes** (Settings → General) to have the section your cursor is in
+  stay at the top of the outline instead.
 - **Multi-select** — Mod-click adds an entry to the selection,
   Shift-click selects a contiguous range.
 - **Reorder** — drag an entry (or a multi-selection) up or down. It
@@ -1991,6 +1994,12 @@ headers shown inside each tab.
   at when a document opens (Pocket / Hat / Block / Tag; Block by
   default). The 1–4 buttons in the pane change the depth for that
   window only.
+- **Keep your place when the navigation depth changes** — off by
+  default. On, clicking the pane's 1–4 buttons keeps the section your
+  cursor is in at the top of the outline instead of jumping back to the
+  top of the document; if that section is hidden at the new depth, the
+  outline anchors on its nearest visible parent. Only the outline's
+  scroll position moves — your cursor and the document stay put.
 - **Multi-doc layout** — with three docs open, show all three at once
   (compact) or two-and-a-bit with click-to-snap (wide). No effect with
   one or two docs.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -269,9 +269,9 @@ mirrors Word's Navigation Pane, but does more:
   **Default navigation depth** setting (Settings → General), Block by
   default. Clicking the already-active level re-collapses any manual
   expansions. Changing depth normally returns the outline to the top of
-  the document; turn on **Keep your place when the navigation depth
-  changes** (Settings → General) to have the section your cursor is in
-  stay at the top of the outline instead.
+  the document; turn on **Navigation pane follows the cursor** (Settings
+  → General) to have the section your cursor is in stay at the top of
+  the outline instead.
 - **Multi-select** — Mod-click adds an entry to the selection,
   Shift-click selects a contiguous range.
 - **Reorder** — drag an entry (or a multi-selection) up or down. It
@@ -1994,12 +1994,17 @@ headers shown inside each tab.
   at when a document opens (Pocket / Hat / Block / Tag; Block by
   default). The 1–4 buttons in the pane change the depth for that
   window only.
-- **Keep your place when the navigation depth changes** — off by
-  default. On, clicking the pane's 1–4 buttons keeps the section your
-  cursor is in at the top of the outline instead of jumping back to the
-  top of the document; if that section is hidden at the new depth, the
-  outline anchors on its nearest visible parent. Only the outline's
-  scroll position moves — your cursor and the document stay put.
+- **Navigation pane follows the cursor** — off by default. On, the
+  outline scrolls to keep your place in sight. Moving the cursor into a
+  different section brings that heading into view, and clicking the
+  pane's 1–4 buttons keeps the section you were in at the top of the
+  outline instead of jumping back to the top of the document. If your
+  section is hidden at the current depth, the outline follows its
+  nearest visible parent. The pane only moves when the heading would
+  otherwise be off-screen, so typing within one section — or scrolling
+  the outline by hand to look somewhere else — leaves it where you put
+  it. Only the outline's scroll position moves; your cursor and the
+  document stay put.
 - **Multi-doc layout** — with three docs open, show all three at once
   (compact) or two-and-a-bit with click-to-snap (wide). No effect with
   one or two docs.

--- a/src/editor/nav-panel.ts
+++ b/src/editor/nav-panel.ts
@@ -68,6 +68,7 @@ import {
   zoneRangeForEntry,
   headingInsertPos,
   TYPE_LABEL,
+  TYPE_TO_LEVEL,
   type HeadingEntry,
 } from './headings.js';
 import { setIcon } from './icons';
@@ -1956,10 +1957,102 @@ export class NavigationPanel {
    *  level re-collapses any manual chevron expansions. */
   private setMaxLevel(level: number): void {
     if (level < 1 || level > 4) return;
+    // `render` clears the list, which drops the scroll offset to 0 — the
+    // outline snaps back to the top of the document and the user loses
+    // the place they were reading. With `navKeepPlaceOnLevelChange` on,
+    // note where the cursor is BEFORE the rebuild and re-anchor after it.
+    const anchorPos = settings.get('navKeepPlaceOnLevelChange')
+      ? this.activeHeadingPos()
+      : null;
     this.applyMaxLevelToCollapseState(level);
     this.localMaxLevel = level;
     this.updateLevelButtonsActive();
     if (this.currentDoc) this.render(this.currentDoc);
+    if (anchorPos !== null) this.scrollAnchorToTop(anchorPos);
+  }
+
+  /**
+   * Position of the heading whose section holds the cursor — the outline
+   * row that should keep its place across a level change, or null when
+   * there's nothing to anchor on (no view, empty doc, or a cursor sitting
+   * ahead of the document's first heading).
+   *
+   * Sections resolve POSITIONALLY, not structurally: a pocket/hat/block
+   * heading owns everything after it up to the next equal-or-shallower
+   * heading, so the enclosing one is found by scanning the doc's top-level
+   * children backwards from the cursor's (the same idiom as
+   * `findEnclosingContainer` in `live-read-time.ts`). Two differences,
+   * both because this feeds the OUTLINE rather than a read-time readout:
+   * every heading type counts — each one is a row the user can be parked
+   * on — and the ancestor walk runs first, so a cursor inside a card or
+   * analytic unit resolves to that wrapper's own tag/analytic head
+   * (heading-anchored nodes live INSIDE their wrapper, where a sibling
+   * scan at doc level can't see them). Finer is better here: at level 4
+   * the card under the cursor is a row of its own, and it's the row the
+   * user is looking at.
+   *
+   * Read from `view.state`, which can be a few edits ahead of
+   * `currentDoc` (the outline rebuilds on a ~200ms debounce). Positions
+   * drift by at most those edits, and the anchor only picks a scroll
+   * target, so the same tolerance `setCaretHeading` documents applies.
+   */
+  private activeHeadingPos(): number | null {
+    const view = this.view;
+    if (!view) return null;
+    const $pos = view.state.selection.$from;
+
+    // Outward first: the cursor may be in the heading itself, or in the
+    // body of a card / analytic unit whose head IS the heading.
+    for (let d = $pos.depth; d >= 1; d--) {
+      const node = $pos.node(d);
+      if (TYPE_TO_LEVEL[node.type.name] !== undefined) return $pos.before(d);
+      const first = node.firstChild;
+      if (first && TYPE_TO_LEVEL[first.type.name] !== undefined) return $pos.before(d) + 1;
+    }
+
+    // Then backwards across top-level siblings, for content that sits
+    // under a pocket/hat/block heading without any wrapper of its own.
+    const doc = view.state.doc;
+    if (doc.childCount === 0) return null;
+    const index = Math.min($pos.index(0), doc.childCount - 1);
+    let childPos = 0;
+    const positions: number[] = [];
+    for (let i = 0; i < doc.childCount; i++) {
+      positions.push(childPos);
+      childPos += doc.child(i).nodeSize;
+    }
+    for (let i = index; i >= 0; i--) {
+      const child = doc.child(i);
+      if (TYPE_TO_LEVEL[child.type.name] !== undefined) return positions[i]!;
+      const first = child.firstChild;
+      if (first && TYPE_TO_LEVEL[first.type.name] !== undefined) return positions[i]! + 1;
+    }
+    return null; // nothing but loose content before the cursor
+  }
+
+  /**
+   * Scroll the outline so the row anchoring `pos` sits at the top of the
+   * list viewport.
+   *
+   * The heading at `pos` needn't have a row at the new level — it can be
+   * collapsed under a shallower parent — so the anchor is the LAST
+   * rendered row at or before it: its deepest rendered ancestor, the same
+   * rule the find-hit and caret decorations resolve by. `liEntries` is
+   * filled in render order, which is document order, so the last match
+   * wins. Scroll only — the editor selection, the nav selection, and the
+   * collapsed set are all left exactly as they were.
+   */
+  private scrollAnchorToTop(pos: number): void {
+    let target: HTMLLIElement | null = null;
+    for (const [li, entry] of this.liEntries) {
+      if (entry.pos <= pos) target = li;
+    }
+    // Nothing rendered at or before the cursor (empty outline, or the
+    // cursor is ahead of the first heading): the top is already right.
+    if (!target) return;
+    const max = Math.max(0, this.listEl.scrollHeight - this.listEl.clientHeight);
+    const top = target.offsetTop - this.listEl.offsetTop;
+    this.listEl.scrollTop = Math.max(0, Math.min(top, max));
   }
 
   private updateLevelButtonsActive(): void {

--- a/src/editor/nav-panel.ts
+++ b/src/editor/nav-panel.ts
@@ -18,7 +18,11 @@ import { settings, SETTINGS_DEFAULTS } from './settings.js';
 import { CLIPBOARD_BUSY_MESSAGE, writeClipboardHtml } from './clipboard-write.js';
 import { showToast } from './toast.js';
 import { setManualShadowSelection } from './similar-selection-plugin.js';
-import { insertSelfRef, insertInDocCopy } from './self-transclusion-commands.js';
+import {
+  insertSelfRef,
+  insertInDocCopy,
+  selfRefSelectionPos,
+} from './self-transclusion-commands.js';
 import { registerOpenContextMenu, clearOpenContextMenu } from './context-menu-registry.js';
 import { dragController, type DragItem, type DragSurface } from './drag-controller.js';
 import { isTransclusionNode, zoneIdentity } from './transclusion.js';
@@ -68,7 +72,6 @@ import {
   zoneRangeForEntry,
   headingInsertPos,
   TYPE_LABEL,
-  TYPE_TO_LEVEL,
   type HeadingEntry,
 } from './headings.js';
 import { setIcon } from './icons';
@@ -1189,9 +1192,13 @@ export class NavigationPanel {
    * highlight may briefly point at a stale neighbor in that window,
    * which is acceptable for a visual indicator.
    *
-   * Doesn't auto-scroll the nav pane to bring the highlight into
-   * view — that'd dominate scroll behavior for users who scroll the
-   * editor freely. Add later if it turns out to be desired.
+   * Auto-scrolling the pane to bring the highlight into view is opt-in
+   * (`navFollowCursor`, default off) — unconditional scrolling would
+   * dominate scroll behavior for users who scroll the editor freely,
+   * which is why this stayed highlight-only until asked for. The
+   * following mode only moves the pane when the highlight actually
+   * CHANGES rows and the new row is off-screen; see
+   * `scrollCaretRowIntoView`.
    *
    * `opts.preserveMultiSelect`: set by the POSITIONAL RESYNC callers
    * (post-rebuild / divergence refresh), where the caret didn't move —
@@ -1245,6 +1252,19 @@ export class NavigationPanel {
     }
     if (!hadWindow && this.selectedIds.size === 1 && this.selectedIds.has(best.id!)) return;
     this.selectSingle(best);
+    // Reached only when the highlight moved to a DIFFERENT row (every
+    // no-change path returned above), which is what keeps following from
+    // fighting the user: typing inside one section can't scroll the pane.
+    //
+    // Positional resyncs are excluded. `preserveMultiSelect` marks exactly
+    // those callers (see the opts docs above): the caret did NOT move, the
+    // doc changed under it — a drag-reorder, a debounced rebuild, a level
+    // change. Scrolling there would yank the pane for something the user
+    // didn't do with the cursor, and the level-change caller wants the
+    // 'top' anchoring instead, which it applies itself.
+    if (opts?.preserveMultiSelect !== true && settings.get('navFollowCursor')) {
+      this.scrollCaretRowIntoView('nearest');
+    }
   }
 
   private handleShiftClick(entry: HeadingEntry): void {
@@ -1957,102 +1977,97 @@ export class NavigationPanel {
    *  level re-collapses any manual chevron expansions. */
   private setMaxLevel(level: number): void {
     if (level < 1 || level > 4) return;
-    // `render` clears the list, which drops the scroll offset to 0 — the
-    // outline snaps back to the top of the document and the user loses
-    // the place they were reading. With `navKeepPlaceOnLevelChange` on,
-    // note where the cursor is BEFORE the rebuild and re-anchor after it.
-    const anchorPos = settings.get('navKeepPlaceOnLevelChange')
-      ? this.activeHeadingPos()
-      : null;
     this.applyMaxLevelToCollapseState(level);
     this.localMaxLevel = level;
     this.updateLevelButtonsActive();
     if (this.currentDoc) this.render(this.currentDoc);
-    if (anchorPos !== null) this.scrollAnchorToTop(anchorPos);
+    // `render` rebuilt `liEntries`, so the caret highlight has to be
+    // re-resolved against the rows that now exist — the same positional
+    // resync the editor runs after its debounced `update()`. Without it
+    // the highlight simply VANISHES whenever the new depth collapses the
+    // caret's heading away: `selectedIds` still holds that heading's id,
+    // but no rendered row carries it, so nothing lights up. (Pre-existing
+    // on main, where it hid behind the scroll jumping to the top too.)
+    // Positional resync, not a caret move → an explicit multi-select
+    // survives, matching the other resync callers.
+    this.resyncCaretHighlight();
+    // Then keep the user's place: the rebuild dropped `scrollTop` to 0,
+    // so the outline would otherwise snap to the top of the document.
+    if (settings.get('navFollowCursor')) this.scrollCaretRowIntoView('top');
   }
 
-  /**
-   * Position of the heading whose section holds the cursor — the outline
-   * row that should keep its place across a level change, or null when
-   * there's nothing to anchor on (no view, empty doc, or a cursor sitting
-   * ahead of the document's first heading).
-   *
-   * Sections resolve POSITIONALLY, not structurally: a pocket/hat/block
-   * heading owns everything after it up to the next equal-or-shallower
-   * heading, so the enclosing one is found by scanning the doc's top-level
-   * children backwards from the cursor's (the same idiom as
-   * `findEnclosingContainer` in `live-read-time.ts`). Two differences,
-   * both because this feeds the OUTLINE rather than a read-time readout:
-   * every heading type counts — each one is a row the user can be parked
-   * on — and the ancestor walk runs first, so a cursor inside a card or
-   * analytic unit resolves to that wrapper's own tag/analytic head
-   * (heading-anchored nodes live INSIDE their wrapper, where a sibling
-   * scan at doc level can't see them). Finer is better here: at level 4
-   * the card under the cursor is a row of its own, and it's the row the
-   * user is looking at.
-   *
-   * Read from `view.state`, which can be a few edits ahead of
-   * `currentDoc` (the outline rebuilds on a ~200ms debounce). Positions
-   * drift by at most those edits, and the anchor only picks a scroll
-   * target, so the same tolerance `setCaretHeading` documents applies.
-   */
-  private activeHeadingPos(): number | null {
+  /** Re-resolve the caret highlight against the currently-rendered rows.
+   *  Call after any `render()` that wasn't driven by a caret move. */
+  private resyncCaretHighlight(): void {
     const view = this.view;
-    if (!view) return null;
-    const $pos = view.state.selection.$from;
-
-    // Outward first: the cursor may be in the heading itself, or in the
-    // body of a card / analytic unit whose head IS the heading.
-    for (let d = $pos.depth; d >= 1; d--) {
-      const node = $pos.node(d);
-      if (TYPE_TO_LEVEL[node.type.name] !== undefined) return $pos.before(d);
-      const first = node.firstChild;
-      if (first && TYPE_TO_LEVEL[first.type.name] !== undefined) return $pos.before(d) + 1;
-    }
-
-    // Then backwards across top-level siblings, for content that sits
-    // under a pocket/hat/block heading without any wrapper of its own.
-    const doc = view.state.doc;
-    if (doc.childCount === 0) return null;
-    const index = Math.min($pos.index(0), doc.childCount - 1);
-    let childPos = 0;
-    const positions: number[] = [];
-    for (let i = 0; i < doc.childCount; i++) {
-      positions.push(childPos);
-      childPos += doc.child(i).nodeSize;
-    }
-    for (let i = index; i >= 0; i--) {
-      const child = doc.child(i);
-      if (TYPE_TO_LEVEL[child.type.name] !== undefined) return positions[i]!;
-      const first = child.firstChild;
-      if (first && TYPE_TO_LEVEL[first.type.name] !== undefined) return positions[i]! + 1;
-    }
-    return null; // nothing but loose content before the cursor
+    if (!view) return;
+    this.setCaretHeading(view.state.selection.from, selfRefSelectionPos(view.state), {
+      preserveMultiSelect: true,
+    });
   }
 
   /**
-   * Scroll the outline so the row anchoring `pos` sits at the top of the
-   * list viewport.
+   * The rendered row carrying the caret highlight — what the outline
+   * currently says "you are here" about. Null when nothing is
+   * highlighted (empty outline, or a caret ahead of the first heading).
    *
-   * The heading at `pos` needn't have a row at the new level — it can be
-   * collapsed under a shallower parent — so the anchor is the LAST
-   * rendered row at or before it: its deepest rendered ancestor, the same
-   * rule the find-hit and caret decorations resolve by. `liEntries` is
-   * filled in render order, which is document order, so the last match
-   * wins. Scroll only — the editor selection, the nav selection, and the
+   * Deliberately reads the DOM class rather than re-deriving the caret's
+   * heading from the doc: `setCaretHeading` already owns that resolution
+   * (largest rendered `entry.pos <= caret pos`, which lands on the
+   * deepest rendered ancestor when the exact heading is collapsed away),
+   * and scrolling to a row the highlight DISAGREES with would be worse
+   * than not scrolling at all.
+   */
+  private caretRow(): HTMLLIElement | null {
+    for (const li of this.liEntries.keys()) {
+      if (li.classList.contains('pmd-nav-item-selected')) return li;
+    }
+    return null;
+  }
+
+  /**
+   * Scroll the outline to the highlighted row, so the pane keeps up with
+   * where the caret is in the document.
+   *
+   * Two modes, and the difference is the whole reason this doesn't
+   * "dominate scroll behavior for users who scroll the editor freely"
+   * (the concern `setCaretHeading` documents):
+   *
+   *   - `'nearest'` — the caret-following case. Does NOTHING when the row
+   *     is already visible, so ordinary typing and cursor movement inside
+   *     one section never move the pane, and a nav pane the user scrolled
+   *     by hand is left alone until the caret actually leaves the visible
+   *     span. Only an off-screen row scrolls, and only just far enough.
+   *   - `'top'` — the level-change case, where `render()` has already
+   *     destroyed the scroll offset. There is no position left to
+   *     preserve, so the row is pinned to the top of the viewport and the
+   *     section the user was reading heads the list.
+   *
+   * Scroll only: the editor selection, the nav selection, and the
    * collapsed set are all left exactly as they were.
    */
-  private scrollAnchorToTop(pos: number): void {
-    let target: HTMLLIElement | null = null;
-    for (const [li, entry] of this.liEntries) {
-      if (entry.pos <= pos) target = li;
-    }
-    // Nothing rendered at or before the cursor (empty outline, or the
-    // cursor is ahead of the first heading): the top is already right.
+  private scrollCaretRowIntoView(mode: 'nearest' | 'top'): void {
+    const target = this.caretRow();
     if (!target) return;
-    const max = Math.max(0, this.listEl.scrollHeight - this.listEl.clientHeight);
-    const top = target.offsetTop - this.listEl.offsetTop;
-    this.listEl.scrollTop = Math.max(0, Math.min(top, max));
+    const list = this.listEl;
+    // `offsetTop` is measured from the nearest POSITIONED ancestor, which
+    // is the panel (`position: fixed`), not the list (`.pmd-nav-list` is
+    // an unpositioned flex child) — so the list's own offset comes off to
+    // get a content-relative coordinate. Both are scroll-independent.
+    const top = target.offsetTop - list.offsetTop;
+    const max = Math.max(0, list.scrollHeight - list.clientHeight);
+    if (mode === 'nearest') {
+      const viewTop = list.scrollTop;
+      const viewBottom = viewTop + list.clientHeight;
+      const bottom = top + target.offsetHeight;
+      if (top >= viewTop && bottom <= viewBottom) return; // already visible
+      // Off the bottom → bring its bottom edge just inside; off the top →
+      // its top edge. Either way the pane moves the minimum distance.
+      const next = top < viewTop ? top : bottom - list.clientHeight;
+      list.scrollTop = Math.max(0, Math.min(next, max));
+      return;
+    }
+    list.scrollTop = Math.max(0, Math.min(top, max));
   }
 
   private updateLevelButtonsActive(): void {

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -389,15 +389,23 @@ export interface Settings {
    *  doc's view only (transient, per-pane); this setting is what
    *  every new doc starts at. */
   navMaxLevel: number;
-  /** When true, switching the nav pane's level (the 1–4 buttons or the
-   *  context menu's "Show heading level N") keeps the section the cursor
-   *  sits in pinned to the top of the outline instead of scrolling back
-   *  to the top of the document. If that section's own row isn't
-   *  rendered at the new level — it collapsed under a shallower parent —
-   *  the nearest ancestor row that IS rendered takes its place. Scroll
-   *  only: the cursor, the nav selection, and the collapsed set are
+  /** When true, the nav pane scrolls to keep the outline row the cursor
+   *  is in visible — the pane follows your place in the document instead
+   *  of sitting wherever it was last left.
+   *
+   *  Two occasions, both resolving to whichever row currently carries the
+   *  caret highlight (the deepest RENDERED ancestor, when the cursor's own
+   *  heading is collapsed away): moving the cursor into a different
+   *  section scrolls that row into view, and only when it's actually
+   *  off-screen, so typing within one section never moves the pane and a
+   *  hand-scrolled outline is left alone. Switching level (the 1–4 buttons
+   *  or the context menu's "Show heading level N") rebuilds the list and
+   *  destroys its scroll offset outright, so there the row is pinned to
+   *  the top instead.
+   *
+   *  Scroll only: the cursor, the nav selection, and the collapsed set are
    *  untouched. Off by default. */
-  navKeepPlaceOnLevelChange: boolean;
+  navFollowCursor: boolean;
   /** When true (default), `New document` mounts the CardMirror
    *  welcome / onboarding doc. When false, it mounts a blank
    *  doc — a single empty paragraph. The starter is the same one
@@ -1568,7 +1576,7 @@ export const CUSTOM_DASH_STYLES: ReadonlyArray<Settings['customDashStyle']> = [
 const DEFAULTS: Settings = {
   navWidth: 300,
   navMaxLevel: 3,
-  navKeepPlaceOnLevelChange: false,
+  navFollowCursor: false,
   copyPreviousCiteNearestOnly: true,
   showOnboardingStarter: true,
   hasSeenUiTour: false,
@@ -2044,14 +2052,22 @@ export const SETTING_METADATA: SettingMeta[] = [
     aliases: ['nav depth', 'outline depth', 'navigation level', 'nav pane depth'],
   },
   {
-    key: 'navKeepPlaceOnLevelChange',
-    label: 'Keep your place when the navigation depth changes',
+    key: 'navFollowCursor',
+    label: 'Navigation pane follows the cursor',
     description:
-      "Off by default. When on, clicking the navigation pane's 1–4 buttons keeps the section your cursor is in at the top of the outline, instead of jumping back to the top of the document. If that section is hidden at the new depth, the outline anchors on its nearest visible parent. Nothing but the outline's scroll position moves — your cursor and the document stay put.",
+      "Off by default. When on, the navigation pane scrolls to keep your place in sight: moving the cursor into a different section brings that heading into view, and changing the depth with the 1–4 buttons keeps the section you were in at the top of the outline instead of jumping back to the top of the document. If your section is hidden at the current depth, the outline follows its nearest visible parent. The pane only moves when the heading would otherwise be off-screen, so typing within one section leaves it alone. Nothing but the outline's scroll position moves — your cursor and the document stay put.",
     kind: 'toggle',
     category: 'general',
     section: 'Workspace',
-    aliases: ['nav scroll', 'outline scroll position', 'keep place', 'nav pane place'],
+    aliases: [
+      'nav scroll',
+      'outline scroll position',
+      'keep place',
+      'nav pane place',
+      'follow cursor',
+      'sync outline',
+      'outline follows',
+    ],
   },
   {
     key: 'mobileLayout',
@@ -4027,7 +4043,7 @@ function sanitize(s: Settings): Settings {
   return {
     navWidth: clamp(s.navWidth, 150, 800),
     navMaxLevel: clamp(Math.round(s.navMaxLevel), 1, 4),
-    navKeepPlaceOnLevelChange: s.navKeepPlaceOnLevelChange === true,
+    navFollowCursor: s.navFollowCursor === true,
     // Default-on: preserve `false` only when explicitly set so the
     // onboarding shows up for new installs and survives upgrades
     // from before this setting existed.

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -389,6 +389,15 @@ export interface Settings {
    *  doc's view only (transient, per-pane); this setting is what
    *  every new doc starts at. */
   navMaxLevel: number;
+  /** When true, switching the nav pane's level (the 1–4 buttons or the
+   *  context menu's "Show heading level N") keeps the section the cursor
+   *  sits in pinned to the top of the outline instead of scrolling back
+   *  to the top of the document. If that section's own row isn't
+   *  rendered at the new level — it collapsed under a shallower parent —
+   *  the nearest ancestor row that IS rendered takes its place. Scroll
+   *  only: the cursor, the nav selection, and the collapsed set are
+   *  untouched. Off by default. */
+  navKeepPlaceOnLevelChange: boolean;
   /** When true (default), `New document` mounts the CardMirror
    *  welcome / onboarding doc. When false, it mounts a blank
    *  doc — a single empty paragraph. The starter is the same one
@@ -1559,6 +1568,7 @@ export const CUSTOM_DASH_STYLES: ReadonlyArray<Settings['customDashStyle']> = [
 const DEFAULTS: Settings = {
   navWidth: 300,
   navMaxLevel: 3,
+  navKeepPlaceOnLevelChange: false,
   copyPreviousCiteNearestOnly: true,
   showOnboardingStarter: true,
   hasSeenUiTour: false,
@@ -2032,6 +2042,16 @@ export const SETTING_METADATA: SettingMeta[] = [
     category: 'general',
     section: 'Workspace',
     aliases: ['nav depth', 'outline depth', 'navigation level', 'nav pane depth'],
+  },
+  {
+    key: 'navKeepPlaceOnLevelChange',
+    label: 'Keep your place when the navigation depth changes',
+    description:
+      "Off by default. When on, clicking the navigation pane's 1–4 buttons keeps the section your cursor is in at the top of the outline, instead of jumping back to the top of the document. If that section is hidden at the new depth, the outline anchors on its nearest visible parent. Nothing but the outline's scroll position moves — your cursor and the document stay put.",
+    kind: 'toggle',
+    category: 'general',
+    section: 'Workspace',
+    aliases: ['nav scroll', 'outline scroll position', 'keep place', 'nav pane place'],
   },
   {
     key: 'mobileLayout',
@@ -4007,6 +4027,7 @@ function sanitize(s: Settings): Settings {
   return {
     navWidth: clamp(s.navWidth, 150, 800),
     navMaxLevel: clamp(Math.round(s.navMaxLevel), 1, 4),
+    navKeepPlaceOnLevelChange: s.navKeepPlaceOnLevelChange === true,
     // Default-on: preserve `false` only when explicitly set so the
     // onboarding shows up for new installs and survives upgrades
     // from before this setting existed.

--- a/tests/editor/nav-follow-cursor.test.ts
+++ b/tests/editor/nav-follow-cursor.test.ts
@@ -1,20 +1,30 @@
 // @vitest-environment jsdom
 
 /**
- * `navKeepPlaceOnLevelChange` — the nav pane keeps the cursor's section at
- * the top of the outline across a level change instead of snapping back to
- * the top of the document.
+ * The nav pane keeping up with your place in the document.
  *
- * jsdom has no layout: `offsetTop` / `clientHeight` / `scrollHeight` are all
- * 0, so the anchoring math would be indistinguishable from the fallback. The
- * geometry is stubbed instead — every row is `ROW_H` tall in DOM order, the
- * list viewport is `VIEWPORT_H` — which is exactly the shape a real browser
- * reports and lets the tests assert the offset the panel actually computes.
+ * Two behaviors, deliberately separated because only one of them is
+ * opt-in:
+ *
+ *   - The caret HIGHLIGHT surviving a level change is a plain bug fix and
+ *     runs unconditionally. `render()` rebuilds every row, so a heading
+ *     that collapses away at the new depth leaves `selectedIds` pointing
+ *     at an id no rendered row carries — and the outline goes blank with
+ *     no "you are here" at all. Every other rebuild in the editor is
+ *     followed by a positional resync; `setMaxLevel` was missing it.
+ *   - SCROLLING to follow the caret is `navFollowCursor`, default off.
+ *
+ * jsdom has no layout: `offsetTop` / `offsetHeight` / `clientHeight` /
+ * `scrollHeight` are all 0, so the anchoring math would be
+ * indistinguishable from the fallback. The geometry is stubbed instead —
+ * every row `ROW_H` tall in DOM order, the list viewport `VIEWPORT_H` —
+ * which is the shape a real browser reports and lets the tests assert the
+ * offsets the panel actually computes.
  *
  * The scroll RESET on the flag-off path can't be observed the same way:
- * jsdom stores `scrollTop` as a plain number and never re-clamps it when the
- * list is emptied, so the browser's "wipe the list, lose the offset" is
- * simply absent here. The honest assertion is that the panel writes
+ * jsdom stores `scrollTop` as a plain number and never re-clamps it when
+ * the list is emptied, so the browser's "wipe the list, lose the offset"
+ * is simply absent here. The honest assertion is that the panel writes
  * `scrollTop` only when the feature is on — with the flag off it doesn't
  * touch the offset at all, which in a real browser is precisely today's
  * snap-to-top.
@@ -29,7 +39,7 @@ import { NavigationPanel } from '../../src/editor/nav-panel.js';
 import { settings } from '../../src/editor/settings.js';
 
 const ROW_H = 20;
-const VIEWPORT_H = 40;
+const VIEWPORT_H = 40; // two rows visible at a time
 
 const node = (name: string, attrs: Record<string, unknown> | null, content?: PMNode | PMNode[]): PMNode =>
   schema.nodes[name]!.create(attrs, content);
@@ -125,6 +135,10 @@ function stubGeometry(listEl: HTMLElement): void {
       return Array.prototype.indexOf.call(parent.children, this) * ROW_H;
     },
   });
+  Object.defineProperty(HTMLLIElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => ROW_H,
+  });
   Object.defineProperty(listEl, 'clientHeight', {
     configurable: true,
     get: () => VIEWPORT_H,
@@ -140,6 +154,8 @@ interface Harness {
   view: EditorView;
   writes: number[];
   rowLabels(): string[];
+  /** Label of the row currently carrying the caret highlight, or null. */
+  highlighted(): string | null;
 }
 
 const open: Harness[] = [];
@@ -156,6 +172,10 @@ function setup(doc: PMNode = makeDoc()): Harness {
     view,
     writes,
     rowLabels: () => [...listEl.children].map((li) => li.textContent ?? ''),
+    highlighted: () => {
+      const li = listEl.querySelector('.pmd-nav-item-selected');
+      return li ? (li.textContent ?? '') : null;
+    },
   };
   open.push(h);
   return h;
@@ -165,8 +185,14 @@ function putCursor(view: EditorView, pos: number): void {
   view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, pos)));
 }
 
+/** What the editor's `dispatchTransaction` does on every caret move — the
+ *  panel doesn't observe the view itself. */
+function syncCaret(h: Harness): void {
+  h.panel.setCaretHeading(h.view.state.selection.from);
+}
+
 beforeEach(() => {
-  settings.set('navKeepPlaceOnLevelChange', false);
+  settings.set('navFollowCursor', false);
   settings.set('navMaxLevel', 3);
 });
 
@@ -176,10 +202,36 @@ afterEach(() => {
     h.view.destroy();
   }
   delete (HTMLLIElement.prototype as unknown as Record<string, unknown>)['offsetTop'];
-  settings.set('navKeepPlaceOnLevelChange', false);
+  delete (HTMLLIElement.prototype as unknown as Record<string, unknown>)['offsetHeight'];
+  settings.set('navFollowCursor', false);
 });
 
-describe('nav level change with navKeepPlaceOnLevelChange OFF', () => {
+describe('caret highlight across a level change (unconditional)', () => {
+  it('keeps a highlight when the depth collapses the caret\'s heading away', () => {
+    const h = setup();
+    putCursor(h.view, inCardBody(h.view.state.doc, 2));
+    clickLevel(h.panel, 4);
+    expect(h.highlighted()).toContain('Tag two'); // its own row
+
+    // Level 3 collapses the tags: the row that WAS highlighted no longer
+    // exists. Before the resync this went blank — the reported bug.
+    clickLevel(h.panel, 3);
+    expect(h.highlighted()).toContain('Block one');
+  });
+
+  it('does so with the follow setting off — it is a fix, not a feature', () => {
+    const h = setup();
+    settings.set('navFollowCursor', false);
+    putCursor(h.view, inCardBody(h.view.state.doc, 4));
+    clickLevel(h.panel, 4);
+    expect(h.highlighted()).toContain('Tag four');
+    clickLevel(h.panel, 3);
+    expect(h.highlighted()).toContain('Block three');
+    expect(h.writes).toEqual([]); // …and still no scrolling
+  });
+});
+
+describe('level change with navFollowCursor OFF', () => {
   it('leaves the scroll offset alone — the rebuild lands at the top, as before', () => {
     const h = setup();
     putCursor(h.view, inCardBody(h.view.state.doc, 3));
@@ -188,8 +240,8 @@ describe('nav level change with navKeepPlaceOnLevelChange OFF', () => {
   });
 });
 
-describe('nav level change with navKeepPlaceOnLevelChange ON', () => {
-  beforeEach(() => settings.set('navKeepPlaceOnLevelChange', true));
+describe('level change with navFollowCursor ON', () => {
+  beforeEach(() => settings.set('navFollowCursor', true));
 
   it("pins the cursor's own row to the top when the new level renders it", () => {
     const h = setup();
@@ -231,6 +283,7 @@ describe('nav level change with navKeepPlaceOnLevelChange ON', () => {
     const h = setup(doc);
     putCursor(h.view, 1); // inside the leading paragraph
     clickLevel(h.panel, 4);
+    expect(h.highlighted()).toBeNull();
     expect(h.writes).toEqual([]);
   });
 
@@ -249,5 +302,56 @@ describe('nav level change with navKeepPlaceOnLevelChange ON', () => {
     expect(() => clickLevel(panel, 4)).not.toThrow();
     expect(writes).toEqual([]);
     panel.destroy();
+  });
+});
+
+describe('following the caret as it moves', () => {
+  beforeEach(() => {
+    settings.set('navFollowCursor', true);
+    settings.set('navMaxLevel', 4); // all eight rows rendered
+  });
+
+  it('scrolls an off-screen row just far enough into view', () => {
+    const h = setup();
+    putCursor(h.view, inCardBody(h.view.state.doc, 3));
+    syncCaret(h);
+    // Row 5 (Tag three) spans 100–120; the viewport shows 0–40. Scrolling
+    // DOWN brings its bottom edge to the viewport's bottom, not its top —
+    // the minimum move.
+    expect(h.highlighted()).toContain('Tag three');
+    expect(h.writes).toEqual([6 * ROW_H - VIEWPORT_H]);
+  });
+
+  it('leaves an already-visible row alone', () => {
+    const h = setup();
+    // Row 1 (Block one) spans 20–40, fully inside the 0–40 viewport.
+    putCursor(h.view, inCardBody(h.view.state.doc, 1));
+    h.panel.setCaretHeading(1); // resolve onto the Block one row
+    expect(h.writes).toEqual([]);
+  });
+
+  it('does not move the pane while the caret stays in one section', () => {
+    const h = setup();
+    const doc = h.view.state.doc;
+    putCursor(h.view, inCardBody(doc, 3));
+    syncCaret(h);
+    const afterFirst = h.writes.length;
+
+    // Typing along inside the same card keeps resolving to the same row,
+    // and `setCaretHeading` returns before ever reaching the scroll.
+    putCursor(h.view, inCardBody(h.view.state.doc, 3) + 2);
+    syncCaret(h);
+    putCursor(h.view, inCardBody(h.view.state.doc, 3) + 4);
+    syncCaret(h);
+    expect(h.writes).toHaveLength(afterFirst);
+  });
+
+  it('stays put with the setting off', () => {
+    settings.set('navFollowCursor', false);
+    const h = setup();
+    putCursor(h.view, inCardBody(h.view.state.doc, 4));
+    syncCaret(h);
+    expect(h.highlighted()).toContain('Tag four'); // highlight still tracks
+    expect(h.writes).toEqual([]); // …the pane just doesn't chase it
   });
 });

--- a/tests/editor/nav-keep-place.test.ts
+++ b/tests/editor/nav-keep-place.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+
+/**
+ * `navKeepPlaceOnLevelChange` — the nav pane keeps the cursor's section at
+ * the top of the outline across a level change instead of snapping back to
+ * the top of the document.
+ *
+ * jsdom has no layout: `offsetTop` / `clientHeight` / `scrollHeight` are all
+ * 0, so the anchoring math would be indistinguishable from the fallback. The
+ * geometry is stubbed instead — every row is `ROW_H` tall in DOM order, the
+ * list viewport is `VIEWPORT_H` — which is exactly the shape a real browser
+ * reports and lets the tests assert the offset the panel actually computes.
+ *
+ * The scroll RESET on the flag-off path can't be observed the same way:
+ * jsdom stores `scrollTop` as a plain number and never re-clamps it when the
+ * list is emptied, so the browser's "wipe the list, lose the offset" is
+ * simply absent here. The honest assertion is that the panel writes
+ * `scrollTop` only when the feature is on — with the flag off it doesn't
+ * touch the offset at all, which in a real browser is precisely today's
+ * snap-to-top.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { EditorState, TextSelection } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import type { Node as PMNode } from 'prosemirror-model';
+import { schema, newHeadingId } from '../../src/schema/index.js';
+import { NavigationPanel } from '../../src/editor/nav-panel.js';
+import { settings } from '../../src/editor/settings.js';
+
+const ROW_H = 20;
+const VIEWPORT_H = 40;
+
+const node = (name: string, attrs: Record<string, unknown> | null, content?: PMNode | PMNode[]): PMNode =>
+  schema.nodes[name]!.create(attrs, content);
+
+const heading = (name: string, text: string): PMNode =>
+  node(name, { id: newHeadingId() }, schema.text(text));
+
+const card = (tagText: string, bodyText: string): PMNode =>
+  node('card', null, [
+    heading('tag', tagText),
+    node('card_body', null, schema.text(bodyText)),
+  ]);
+
+/**
+ * Four rows at level 3 (pocket + three blocks), eight at level 4 (each
+ * block's card joins them) — enough that a mid-document anchor lands at a
+ * distinct, unclamped offset at both depths, and the last one clamps.
+ */
+function makeDoc(): PMNode {
+  return node('doc', null, [
+    heading('pocket', 'Pocket'),
+    heading('block', 'Block one'),
+    card('Tag one', 'body one'),
+    card('Tag two', 'body two'),
+    heading('block', 'Block two'),
+    card('Tag three', 'body three'),
+    heading('block', 'Block three'),
+    card('Tag four', 'body four'),
+  ]);
+}
+
+/** Position inside the Nth (1-based) card body — a plain cursor parked in
+ *  card text, which is where a reader's cursor actually sits. */
+function inCardBody(doc: PMNode, n: number): number {
+  let seen = 0;
+  let found = -1;
+  doc.descendants((child, pos) => {
+    if (child.type.name !== 'card_body') return true;
+    seen++;
+    if (seen === n && found < 0) found = pos + 1;
+    return false;
+  });
+  return found;
+}
+
+function mountView(doc: PMNode): EditorView {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  return new EditorView(host, { state: EditorState.create({ doc }) });
+}
+
+function listOf(panel: NavigationPanel): HTMLElement {
+  return (panel as unknown as { listEl: HTMLElement }).listEl;
+}
+
+function rootOf(panel: NavigationPanel): HTMLElement {
+  return (panel as unknown as { root: HTMLElement }).root;
+}
+
+/** Click the header's `1 2 3 4` button — the real entry point, same one the
+ *  context menu's "Show heading level N" routes through. */
+function clickLevel(panel: NavigationPanel, level: number): void {
+  const btn = rootOf(panel).querySelector<HTMLButtonElement>(
+    `.pmd-nav-level-btn[data-level="${level}"]`,
+  );
+  if (!btn) throw new Error(`no level button ${level}`);
+  btn.click();
+}
+
+/** Record every `scrollTop` write the panel makes to the outline list. */
+function recordScroll(listEl: HTMLElement): number[] {
+  const writes: number[] = [];
+  let value = 0;
+  Object.defineProperty(listEl, 'scrollTop', {
+    configurable: true,
+    get: () => value,
+    set: (v: number) => {
+      writes.push(v);
+      value = v;
+    },
+  });
+  return writes;
+}
+
+/** Stub the layout a browser would report: rows stacked `ROW_H` apart in DOM
+ *  order inside a `VIEWPORT_H`-tall scroller. */
+function stubGeometry(listEl: HTMLElement): void {
+  Object.defineProperty(HTMLLIElement.prototype, 'offsetTop', {
+    configurable: true,
+    get(this: HTMLLIElement) {
+      const parent = this.parentElement;
+      if (!parent) return 0;
+      return Array.prototype.indexOf.call(parent.children, this) * ROW_H;
+    },
+  });
+  Object.defineProperty(listEl, 'clientHeight', {
+    configurable: true,
+    get: () => VIEWPORT_H,
+  });
+  Object.defineProperty(listEl, 'scrollHeight', {
+    configurable: true,
+    get: () => listEl.children.length * ROW_H,
+  });
+}
+
+interface Harness {
+  panel: NavigationPanel;
+  view: EditorView;
+  writes: number[];
+  rowLabels(): string[];
+}
+
+const open: Harness[] = [];
+
+function setup(doc: PMNode = makeDoc()): Harness {
+  const view = mountView(doc);
+  const panel = new NavigationPanel(document.createElement('div'));
+  panel.attach(view);
+  const listEl = listOf(panel);
+  stubGeometry(listEl);
+  const writes = recordScroll(listEl);
+  const h: Harness = {
+    panel,
+    view,
+    writes,
+    rowLabels: () => [...listEl.children].map((li) => li.textContent ?? ''),
+  };
+  open.push(h);
+  return h;
+}
+
+function putCursor(view: EditorView, pos: number): void {
+  view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, pos)));
+}
+
+beforeEach(() => {
+  settings.set('navKeepPlaceOnLevelChange', false);
+  settings.set('navMaxLevel', 3);
+});
+
+afterEach(() => {
+  for (const h of open.splice(0)) {
+    h.panel.destroy();
+    h.view.destroy();
+  }
+  delete (HTMLLIElement.prototype as unknown as Record<string, unknown>)['offsetTop'];
+  settings.set('navKeepPlaceOnLevelChange', false);
+});
+
+describe('nav level change with navKeepPlaceOnLevelChange OFF', () => {
+  it('leaves the scroll offset alone — the rebuild lands at the top, as before', () => {
+    const h = setup();
+    putCursor(h.view, inCardBody(h.view.state.doc, 3));
+    clickLevel(h.panel, 4);
+    expect(h.writes).toEqual([]);
+  });
+});
+
+describe('nav level change with navKeepPlaceOnLevelChange ON', () => {
+  beforeEach(() => settings.set('navKeepPlaceOnLevelChange', true));
+
+  it("pins the cursor's own row to the top when the new level renders it", () => {
+    const h = setup();
+    putCursor(h.view, inCardBody(h.view.state.doc, 3));
+    clickLevel(h.panel, 4);
+    // Pocket, Block one, Tag one, Tag two, Block two, [Tag three], …
+    expect(h.rowLabels()[5]).toContain('Tag three');
+    expect(h.writes).toEqual([5 * ROW_H]);
+  });
+
+  it('clamps at the bottom of the list rather than scrolling past it', () => {
+    const h = setup();
+    putCursor(h.view, inCardBody(h.view.state.doc, 4));
+    clickLevel(h.panel, 4);
+    // Row 7 wants 140; eight rows in a 40-tall viewport cap at 120.
+    expect(h.rowLabels()[7]).toContain('Tag four');
+    expect(h.writes).toEqual([8 * ROW_H - VIEWPORT_H]);
+  });
+
+  it('falls back to the nearest rendered ancestor when the row collapses away', () => {
+    const h = setup();
+    putCursor(h.view, inCardBody(h.view.state.doc, 2));
+    clickLevel(h.panel, 4);
+    expect(h.writes).toEqual([3 * ROW_H]); // its own row, at level 4
+
+    clickLevel(h.panel, 3); // tags collapse under their blocks
+    expect(h.rowLabels()).toHaveLength(4);
+    expect(h.rowLabels()[1]).toContain('Block one');
+    expect(h.writes[1]).toBe(1 * ROW_H); // the block that owns the card
+  });
+
+  it('does nothing when the cursor sits ahead of the first heading', () => {
+    const doc = node('doc', null, [
+      node('paragraph', null, schema.text('loose intro')),
+      heading('pocket', 'Pocket'),
+      heading('block', 'Block one'),
+      card('Tag one', 'body one'),
+    ]);
+    const h = setup(doc);
+    putCursor(h.view, 1); // inside the leading paragraph
+    clickLevel(h.panel, 4);
+    expect(h.writes).toEqual([]);
+  });
+
+  it('does nothing on a document with no headings at all', () => {
+    const doc = node('doc', null, [node('paragraph', null, schema.text('just prose'))]);
+    const h = setup(doc);
+    putCursor(h.view, 1);
+    clickLevel(h.panel, 4);
+    expect(h.rowLabels()).toHaveLength(0);
+    expect(h.writes).toEqual([]);
+  });
+
+  it('does nothing on a panel with no view attached (mobile shell boot)', () => {
+    const panel = new NavigationPanel(document.createElement('div'));
+    const writes = recordScroll(listOf(panel));
+    expect(() => clickLevel(panel, 4)).not.toThrow();
+    expect(writes).toEqual([]);
+    panel.destroy();
+  });
+});


### PR DESCRIPTION
The navigation pane highlights the heading your cursor is in, but never scrolls to it. `setCaretHeading` says why:

> Doesn't auto-scroll the nav pane to bring the highlight into view — that'd dominate scroll behavior for users who scroll the editor freely. **Add later if it turns out to be desired.**

It turned out to be desired. Changing depth made it acute: the 1–4 buttons rebuild the outline, which drops `scrollTop` to 0, so switching depth halfway through a file threw away your place and left you to find it again.

## Bug fixed first

Every rebuild of `liEntries` has to be followed by a positional resync — `setCaretHeading` re-resolved against the rows that now exist — which is why the editor runs one after its debounced `update()` (`index.ts:5759`). **`setMaxLevel` rebuilds the list and never did.** `selectedIds` kept the caret heading's id, but when the new depth collapsed that heading away, no rendered row carried it, `render`'s selected-class pass matched nothing, and the outline lost its "you are here" entirely.

This is reachable on `main` today: put the cursor in a tag at level 4, click **3**, and the highlight vanishes. It hides behind the scroll also jumping to the top — there's no place-you-were left to look at, so nobody notices the missing highlight. Fixing the scroll is what made it visible.

`setMaxLevel` now resyncs after the render, **unconditionally** — a bug fix, not part of the setting. It resolves the way every other caret consumer does (largest rendered `entry.pos <= caret pos`), landing on the deepest rendered ancestor when the exact heading is gone, and passes the positional-resync flavor so an explicit nav multi-select survives a depth change like it survives a rebuild.

## The setting

**Navigation pane follows the cursor** — Settings → General → Workspace, **off by default**. `kind: 'toggle'`, so it picks up a command-palette toggle for free.

The scroll target is whichever row currently carries the highlight, read back off the DOM rather than re-derived from the doc. That's deliberate: `setCaretHeading` already owns that resolution, and a scroll that disagreed with the visible highlight would be worse than no scroll at all.

Two modes, and the difference between them is the whole answer to the original concern:

- **`'nearest'`** — caret movement. Runs only where `setCaretHeading` has established the highlight moved to a *different* row (every no-change path returns before it), and then only if that row is off-screen, moving the minimum distance to reveal it. Typing inside one section never moves the pane; an outline you scrolled by hand stays put until the caret actually leaves the visible span. Positional resyncs are excluded outright — the caret didn't move, the doc changed under it, and yanking the pane after a drag-reorder is exactly what the original note was guarding against.
- **`'top'`** — level change, where `render()` has already destroyed the scroll offset. No position left to preserve, so the row is pinned to the top and the section you were reading heads the list.

`offsetTop` is measured from the nearest positioned ancestor — the panel (`position: fixed`), since `.pmd-nav-list` is an unpositioned flex child — so the list's own offset comes off to get a content-relative coordinate. Both are scroll-independent; results clamp to the scrollable range. Scroll only: the editor selection, the nav multi-selection, and the collapsed set are untouched. `scrollToTop()`, the doc-load reset, is left alone.

Both surfaces inherit it — the single-doc panel and each pane's panel in the three-pane shell attach a view at construction; the mobile shell reuses the single-doc instance.

## What changed since the first push

The original commit added `navKeepPlaceOnLevelChange`, whose ~60-line `activeHeadingPos()` re-derived the caret's heading with its own ancestor walk and doc-level sibling scan. It reached the same answer `setCaretHeading` already had, by a second route — and it fixed the scroll while leaving the highlight broken, which is how the missing resync surfaced in testing. Both are gone; the setting is now `navFollowCursor` and covers caret movement as well as depth changes.

## Verification

- `npx vitest run tests/editor` → **220 files, 2396 tests passed** (baseline 2383).
- `npm run typecheck` → clean.
- `npm run check:links` → `All 100 internal links resolve (9 docs).`

`tests/editor/nav-follow-cursor.test.ts` (13 cases) stubs the geometry jsdom doesn't have — rows a fixed height apart, a fixed viewport — and asserts the offsets the panel computes: the bottom clamp, the collapsed-away fallback, the minimum-distance reveal, and the two anti-fighting guarantees (an already-visible row isn't touched; moving within one section doesn't scroll). The highlight fix is asserted with the setting **off**, where it belongs.

One honest gap: the flag-OFF scroll reset can't be observed in jsdom, which stores `scrollTop` as a plain number and never re-clamps it when the list is emptied — the browser's "wipe the list, lose the offset" simply doesn't happen there. Those cases assert instead that the panel never writes `scrollTop`, which is the pre-existing path a real browser turns into a snap-to-top.

Docs updated: `MANUAL.md`, `CHANGELOG.md`, `DETAILED_CHANGELOG.md`.

Both changelogs add an `## Unreleased` heading at the top, which will conflict trivially with #37 — whichever merges second.
