### PR TITLE
Live read time for what is left to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ changes in each release, written for users of the editor. For
 in-depth rationale and implementation context behind each entry,
 see `DETAILED_CHANGELOG.md`.
 
+## Unreleased
+
+### Added
+
+- **The status bar can show how much is left to read.** Turn on
+  **Settings → General → "Live read time for what is left to read"**
+  and the bottom bar gains a third readout — every read-aloud word from
+  your cursor to the end of the document, with each of your top two
+  readers' times for it. Handy mid-speech, or for checking whether the
+  rest of a block fits the time you have left. Off by default; with
+  text selected it measures from the end of the selection, and it stays
+  quick on long files.
+
 ## 1.1.0 — 2026-08-18
 
 ### Added

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -5,6 +5,49 @@ behavior, rationale, and (where useful) the implementation context
 behind a change. For a shorter, jargon-free summary of what's new
 in each release, see `CHANGELOG.md`.
 
+## Unreleased
+
+### Added: live remaining read time (third readout segment)
+
+`src/editor/live-read-time.ts` gains `remainingReadSegment(state)`, a
+sibling of `liveContainerSegment` behind the new `liveRemainingReadTime`
+setting (boolean, **default off**, General → Word counts, `kind:
+'toggle'` so it also gets a command-palette toggle). It appends a third
+pipe-joined segment — `Left: 1,204 · Amy: 6:31 · Ben: 5:44` — counting
+the read-aloud words from the cursor to the end of the document. The
+predicate is the existing one (`countReadAloudSplit`): nothing new
+decides what "readable" means, so the three segments can never disagree
+about which words a reader says out loud.
+
+Measured from `selection.to`, not `from`: the end of a selection is the
+furthest point the user has accounted for, so a selection reads as
+"I've been through this much" and the remainder starts after it. With a
+bare cursor the two coincide.
+
+The cost model is the point of the design. Counted directly, a suffix
+is O(doc − cursor) on **every cursor move and every keystroke** — an
+arrow key near the top of a large brief would pay a full document walk,
+which is exactly the regression the container segment was built to
+avoid. Instead a **suffix-sum table over the doc's top-level children**
+is built once per doc: for each child index `i`, the `ReadAloudCounts`
+of children `i..end`. Building it is one O(doc) pass — the same cost the
+whole-doc readout already pays per doc change. A cursor move is then
+`$pos.index(0)` (O(depth)) to find the child the cursor sits in, the
+table's suffix total for the next child on, plus one partial count of
+that single child. Never O(doc). The table is a one-slot module cache
+keyed on the doc NODE identity, matching the container cache's pattern:
+an edit produces a new node, so a stale table cannot be served for a
+changed doc.
+
+Both readouts compose in the same two mirrored places
+(`src/editor/index.ts` `refreshWordCount`, `multi-pane-shell.ts`
+`refreshWordCount`), which now build a segment list and drop the nulls
+rather than nesting conditionals — so container-off/remaining-on reads
+`Doc: … | Left: …` in scope order. The selection-only refresh gates in
+both surfaces take the new setting alongside `liveContainerReadTime`:
+the cursor is what the count runs from, so a plain caret move has to
+recompute.
+
 ## 1.1.0 — 2026-08-18
 
 ### Added: guided UI tour (spotlight onboarding)

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1024,6 +1024,18 @@ count is cached per container, so moving the cursor doesn't re-count
 anything). Turning it off restores the plain whole-doc readout exactly
 as it was.
 
+A third readout — **what's left to read** — is available and **off by
+default**: turn on **Settings → General → "Live read time for what is
+left to read"** and the bar appends everything still ahead of your
+cursor, from the cursor to the end of the document, with each reader's
+time for it: `Doc: 1,234 · Amy: 8:12 | Card: 42 · Amy: 0:31 | Left: 806
+· Amy: 5:20`. Only read-aloud text counts, same as every other readout,
+so trimming highlights lowers it. Select text and it measures from the
+**end** of the selection — a selection reads as "I've been through this
+much". It's cheap on large files too: CardMirror keeps a running total
+per section of the document, so moving the cursor only re-counts the
+card or paragraph it lands in.
+
 By default the primary readout always reflects the **whole document**.
 Turn on **Settings → General → "Live selection word count"** to have the
 bar switch to the **selection's** word count and read time the moment you
@@ -2028,6 +2040,10 @@ headers shown inside each tab.
 - **Live word count for the current selection** — off by default. When
   on, the status bar's count and read time follow your selection as you
   change it; leave it off on very large docs if you notice drag lag.
+- **Live read time for what is left to read** — off by default. When on,
+  the status bar appends everything still ahead of the cursor (measured
+  from the end of a selection); cheap even on large files
+  (see [Read-time estimates](#read-time-estimates)).
 
 **Find**
 

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -306,7 +306,7 @@ import {
   formatNumber,
   type ReadAloudCounts,
 } from './word-count.js';
-import { liveContainerSegment } from './live-read-time.js';
+import { liveContainerSegment, remainingReadSegment } from './live-read-time.js';
 import { getHost, getElectronHost, isWindowsHost, isSameOpenHandle, type OpenedFile, type JournalEntry } from './host/index.js';
 import {
   installGlobalErrorSurface,
@@ -4802,10 +4802,16 @@ function refreshWordCount(opts?: { selectionOnly?: boolean }): void {
   for (const r of readers) {
     parts.push(`${r.name}: ${formatReadTimeFor(counts, r)}`);
   }
-  const container = liveContainerSegment(view.state);
-  wordCountText.textContent = container
-    ? `${parts.join(' · ')} | ${container}`
-    : parts.join(' · ');
+  // Segments are pipe-joined in scope order — whole doc, the enclosing
+  // container, what's left — and each is independently optional, so the
+  // join filters rather than nesting conditionals (container off with
+  // remaining on reads "Doc: … | Left: …").
+  const segments = [
+    parts.join(' · '),
+    liveContainerSegment(view.state),
+    remainingReadSegment(view.state),
+  ].filter((s): s is string => s !== null);
+  wordCountText.textContent = segments.join(' | ');
 }
 
 /**
@@ -5553,14 +5559,18 @@ function mountView(doc: PMNode, threads: Thread[] = []): void {
       // it when a range is involved on either side (plain cursor moves
       // can't change a selection count); `liveContainerReadTime` needs
       // every selection change, cursor moves included — the enclosing
-      // container follows the caret. Both reuse the cached whole-doc
-      // count (no doc walk), and the container count is itself cached
-      // per container, so an empty→empty move costs an ancestor walk.
+      // container follows the caret, and so does `liveRemainingReadTime`'s
+      // "what's left" boundary. All three reuse the cached whole-doc
+      // count (no doc walk); the container count is itself cached per
+      // container and the remaining count reads a per-doc suffix table,
+      // so an empty→empty move costs an ancestor walk plus at most one
+      // top-level child.
       else if (
         !prevState.selection.eq(next.selection) &&
         ((settings.get('liveSelectionWordCount') &&
           (!prevState.selection.empty || !next.selection.empty)) ||
-          settings.get('liveContainerReadTime'))
+          settings.get('liveContainerReadTime') ||
+          settings.get('liveRemainingReadTime'))
       ) {
         refreshWordCount({ selectionOnly: true });
       }

--- a/src/editor/live-read-time.ts
+++ b/src/editor/live-read-time.ts
@@ -1,6 +1,8 @@
 /**
  * Live enclosing-container read time — the second segment of the
- * word-count readouts (`liveContainerReadTime`, default on).
+ * word-count readouts (`liveContainerReadTime`, default on) — and the
+ * live remaining read time, the third (`liveRemainingReadTime`,
+ * default off).
  *
  * With the cursor parked (no selection), the bars append the read time
  * of the SMALLEST container enclosing it: the card, the analytic unit,
@@ -15,11 +17,32 @@
  * unless `liveSelectionWordCount` is on, in which case the PRIMARY
  * readout already is the selection and the segment is dropped.
  *
+ * The remaining segment answers "how much is left to read?" — the
+ * read-aloud words from the cursor to the end of the doc, same
+ * predicate, same per-reader times. Off by default: it's a speech-prep
+ * readout, not something every user wants in the bar.
+ *
  * Shared by the single-pane status bar and the three-pane pane footers
- * so the two readouts cannot diverge. The container count is cached on
- * (doc identity, range): cursor moves WITHIN a container reuse it, so
- * per-keypress cost is an ancestor walk, and crossing into a different
- * container costs one O(container) count — never O(doc).
+ * so the two readouts cannot diverge. Both segments are built to keep
+ * a cursor move off the O(doc) path:
+ *
+ *   - The container count is cached on (doc identity, range): cursor
+ *     moves WITHIN a container reuse it, so per-keypress cost is an
+ *     ancestor walk, and crossing into a different container costs one
+ *     O(container) count — never O(doc).
+ *   - The remaining count would be O(doc − cursor) if counted
+ *     directly, i.e. O(doc) on every arrow key near the top of a brief.
+ *     Instead a SUFFIX-SUM TABLE over the doc's top-level children is
+ *     built once per doc — one O(doc) pass, the same cost the whole-doc
+ *     readout already pays per doc change — holding, for each child
+ *     index `i`, the read-aloud counts of children `i..end`. A cursor
+ *     move then costs `$pos.index(0)` (O(depth)) plus one partial count
+ *     of just the child the cursor sits in (O(that child)), added to
+ *     the table's suffix total for the next child on. Never O(doc).
+ *
+ * Both caches are one slot keyed on the doc NODE identity, so a stale
+ * entry cannot survive a doc change: any transaction that changes the
+ * doc produces a new node, and the key misses.
  */
 
 import type { EditorState } from 'prosemirror-state';
@@ -117,9 +140,97 @@ export function liveContainerSegment(state: EditorState): string | null {
     label = container.label;
     counts = countCached(state.doc, container.from, container.to);
   }
+  return formatSegment(label, counts);
+}
+
+/** One segment's text: the labelled word count plus the first two
+ *  readers' times, exactly as the primary readout formats its own. */
+function formatSegment(label: string, counts: ReadAloudCounts): string {
   const parts = [`${label}: ${formatNumber(totalWords(counts))}`];
   for (const r of settings.get('readers').slice(0, 2)) {
     parts.push(`${r.name}: ${formatReadTimeFor(counts, r)}`);
   }
   return parts.join(' · ');
+}
+
+/**
+ * Suffix sums of read-aloud counts over the doc's top-level children.
+ * `starts[i]` is child `i`'s doc position; `suffix[i]` is the counts of
+ * children `i` through the end, so `suffix[0]` is the whole doc and
+ * `suffix[childCount]` is zero (the slot that makes "cursor in the last
+ * child" need no special case).
+ */
+interface SuffixTable {
+  starts: number[];
+  suffix: ReadAloudCounts[];
+}
+
+let suffixCache: { doc: PMNode; table: SuffixTable } | null = null;
+
+/** Build (or reuse) the doc's suffix table. Building is one O(doc)
+ *  walk; the cache key is the doc node itself, so an edit produces a
+ *  new node, misses, and forces the rebuild — a stale table can never
+ *  be served for a changed doc. */
+function suffixTable(doc: PMNode): SuffixTable {
+  if (suffixCache && suffixCache.doc === doc) return suffixCache.table;
+  const n = doc.childCount;
+  const starts: number[] = new Array(n);
+  const suffix: ReadAloudCounts[] = new Array(n + 1);
+  const perChild: ReadAloudCounts[] = new Array(n);
+  let pos = 0;
+  for (let i = 0; i < n; i++) {
+    const child = doc.child(i);
+    starts[i] = pos;
+    // Counted with the CHILD as the root, not a doc-coordinate range:
+    // a doc-level `nodesBetween` rescans the preceding siblings to find
+    // the window, which would make building the table quadratic in the
+    // number of top-level children. The predicate is unaffected — it
+    // reads each text node's own parent, which is inside the child.
+    perChild[i] = countReadAloudSplit(child);
+    pos += child.nodeSize;
+  }
+  suffix[n] = { body: 0, other: 0 };
+  for (let i = n - 1; i >= 0; i--) {
+    const next = suffix[i + 1]!;
+    const own = perChild[i]!;
+    suffix[i] = { body: own.body + next.body, other: own.other + next.other };
+  }
+  const table = { starts, suffix };
+  suffixCache = { doc, table };
+  return table;
+}
+
+/** Read-aloud counts from `pos` to the end of the doc. O(depth) plus
+ *  one count of the single top-level child holding `pos`. */
+function countRemaining(doc: PMNode, pos: number): ReadAloudCounts {
+  const table = suffixTable(doc);
+  const n = doc.childCount;
+  // `index(0)` is the number of top-level children entirely before
+  // `pos`: inside child i it's i, and at the very end of the doc it's
+  // childCount — which lands on the zero slot and short-circuits.
+  const i = Math.max(0, Math.min(doc.resolve(pos).index(0), n));
+  if (i >= n) return { ...table.suffix[n]! };
+  const rest = table.suffix[i + 1]!;
+  const child = doc.child(i);
+  // Child-relative again (same reason as the build): the child's own
+  // content starts one position after the child does, so a doc position
+  // `p` inside it sits at `p - start - 1`. A position resting ON the
+  // child's boundary — a node selection's end, a gap cursor — is one
+  // before that, and clamps to counting the child whole, which is what
+  // "nothing of it has been read yet" should mean.
+  const rel = Math.max(0, pos - table.starts[i]! - 1);
+  const partial = countReadAloudSplit(child, rel, child.content.size);
+  return { body: partial.body + rest.body, other: partial.other + rest.other };
+}
+
+/** The readout tail for what's still unread ("Left: 1,204 · Amy: 6:31 ·
+ *  Ben: 5:44"), or null when the feature is off. Callers join it after
+ *  the container segment with " | ". */
+export function remainingReadSegment(state: EditorState): string | null {
+  if (!settings.get('liveRemainingReadTime')) return null;
+  // Measured from `selection.to`, not `from`: the end of a selection is
+  // the furthest point the user has accounted for, so a selection reads
+  // as "I've gone through this much" and what's left starts after it.
+  // With a bare cursor the two coincide.
+  return formatSegment('Left', countRemaining(state.doc, state.selection.to));
 }

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -65,7 +65,7 @@ import {
   formatNumber,
   type ReadAloudCounts,
 } from './word-count.js';
-import { liveContainerSegment } from './live-read-time.js';
+import { liveContainerSegment, remainingReadSegment } from './live-read-time.js';
 import { openWordCount } from './word-count-ui.js';
 import { isAutosaveOnForPath, setAutosaveForPath } from './autosave-prefs-store.js';
 import {
@@ -1190,10 +1190,14 @@ class Slot {
     for (const r of readers) {
       parts.push(`${r.name}: ${formatReadTimeFor(counts, r)}`);
     }
-    const container = liveContainerSegment(rec.view.state);
-    this.wcEl.textContent = container
-      ? `${parts.join(' · ')} | ${container}`
-      : parts.join(' · ');
+    // Pipe-joined in scope order — whole doc, enclosing container,
+    // what's left — each independently optional, mirroring single-pane.
+    const segments = [
+      parts.join(' · '),
+      liveContainerSegment(rec.view.state),
+      remainingReadSegment(rec.view.state),
+    ].filter((s): s is string => s !== null);
+    this.wcEl.textContent = segments.join(' | ');
   }
 
   /** Open a small dropdown over the chip listing every doc in this
@@ -3161,14 +3165,17 @@ function buildDocRecord(
       // mirroring single-pane. `liveSelectionWordCount` needs it only
       // when a range is involved on either side; `liveContainerReadTime`
       // needs every selection change, cursor moves included — the
-      // enclosing container follows the caret. Cheap either way: the
-      // whole-doc count is cached per doc, the container count per
-      // container.
+      // enclosing container follows the caret, as does the boundary
+      // `liveRemainingReadTime` counts forward from. Cheap either way:
+      // the whole-doc count is cached per doc, the container count per
+      // container, and the remaining count comes off a per-doc suffix
+      // table plus one top-level child.
       else if (
         !prevState.selection.eq(next.selection) &&
         ((settings.get('liveSelectionWordCount') &&
           (!prevState.selection.empty || !next.selection.empty)) ||
-          settings.get('liveContainerReadTime'))
+          settings.get('liveContainerReadTime') ||
+          settings.get('liveRemainingReadTime'))
       ) {
         record.owner.refreshWordCount();
       }

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -914,6 +914,15 @@ export interface Settings {
    */
   liveContainerReadTime: boolean;
   /**
+   * Append a third segment to the live word-count readout: the
+   * read-aloud words still ahead of the cursor, with the same per-reader
+   * times ("what's left to read"). Off by default. Measured from the
+   * selection's end, so a selection counts as already read. Cheap — a
+   * suffix-sum table over the doc's top-level children is built once per
+   * doc, so a cursor move only counts the child it lands in.
+   */
+  liveRemainingReadTime: boolean;
+  /**
    * Per-style font sizes (in points). See DisplaySizes for details.
    * Each field becomes a CSS custom property on `#editor`.
    */
@@ -1670,6 +1679,7 @@ const DEFAULTS: Settings = {
   ],
   liveSelectionWordCount: false,
   liveContainerReadTime: true,
+  liveRemainingReadTime: false,
   displaySizes: { ...DEFAULT_DISPLAY_SIZES },
   displayParagraphSpacing: { ...DEFAULT_PARAGRAPH_SPACING },
   displayTypography: { ...DEFAULT_DISPLAY_TYPOGRAPHY },
@@ -2116,6 +2126,16 @@ export const SETTING_METADATA: SettingMeta[] = [
     category: 'general',
     section: 'Word counts',
     aliases: ['container read time', 'card read time', 'block read time', 'enclosing read time'],
+  },
+  {
+    key: 'liveRemainingReadTime',
+    label: 'Live read time for what is left to read',
+    description:
+      "Off by default. Appends one more segment to the bottom bar's word count: everything still ahead of your cursor — the read-aloud words from the cursor to the end of the document, with each reader's time for them. With text selected it measures from the end of the selection, so a selection counts as already read. Cheap even on large files: the count is built from a suffix table over the document, so moving the cursor only re-counts the card or paragraph it lands in.",
+    kind: 'toggle',
+    category: 'general',
+    section: 'Word counts',
+    aliases: ['time left', 'remaining read time', 'words left', 'unread words'],
   },
   {
     key: 'findRememberLastQuery',
@@ -4195,6 +4215,7 @@ function sanitize(s: Settings): Settings {
     // Default-on: preserve `false` only when explicitly set, so
     // installs upgrading from before this setting existed get it on.
     liveContainerReadTime: s.liveContainerReadTime === false ? false : true,
+    liveRemainingReadTime: s.liveRemainingReadTime === true,
     displaySizes: sanitizeDisplaySizes(s.displaySizes),
     displayParagraphSpacing: sanitizeParagraphSpacing(s.displayParagraphSpacing),
     displayTypography: sanitizeDisplayTypography(s.displayTypography),

--- a/tests/editor/live-read-time.test.ts
+++ b/tests/editor/live-read-time.test.ts
@@ -8,16 +8,22 @@
  * headings and loose doc-level content show nothing (design call,
  * 2026-07-26). With `liveSelectionWordCount` on, a selection is
  * already the primary readout, so the segment is dropped.
+ *
+ * Also the remaining read time (`liveRemainingReadTime`, default off):
+ * the third segment counts the read-aloud words still ahead of the
+ * cursor, off the per-doc suffix table.
  */
 
-import { describe, expect, it, afterEach } from 'vitest';
-import { EditorState, TextSelection } from 'prosemirror-state';
+import { describe, expect, it, afterEach, beforeEach } from 'vitest';
+import { EditorState, NodeSelection, TextSelection } from 'prosemirror-state';
 import type { Node as PMNode } from 'prosemirror-model';
 import { schema, newHeadingId } from '../../src/schema/index.js';
 import {
   findEnclosingContainer,
   liveContainerSegment,
+  remainingReadSegment,
 } from '../../src/editor/live-read-time.js';
+import { countReadAloudSplit, totalWords } from '../../src/editor/word-count.js';
 import { settings } from '../../src/editor/settings.js';
 
 function tag(text: string): PMNode {
@@ -64,6 +70,7 @@ function textOfRange(state: EditorState, c: { from: number; to: number }): strin
 
 afterEach(() => {
   settings.set('liveContainerReadTime', true);
+  settings.set('liveRemainingReadTime', false);
   settings.set('liveSelectionWordCount', false);
   settings.set('readers', [
     { name: 'Reader 1', wpm: 200 },
@@ -163,5 +170,175 @@ describe('liveContainerSegment', () => {
     expect(liveContainerSegment(sel)).toMatch(/^Sel: \d/);
     settings.set('liveSelectionWordCount', true);
     expect(liveContainerSegment(sel)).toBeNull();
+  });
+});
+
+describe('remainingReadSegment', () => {
+  const m = schema.marks;
+  const hl = () => m['highlight']!.create();
+  const shaded = () => m['shading']!.create();
+
+  /**
+   * A doc whose top-level children mix every read-aloud kind with the
+   * kinds that must NOT count — plain body text and shaded highlight.
+   * Read-aloud totals: body 9 (4 + 2 + 3), other 7 (3 tag + 2 tag +
+   * 2 cite) = 16, against 27 words of raw text.
+   */
+  function fixture(): PMNode[] {
+    return [
+      heading('block', 'Block One'),
+      schema.nodes['card']!.createChecked(null, [
+        tag('ALPHA TAG HERE'),
+        schema.nodes['card_body']!.create(null, [
+          schema.text('one two three four', [hl()]),
+          schema.text(' plain unread words'),
+          schema.text(' shaded skip here', [hl(), shaded()]),
+        ]),
+      ]),
+      schema.nodes['paragraph']!.create(null, schema.text('five six', [hl()])),
+      schema.nodes['card']!.createChecked(null, [
+        tag('BETA TAG'),
+        schema.nodes['cite_paragraph']!.create(null, [
+          schema.text('Smith 25', [m['cite_mark']!.create()]),
+          schema.text(' filler text here'),
+        ]),
+        schema.nodes['card_body']!.create(null, schema.text('seven eight nine', [hl()])),
+      ]),
+    ];
+  }
+
+  const doc = schema.nodes['doc']!.createChecked(null, fixture());
+
+  /** Doc position where `needle` starts. */
+  function textStart(node: PMNode, needle: string): number {
+    let at = -1;
+    node.descendants((child, pos) => {
+      if (at >= 0) return false;
+      const text = child.text ?? '';
+      if (child.isText && text.includes(needle)) {
+        at = pos + text.indexOf(needle);
+        return false;
+      }
+      return true;
+    });
+    if (at < 0) throw new Error(`text "${needle}" not found`);
+    return at;
+  }
+
+  function cursorAt(node: PMNode, pos: number): EditorState {
+    return EditorState.create({ doc: node, selection: TextSelection.create(node, pos) });
+  }
+
+  /** The number the segment leads with. */
+  function left(state: EditorState): number {
+    const seg = remainingReadSegment(state);
+    if (seg === null) throw new Error('segment is off');
+    const match = /^Left: ([\d,]+) /.exec(seg);
+    if (!match) throw new Error(`unexpected segment "${seg}"`);
+    return Number(match[1]!.replace(/,/g, ''));
+  }
+
+  beforeEach(() => {
+    settings.set('liveRemainingReadTime', true);
+    settings.set('readers', [
+      { name: 'Amy', wpm: 200 },
+      { name: 'Ben', wpm: 100 },
+      { name: 'Cal', wpm: 300 },
+    ]);
+  });
+
+  it('gates on the setting', () => {
+    settings.set('liveRemainingReadTime', false);
+    expect(remainingReadSegment(cursorAt(doc, textStart(doc, 'five six')))).toBeNull();
+  });
+
+  it('renders label, count, and the first two readers', () => {
+    const seg = remainingReadSegment(cursorAt(doc, textStart(doc, 'five six')))!;
+    expect(seg).toMatch(/^Left: \d/);
+    expect(seg).toContain('Amy: ');
+    expect(seg).toContain('Ben: ');
+    expect(seg).not.toContain('Cal'); // first two readers only
+  });
+
+  it('cursor at the doc start counts the whole doc', () => {
+    const state = EditorState.create({ doc, selection: TextSelection.atStart(doc) });
+    expect(left(state)).toBe(totalWords(countReadAloudSplit(doc)));
+    expect(left(state)).toBe(16);
+  });
+
+  it('cursor at the doc end counts nothing', () => {
+    const state = EditorState.create({ doc, selection: TextSelection.atEnd(doc) });
+    expect(left(state)).toBe(0);
+  });
+
+  it('counts only read-aloud words ahead of the cursor', () => {
+    // Mid-card: the rest of the highlighted run (4) + the loose
+    // highlighted paragraph (2) + the last card's tag, cite, and body
+    // (2 + 2 + 3).
+    expect(left(cursorAt(doc, textStart(doc, 'one two three four')))).toBe(13);
+    // Parked right before the plain text: what's left is the loose
+    // paragraph and the last card — the plain run and the shaded
+    // highlight after it are silent, exactly as the read-aloud
+    // predicate says.
+    expect(left(cursorAt(doc, textStart(doc, 'plain unread words')))).toBe(9);
+    // Inside the last card's cite: the cite's own filler doesn't count,
+    // the body after it does.
+    expect(left(cursorAt(doc, textStart(doc, 'filler text here')))).toBe(3);
+  });
+
+  it('a selection measures from its end — what precedes it reads as read', () => {
+    const from = textStart(doc, 'one two three four');
+    const state = EditorState.create({
+      doc,
+      // Through "one two ", leaving "three four" of the run ahead.
+      selection: TextSelection.create(doc, from, from + 8),
+    });
+    expect(left(state)).toBe(11);
+    // …and NOT the 13 a from-anchored count would report.
+    expect(left(cursorAt(doc, from))).toBe(13);
+  });
+
+  it('a node selection ends on a child boundary — everything after it is left', () => {
+    // `to` lands between two top-level children (depth 0), the one
+    // position the child-relative math has to clamp.
+    const at = textStart(doc, 'five six') - 1;
+    const state = EditorState.create({ doc, selection: NodeSelection.create(doc, at) });
+    expect(left(state)).toBe(7); // just the last card
+  });
+
+  it('recounts after an edit — the suffix table is keyed on the doc', () => {
+    const at = textStart(doc, 'five six');
+    const before = cursorAt(doc, at);
+    expect(left(before)).toBe(9);
+    // Three more highlighted words, inserted AFTER the cursor so the
+    // selection maps to the same place. A table surviving the edit
+    // would still say 9.
+    const insertAt = textStart(doc, 'seven eight nine');
+    const after = before.apply(
+      before.tr.replaceWith(insertAt, insertAt, schema.text('ten eleven twelve ', [hl()])),
+    );
+    expect(after.selection.from).toBe(at);
+    expect(left(after)).toBe(12);
+    // The original doc still counts 9 — rebuilding for the new doc
+    // didn't poison the old answer.
+    expect(left(cursorAt(doc, at))).toBe(9);
+  });
+
+  it('composes as the third segment, after the container one', () => {
+    const state = cursorAt(doc, textStart(doc, 'one two three four'));
+    const container = liveContainerSegment(state);
+    const remaining = remainingReadSegment(state);
+    expect(container).toMatch(/^Card: /);
+    expect(remaining).toMatch(/^Left: /);
+    // The bars join in scope order, skipping whatever is off (the join
+    // itself lives in index.ts / multi-pane-shell.ts).
+    const segments = ['Doc: 16 · Amy: 0:04 · Ben: 0:09', container, remaining].filter(
+      (s): s is string => s !== null,
+    );
+    expect(segments.join(' | ')).toMatch(/^Doc: .+ \| Card: .+ \| Left: .+$/);
+    // Container off, remaining on → two segments, still in order.
+    settings.set('liveContainerReadTime', false);
+    expect(liveContainerSegment(state)).toBeNull();
+    expect(remainingReadSegment(state)).toMatch(/^Left: /);
   });
 });


### PR DESCRIPTION
The bottom bar answers "how long is this document?" and "how long is the card I'm in?", but not the question you actually have mid-speech: **how much is left?** The doc total stops being useful the moment you start reading, and counting the rest by eye means adding up cards.

## The setting

**Live read time for what is left to read** — Settings → General → Word counts, **off by default**. On, the readout gains a third segment:

`Doc: 4,201 · Amy: 21:00 · Ben: 18:11 | Card: 142 · Amy: 0:42 · Ben: 0:37 | Left: 1,204 · Amy: 6:31 · Ben: 5:44`

Everything from the cursor to the end of the document, same per-reader times. "Readable" is the existing read-aloud predicate — `countReadAloudSplit` — so nothing new decides which words a reader says out loud and the three segments can't disagree.

With text selected it measures from `selection.to`, not `from`: the end of a selection is the furthest point the user has accounted for, so a selection reads as "I've been through this much". With a bare cursor the two coincide.

Being `kind: 'toggle'` in the registry, it also picks up a command-palette toggle for free ("time left" is an alias, since that's what people call it).

## Implementation notes

The cost model is the design. Counted directly a suffix is `O(doc − cursor)` on **every cursor move and every keystroke** — an arrow key near the top of a large brief would pay a full document walk, exactly the regression the enclosing-container segment was built to avoid.

Instead `src/editor/live-read-time.ts` keeps a **suffix-sum table over the doc's top-level children**: for each child index `i`, the `ReadAloudCounts` of children `i..end`. Building it is one `O(doc)` pass — the same cost the whole-doc readout already pays per doc change — and it's only rebuilt when the doc changes. A cursor move is then `$pos.index(0)` (O(depth)), the table's suffix total for the next child on, plus one partial count of the single child the cursor sits in. Never O(doc).

Both the build and that partial count run **child-relative** rather than over doc coordinates: a doc-level `nodesBetween` rescans the preceding siblings to find its window, which would make building the table quadratic in the number of top-level children. The predicate is unaffected — it reads each text node's own parent, which lives inside the child.

The table is a one-slot module cache keyed on the doc **node identity**, matching the container cache's pattern: an edit produces a new node, so a stale table can never be served for a changed doc (there's a test that asserts the recount rather than a stale number).

Composition: both `refreshWordCount`s (`src/editor/index.ts`, `src/editor/multi-pane-shell.ts`) now build a segment list and drop the nulls instead of nesting conditionals, so container-off/remaining-on reads `Doc: … | Left: …` in scope order. Both selection-only refresh gates take the new setting alongside `liveContainerReadTime` — the cursor is what the count runs from, so a plain caret move has to recompute.

## Verification

`tests/editor` passes (2392 tests, 219 files), `check:links` clean (101 links, 9 docs). `tsc --noEmit` reports the same 10 pre-existing `apps/desktop` errors as `main` in this checkout (`Cannot find module 'electron'` and its knock-on implicit-anys — electron isn't installed here); zero new errors, verified by re-running against a stashed tree.

New tests in `tests/editor/live-read-time.test.ts` cover: setting off → null; label/count/first-two-readers; cursor at doc start equals the whole-doc count; cursor at doc end is zero; a mixed doc (highlighted body, plain body, shaded highlight, tags, cite runs) counting only the read-aloud remainder; a selection measuring from its end and not its start; a node selection landing on a top-level child boundary (the one position the child-relative math clamps); an edit forcing a recount; and both segments on composing in order.

## Docs updated

`MANUAL.md` (Read-time estimates + the Settings reference), `CHANGELOG.md`, `DETAILED_CHANGELOG.md`.

**Merge note:** both changelogs add a new `## Unreleased` heading at the top, which will conflict trivially with the sibling PR (nav-pane place preservation) — whichever merges second just keeps the one heading and both bullets under it.
