### PR TITLE
Small UX fixes

### DIFF
--- a/src/editor/color-panel.ts
+++ b/src/editor/color-panel.ts
@@ -584,6 +584,10 @@ function openPicker(
     if (!openPickerEl) return;
     const target = e.target as Node | null;
     if (target && openPickerEl.contains(target)) return;
+    // The trigger is part of the open picker's owned surface. Let its later
+    // click handler perform the same-control toggle; closing here first would
+    // clear `openPickerEl`, so that click would immediately open a new picker.
+    if (target && anchor.contains(target)) return;
     closeOpenPicker();
   };
   const onKey = (e: KeyboardEvent) => {

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -5699,9 +5699,9 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
 
 /* Tab bar below the header. The bar wraps the tab nav and a
    left/right arrow on each side — the arrows are revealed by JS
-   only when the tab list overflows its container. Active tab is
-   indicated by a bottom border + heavier weight (border lives on
-   the bar so the active-tab border can overlay it). */
+   only when the tab list overflows its container. The active tab is
+   indicated by color + a bottom border (the border lives on the bar
+   so the active-tab border can overlay it). */
 .pmd-settings-tabs-bar {
   display: flex;
   flex: 0 0 auto;

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -6900,28 +6900,34 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
 #ribbon .ribbon-doc-menu-btn {
   height: 1.45rem;
   width: auto;
-  padding: 0 0.5rem;
+  /* Compact side padding leaves room for each label and chevron
+     without letting either intrude into the button's padding box. */
+  padding: 0 0.25rem;
   font-size: 0.78rem;
   line-height: 1;
+  justify-content: space-between;
+  gap: 0.12rem;
 }
 
-/* Doc / Card dropdown-arrow chevron — gray to match the color-panel
-   arrows. Only the A▴ / A▾ font-size increment / decrement buttons
-   keep black arrows (they're action buttons, not dropdown triggers).
-   Margin-left because the smaller font-size on the chevron span
-   would otherwise eat the visual space between "Doc" / "Card" and
-   the arrow. */
+/* Table's fixed two-track width is about 1.2px narrower than the
+   intrinsic label + icon + gap at the shared padding. Release that
+   final fraction so both visual insets remain equal. */
+#ribbon .ribbon-doc-menu-btn.ribbon-format-table-btn {
+  padding-inline: 0.2rem;
+}
+
+/* Doc / Card / Table dropdown-arrow chevron — gray to match the
+   color-panel arrows. The button owns the inter-item gap, so this icon
+   can occupy the same stable right-hand position for every label. */
 .ribbon-doc-menu-arrow {
   color: var(--pmd-c-text-secondary);
   font-size: 0.65rem;
-  margin-left: 0.35rem;
 }
-/* The modern chevron icon reads wider / heavier than the classic ▾
-   glyph (which has its own side-bearing), so the Table / Doc / Card
-   dropdowns feel cramped only in modern mode. Pull the arrow closer to
-   its label there to free up room at the button edges. */
+/* `.pmd-icon`'s normal -0.125em baseline correction has no effect when
+   the icon is a flex item. Reapply that optical offset in modern mode;
+   the classic ▾ is a text glyph with its own baseline and side-bearing. */
 :root[data-icons='modern'] .ribbon-doc-menu-arrow {
-  margin-left: 0.12rem;
+  transform: translateY(0.125em);
 }
 
 .pmd-doc-menu {

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -878,7 +878,7 @@ button {
   --pmd-c-text-muted: #9a9a9a;
   --pmd-c-text-faint: #7a7a7a;
   --pmd-c-text-on-accent: #fff;
-  --pmd-c-segmented-selected-text: #000;
+  --pmd-c-segmented-selected-text: #fff;
 
   /* Hover / press — solid surfaces lift toward lighter grays;
      button-* overlays flip to translucent WHITE so they brighten

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -629,6 +629,7 @@ button {
   --pmd-c-text-muted: #666;            /* dimmer secondary */
   --pmd-c-text-faint: #888;            /* faint annotations */
   --pmd-c-text-on-accent: #fff;        /* text on a filled accent surface */
+  --pmd-c-segmented-selected-text: #fff; /* selected segmented-control text */
   /* Card numbering glyphs. Defaults to muted text (theme-aware via the var),
      but is its OWN token so it's user-overridable — see CUSTOMIZABLE_COLOR_TOKENS
      ('pmd-c-card-number') and the Card numbering settings color control. */
@@ -877,6 +878,7 @@ button {
   --pmd-c-text-muted: #9a9a9a;
   --pmd-c-text-faint: #7a7a7a;
   --pmd-c-text-on-accent: #fff;
+  --pmd-c-segmented-selected-text: #000;
 
   /* Hover / press — solid surfaces lift toward lighter grays;
      button-* overlays flip to translucent WHITE so they brighten
@@ -1328,7 +1330,6 @@ html:has(body.pmd-speech-banner-visible) {
 /* Shared scaffolding (accent fill (2-prop)).
    Diverge by pulling a selector out, not by re-copying. */
 #ribbon #timer-toggle-btn[aria-pressed="true"],
-.pmd-theme-editor-btn[aria-pressed='true'],
 .pmd-pane-focused .pmd-pane-chip,
 :is(#ribbon, body.pmd-timer-popout-page) .pmd-timer-start[aria-pressed="true"] {
   background: var(--pmd-c-accent);
@@ -3535,8 +3536,17 @@ body.pmd-override-shading [data-shading] {
   font-size: 0.85rem;
   cursor: pointer;
 }
+.pmd-theme-editor-btn:not([aria-pressed='true']):hover {
+  background: var(--pmd-c-hover);
+}
+.pmd-theme-editor-btn[aria-pressed='true'] {
+  background: var(--pmd-c-accent);
+  color: var(--pmd-c-segmented-selected-text);
+}
+.pmd-theme-editor-btn[aria-pressed='true']:hover {
+  background: var(--pmd-c-accent-hover);
+}
 .pmd-theme-editor-btn:last-child { border-right: none; }
-.pmd-theme-editor-btn:hover { background: var(--pmd-c-hover); }
 
 
 /* Multi-slot color editor — highlight / shading display

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -5784,7 +5784,6 @@ html.pmd-nav-flat .pmd-nav-type-analytic:hover .pmd-nav-label {
 .pmd-settings-tab-active {
   color: var(--pmd-c-text-strong);
   border-bottom-color: var(--pmd-c-accent);
-  font-weight: 600;
 }
 
 .pmd-settings-list {

--- a/tests/editor/color-panel-picker-toggle.test.ts
+++ b/tests/editor/color-panel-picker-toggle.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+/**
+ * Color-picker trigger ownership: a second activation of the same arrow
+ * closes its picker. The pointerdown is important because the production
+ * outside-dismiss handler runs before the trigger's click handler.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { wireColorPanel } from '../../src/editor/color-panel.js';
+
+function buildRibbonStubs(): void {
+  const ids = [
+    'highlight-btn', 'highlight-picker-btn', 'highlight-bar',
+    'shading-btn', 'shading-picker-btn', 'shading-bar',
+    'fontcolor-btn', 'fontcolor-picker-btn', 'fontcolor-bar', 'fontcolor-glyph',
+  ];
+  for (const id of ids) {
+    const element = document.createElement(id.endsWith('-btn') ? 'button' : 'div');
+    element.id = id;
+    document.body.appendChild(element);
+  }
+}
+
+function activate(button: HTMLButtonElement): void {
+  button.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+  button.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+  button.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0 }));
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }));
+}
+
+describe('color-panel picker toggle', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    buildRibbonStubs();
+    wireColorPanel({ view: null });
+  });
+
+  afterEach(() => {
+    // Close a picker left open by a failed assertion so its document-level
+    // listeners do not leak into another test.
+    if (document.querySelector('.pmd-color-picker')) {
+      document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    }
+    document.body.replaceChildren();
+  });
+
+  it('closes an open picker when its arrow is activated again', () => {
+    const arrow = document.getElementById('highlight-picker-btn') as HTMLButtonElement;
+
+    activate(arrow);
+    expect(document.querySelector('.pmd-color-picker')).not.toBeNull();
+    expect(arrow.getAttribute('aria-expanded')).toBe('true');
+
+    activate(arrow);
+    expect(document.querySelector('.pmd-color-picker')).toBeNull();
+    expect(arrow.getAttribute('aria-expanded')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Changes

- Fixed a color picker dropdown toggle bug & added a regression test
- Align the Doc, Card, and Table menu chevrons (now aligns to text center instead of true center)
- Made sure active and hover state colors were contrast compatible for the settings
- Fixed width thrashing in the Settings nav/tab bar caused by bolded text