### PR TITLE
Debate Relay: coach dashboard, deploy blueprint, docs

### DIFF
--- a/README.debate-relay.md
+++ b/README.debate-relay.md
@@ -1,0 +1,149 @@
+# Debate Relay
+
+A free, self-hosted collaboration stack for debate programs, built on
+[CardMirror](./README.md).
+
+- **What it is:** CardMirror's live co-editing, but running on a relay
+  *you* deploy for free — plus the operational tooling (a coach
+  dashboard, a one-click deploy blueprint, and documentation) a program
+  needs to actually run it.
+- **License:** PolyForm Noncommercial 1.0.0 (inherited from CardMirror).
+  Debate-team and academic use are explicitly permitted.
+- **Status:** relay verified in production on one team. Dashboard built;
+  see the roadmap below.
+- **Cost:** $0. Credit cards required: none.
+
+> This document is the Debate Relay overlay. The repository's main
+> [`README.md`](./README.md) is CardMirror's own — the editor this is
+> built on.
+
+---
+
+## Findings first
+
+The setup you can reconstruct from the services' own docs. **These you
+can't** — they came from testing on live hardware, and they're the reason
+this is worth reading. Full detail in [`docs/findings.md`](./docs/findings.md).
+
+- **Rooms survive the host leaving.** Force-kill the machine that started
+  a session and the room lives on. A partner keeps editing while the host
+  is powered off; the host picks up those edits on return. Asynchronous
+  shared editing, for real.
+- **Ending a session is safe.** Whoever remains keeps the work as an
+  editable local document, journaled by CardMirror even if unsaved.
+  Saving makes work *visible to teammates* — it isn't what prevents loss.
+- **Reopening rejoins the live room.** You get your partner's edits made
+  while you were closed, not a stale local draft.
+- **Storage runs ~3.5× document size** (pre-compaction; steady state is
+  likely lower). ~30–40 concurrent documents fit the 500 MB free tier.
+- **Sessions hold 10**, enforced at stream connect (HTTP 409).
+
+### Traps that cost hours
+
+- **CardMirror Lite has no collaboration** — install the full desktop
+  build.
+- **Supabase: use the Session pooler string, not Direct** (Direct is
+  IPv6-only; Render dials IPv4 — silent failure).
+- **All machines must run the same CardMirror version.**
+- **The web editor needs a desktop-width window** (narrow = mobile
+  layout = no collaboration).
+- **Share codes are credentials** — they carry the room's read+write key.
+  Never in a group chat.
+
+---
+
+## Setup, second
+
+A non-technical coach can stand this up in about **35 minutes**. Full
+walkthrough: [`docs/setup.md`](./docs/setup.md).
+
+```
+  Students (Windows · Mac · Chromebook)            Coach's browser
+         │                                              │ (dashboard)
+         ├──► Google Shared Drive  (permanent file storage)
+         │
+         ▼ encrypted edits              read-only metadata ▼
+   ┌──────────────────────────┐   ┌──────────────────────────┐
+   │  RELAY — Render free tier │   │  POSTGRES — Supabase free │
+   │  stores & forwards        │◄──┤  rooms · updates ·        │
+   │  ciphertext; reads nothing│   │  snapshots · mailbox      │
+   └──────────────────────────┘   └──────────────────────────┘
+         ▲ /relay/health every 5 min
+   ┌──────────────────────┐
+   │  UptimeRobot (free)  │  prevents Render cold starts
+   └──────────────────────┘
+```
+
+| Piece | Service | Why this one |
+|---|---|---|
+| Relay | Render free tier | No credit card; deploys from the repo's Dockerfile |
+| Database | Supabase free tier | Permanent — Render's free Postgres is deleted after 30 days |
+| Keepalive | UptimeRobot free | Render sleeps after 15 min; waking takes ~60s |
+| File storage | Google Shared Drives | Schools already have it; native on ChromeOS |
+
+**Deploy:** click Render's *New → Blueprint*, point it at this repo. It
+reads [`render.yaml`](./render.yaml), generates a unique `RELAY_TOKEN`,
+and prompts for one connection string (`DATABASE_URL`). Wait for **Live**,
+copy the relay URL and token into every machine's **Settings →
+Collaboration**. **No fork required.**
+
+> **The division that matters:** Drive stores files, the relay carries
+> edits, and they never touch each other. Only the host has the file open,
+> so **only the host saves** — which is what prevents Drive conflict
+> copies. The relay is not backup: someone saves to Drive at the end of
+> every real work session. See [`docs/workflow.md`](./docs/workflow.md).
+
+---
+
+## Repository layout (Debate Relay parts)
+
+```
+relay/                 relay source (upstream, unmodified) + Dockerfile
+render.yaml            one-click Deploy-to-Render blueprint
+dashboard/             static coach dashboard + Supabase schema/RLS
+docs/
+  setup.md             35-minute coach walkthrough
+  workflow.md          rooms vs. Drive, who saves, team conventions
+  findings.md          the verified findings, expanded
+  troubleshooting.md   the traps + an error-to-cause table
+```
+
+---
+
+## The dashboard
+
+One page that answers: *is my relay up, which sessions exist, which are
+dying, am I running out of space* — without SQL. It's a **static site**
+(no backend, no build) that reads Supabase through the public **anon key
+under Row-Level Security**, so it can see room *metadata* but never
+document ciphertext. Adding a session keeps only the room ID from a share
+code and **discards the encryption key** — making it structurally unable
+to read student work. See [`dashboard/`](./dashboard/).
+
+Policies shipped in [`dashboard/schema.sql`](./dashboard/schema.sql):
+`relay_rooms` SELECT-only, `dashboard_registry` SELECT+INSERT, everything
+else no access (ciphertext stays private).
+
+---
+
+## Roadmap
+
+- **v1 — Metadata dashboard.** *(this repo)* Static page, anon key,
+  read-only.
+- **v1.1 — End-session action.** Once a privileged token exists that
+  isn't already in twenty students' hands. Pruning is done from inside
+  CardMirror until then.
+- **v2 — Per-student tokens.** A relay-only change: token → `{label,
+  role}`. Per-student revocation, coach-only destructive actions,
+  attribution, live participant names. *Propose upstream before forking.*
+- **v3 — Document viewer.** Decrypt and render room contents. Requires
+  reverse-engineering the cipher framing and decoding Loro CRDT state
+  (20–40 hrs). Build only if coaches ask — and disclose plainly, because
+  it changes the tool from one that *cannot* read student work into one
+  that can.
+
+## Open questions
+
+Chromebook save-in-place · post-compaction storage multiplier ·
+tournament-weekend load · idle-GC space reclamation. Details in
+[`docs/findings.md`](./docs/findings.md#open-questions).

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,71 @@
+# Coach dashboard
+
+One page that answers: **is my relay up, which sessions exist, which are
+dying, and am I running out of space** — without logging into Supabase or
+writing SQL.
+
+It is a static site: three files (`index.html`, `styles.css`, `app.js`)
+plus `schema.sql`. No backend, no build step. Open `index.html` locally,
+or host the folder on GitHub Pages / Netlify drop / any static host.
+
+## What it can and can't do (v1)
+
+| Panel | Shows |
+|---|---|
+| **Health** | Green/red from `GET /relay/health` (no auth) |
+| **Sessions** | Every registered room: label, owner, event, size, last activity, live/dead |
+| **Stale** | Rooms within ~2 days of the 7-day idle deletion |
+| **Storage** | Estimated DB usage vs. the 500 MB free tier, plus rooms-remaining |
+| **Add session** | Paste a share code, give it a label/owner/event |
+
+**It cannot read document contents** — by construction. It talks to
+Supabase with the public **anon key** under Row-Level Security, which is
+allowed to read only room *metadata* (`relay_rooms`) and the names you
+add (`dashboard_registry`). Ciphertext tables stay unreadable. And when
+you add a session, the dashboard keeps only the room ID from the share
+code and **throws the encryption key away** — see below.
+
+## Setup
+
+1. Deploy the relay and create the Supabase database (see
+   [`../docs/setup.md`](../docs/setup.md)).
+2. In Supabase → **SQL Editor**, run [`schema.sql`](./schema.sql) once.
+   It creates `dashboard_registry`, turns on RLS, and grants the anon
+   key exactly the two things it needs.
+3. Open the dashboard, click through the connect screen, and paste:
+   - **Relay base URL** — e.g. `https://debate-relay.onrender.com/relay`
+   - **Supabase project URL** — Supabase → Settings → API → *Project URL*
+   - **Supabase anon key** — Supabase → Settings → API → *anon public*
+
+   These are stored in your browser's localStorage only.
+
+> Paste the **anon** key, never the service-role key and never a Postgres
+> connection string. A connection string in browser JavaScript is a
+> public database.
+
+## The share-code split (why the dashboard can't read work)
+
+A share code looks like:
+
+```
+cmshare2.930cd67c….NgE0QEdJ….1.0.0
+             │           │
+      segment two   segment three
+      = room ID     = encryption key
+```
+
+"Add session" splits on periods and stores **segment two only** — the
+room ID, which joins to `relay_rooms.id`. Segment three, the key, is
+discarded. That makes it structurally impossible for this page to
+decrypt student work, which is the correct default. Reversing it is a
+deliberate v3 decision (a document viewer), not a config toggle.
+
+## Hosting on GitHub Pages
+
+This repo's GitHub Pages already serves the app's redirect stub, so the
+dashboard is intentionally *not* wired into that deploy. To publish it:
+
+- Easiest: open `dashboard/index.html` from a local clone — it needs no
+  server.
+- Or drag the `dashboard/` folder onto <https://app.netlify.com/drop>.
+- Or enable Pages on your own copy pointed at `/dashboard`.

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,311 @@
+/* Debate Relay — coach dashboard.
+ *
+ * A static page. Talks to two things:
+ *   1. The relay's public GET /relay/health  (no auth).
+ *   2. Supabase's REST API with the ANON key + Row-Level Security.
+ *
+ * It never sees a Postgres connection string and never reads ciphertext:
+ * RLS only lets the anon key read relay_rooms and read/insert
+ * dashboard_registry (see schema.sql).
+ */
+'use strict';
+
+// ── Constants from the relay / findings ──────────────────────────────
+const FREE_TIER_BYTES = 500 * 1024 * 1024; // Supabase free tier
+const DB_MULTIPLIER    = 3.5;               // measured DB growth ÷ content bytes (findings §3)
+const IDLE_GC_DAYS     = 7;                 // ROOM_IDLE_GC in the relay
+const STALE_DAYS       = 2;                 // "approaching" = this many days or fewer remaining
+const NOMINAL_ROOM     = 1.5 * 1024 * 1024; // fallback avg content size when no rooms yet
+
+const CFG_KEY = 'debate-relay-dashboard-config';
+
+// ── Config (localStorage) ────────────────────────────────────────────
+function loadConfig() {
+  try { return JSON.parse(localStorage.getItem(CFG_KEY) || 'null'); }
+  catch { return null; }
+}
+function saveConfig(cfg) { localStorage.setItem(CFG_KEY, JSON.stringify(cfg)); }
+
+let config = loadConfig();
+
+// ── Small helpers ────────────────────────────────────────────────────
+const $ = (id) => document.getElementById(id);
+
+// The relay stores naive UTC timestamps; make sure JS parses them as UTC.
+function parseUtc(s) {
+  if (!s) return null;
+  const hasZone = /[zZ]|[+-]\d\d:?\d\d$/.test(s);
+  return new Date(hasZone ? s : s + 'Z');
+}
+function fmtBytes(n) {
+  if (n == null) return '—';
+  if (n < 1024) return n + ' B';
+  const u = ['KB', 'MB', 'GB'];
+  let v = n / 1024, i = 0;
+  while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+  return v.toFixed(v < 10 ? 1 : 0) + ' ' + u[i];
+}
+function daysSince(date) {
+  if (!date) return Infinity;
+  return (Date.now() - date.getTime()) / 86400000;
+}
+function fmtAgo(date) {
+  if (!date) return '—';
+  const s = (Date.now() - date.getTime()) / 1000;
+  if (s < 60) return 'just now';
+  if (s < 3600) return Math.round(s / 60) + ' min ago';
+  if (s < 86400) return Math.round(s / 3600) + ' h ago';
+  return Math.round(s / 86400) + ' d ago';
+}
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+// ── Supabase REST ────────────────────────────────────────────────────
+function sbHeaders() {
+  return { apikey: config.anon, Authorization: 'Bearer ' + config.anon };
+}
+async function sbGet(path) {
+  const res = await fetch(config.supabase.replace(/\/$/, '') + '/rest/v1/' + path, { headers: sbHeaders() });
+  if (!res.ok) throw new Error('Supabase ' + res.status + ': ' + (await res.text()).slice(0, 200));
+  return res.json();
+}
+async function sbInsert(table, row) {
+  const res = await fetch(config.supabase.replace(/\/$/, '') + '/rest/v1/' + table, {
+    method: 'POST',
+    headers: { ...sbHeaders(), 'Content-Type': 'application/json', Prefer: 'return=representation' },
+    body: JSON.stringify(row),
+  });
+  if (!res.ok) throw new Error('Supabase ' + res.status + ': ' + (await res.text()).slice(0, 200));
+  return res.json();
+}
+
+// ── Health ───────────────────────────────────────────────────────────
+async function refreshHealth() {
+  const setDot = (cls) => { for (const el of [$('health-dot'), $('health-dot-lg')]) { el.className = 'dot ' + cls; } };
+  $('health-text').textContent = 'Checking…';
+  $('health-detail').textContent = '';
+  try {
+    const base = config.relay.replace(/\/$/, '');
+    const t0 = performance.now();
+    const res = await fetch(base + '/health', { cache: 'no-store' });
+    const ms = Math.round(performance.now() - t0);
+    const body = await res.json().catch(() => ({}));
+    if (res.ok && body.ok) {
+      setDot('ok');
+      $('health-text').textContent = 'Relay is up';
+      $('health-detail').textContent = `${base}/health · responded in ${ms} ms`;
+    } else {
+      setDot('bad');
+      $('health-text').textContent = 'Relay responded, but not healthy';
+      $('health-detail').textContent = `HTTP ${res.status}`;
+    }
+  } catch (e) {
+    setDot('bad');
+    $('health-text').textContent = 'Relay is unreachable';
+    $('health-detail').textContent = String(e.message || e) +
+      ' — if it was idle, Render may be waking it (~60s). Try Refresh.';
+  }
+}
+
+// ── Rooms + registry ─────────────────────────────────────────────────
+async function refreshData() {
+  let rooms, registry;
+  try {
+    [rooms, registry] = await Promise.all([
+      sbGet('relay_rooms?select=id,created_at,last_activity,bytes_used,tombstoned'),
+      sbGet('dashboard_registry?select=room_id,label,owner,event,created_at'),
+    ]);
+  } catch (e) {
+    const msg = `<tr><td colspan="6" class="error">${esc(e.message || e)}</td></tr>`;
+    $('sessions-body').innerHTML = msg;
+    $('stale-body').innerHTML = `<tr><td colspan="3" class="error">${esc(e.message || e)}</td></tr>`;
+    $('storage-text').textContent = 'Could not load storage.';
+    return;
+  }
+
+  const byId = new Map(rooms.map((r) => [r.id, r]));
+  renderSessions(registry, byId);
+  renderStale(rooms, registry);
+  renderStorage(rooms);
+}
+
+function renderSessions(registry, byId) {
+  const body = $('sessions-body');
+  if (!registry.length) {
+    body.innerHTML = '<tr><td colspan="6" class="muted">No sessions registered yet. Click “+ Add session”.</td></tr>';
+    $('sessions-note').textContent = '';
+    return;
+  }
+  registry.sort((a, b) => (a.label || '').localeCompare(b.label || ''));
+  const rows = registry.map((reg) => {
+    const room = byId.get(reg.room_id);
+    const live = room && !room.tombstoned;
+    const last = live ? parseUtc(room.last_activity) : null;
+    const status = live
+      ? '<span class="status-live">live</span>'
+      : '<span class="status-dead">dead</span>';
+    return `<tr>
+      <td>${esc(reg.label)}<div class="room-id">${esc(reg.room_id.slice(0, 8))}…</div></td>
+      <td>${esc(reg.owner) || '—'}</td>
+      <td>${esc(reg.event) || '—'}</td>
+      <td>${live ? fmtBytes(room.bytes_used) : '—'}</td>
+      <td>${live ? esc(fmtAgo(last)) : '—'}</td>
+      <td>${status}</td>
+    </tr>`;
+  });
+  body.innerHTML = rows.join('');
+  const liveCount = registry.filter((r) => { const m = byId.get(r.room_id); return m && !m.tombstoned; }).length;
+  const unregistered = [...byId.values()].filter((r) => !r.tombstoned && !registry.some((x) => x.room_id === r.id)).length;
+  $('sessions-note').textContent =
+    `${liveCount} live · ${registry.length - liveCount} dead` +
+    (unregistered ? ` · ${unregistered} live room${unregistered > 1 ? 's' : ''} not registered here` : '');
+}
+
+function renderStale(rooms, registry) {
+  const labelOf = new Map(registry.map((r) => [r.room_id, r.label]));
+  const stale = rooms
+    .filter((r) => !r.tombstoned)
+    .map((r) => ({ r, remaining: IDLE_GC_DAYS - daysSince(parseUtc(r.last_activity)) }))
+    .filter((x) => x.remaining <= STALE_DAYS)
+    .sort((a, b) => a.remaining - b.remaining);
+
+  const body = $('stale-body');
+  if (!stale.length) {
+    body.innerHTML = '<tr><td colspan="3" class="muted">Nothing approaching deletion. 🎉</td></tr>';
+    return;
+  }
+  body.innerHTML = stale.map(({ r, remaining }) => {
+    const idle = IDLE_GC_DAYS - remaining;
+    const cls = remaining <= 1 ? 'status-warn' : '';
+    const name = labelOf.get(r.id) || `<span class="room-id">${esc(r.id.slice(0, 8))}… (unregistered)</span>`;
+    return `<tr>
+      <td>${labelOf.has(r.id) ? esc(labelOf.get(r.id)) : name}</td>
+      <td>${idle.toFixed(1)} days</td>
+      <td class="${cls}">${remaining <= 0 ? 'due now' : remaining.toFixed(1) + ' days'}</td>
+    </tr>`;
+  }).join('');
+}
+
+function renderStorage(rooms) {
+  const contentBytes = rooms.filter((r) => !r.tombstoned).reduce((s, r) => s + (r.bytes_used || 0), 0);
+  const roomCount = rooms.filter((r) => !r.tombstoned).length;
+  const estDb = contentBytes * DB_MULTIPLIER;
+  const pct = Math.min(100, (estDb / FREE_TIER_BYTES) * 100);
+
+  const fill = $('storage-fill');
+  fill.style.width = pct.toFixed(1) + '%';
+  fill.className = 'meter-fill' + (pct > 90 ? ' crit' : pct > 70 ? ' warn' : '');
+
+  $('storage-text').innerHTML =
+    `Est. <strong>${fmtBytes(estDb)}</strong> of ${fmtBytes(FREE_TIER_BYTES)} used ` +
+    `(${pct.toFixed(1)}%) across ${roomCount} live room${roomCount === 1 ? '' : 's'}.`;
+
+  const avg = roomCount ? contentBytes / roomCount : NOMINAL_ROOM;
+  const remainingContent = FREE_TIER_BYTES / DB_MULTIPLIER - contentBytes;
+  const roomsLeft = Math.max(0, Math.floor(remainingContent / avg));
+  $('storage-estimate').innerHTML =
+    `Content stored: ${fmtBytes(contentBytes)} · applying the measured ×${DB_MULTIPLIER} on-disk multiplier. ` +
+    `Roughly <strong>${roomsLeft}</strong> more room${roomsLeft === 1 ? '' : 's'} of the current average ` +
+    `(${fmtBytes(avg)}) would fit.`;
+}
+
+// ── Add session ──────────────────────────────────────────────────────
+// Share code: cmshare2.<roomId>.<key>.<major>.<minor>.<patch>
+// Keep segment two (roomId). DISCARD segment three (the encryption key).
+function parseShareCode(code) {
+  const parts = (code || '').trim().split('.');
+  if (parts.length < 2 || !parts[1]) return null;
+  return parts[1]; // room id only — never store parts[2]
+}
+
+function openAdd() {
+  $('add-code').value = '';
+  $('add-label').value = '';
+  $('add-owner').value = '';
+  $('add-event').value = '';
+  $('add-parsed').textContent = '';
+  $('add-error').classList.add('hidden');
+  $('add-modal').classList.remove('hidden');
+  $('add-code').focus();
+}
+function closeAdd() { $('add-modal').classList.add('hidden'); }
+
+async function submitAdd() {
+  const err = $('add-error');
+  err.classList.add('hidden');
+  const roomId = parseShareCode($('add-code').value);
+  const label = $('add-label').value.trim();
+  if (!roomId) { err.textContent = 'That does not look like a share code (need at least cmshare2.<roomId>…).'; err.classList.remove('hidden'); return; }
+  if (!label) { err.textContent = 'A label is required.'; err.classList.remove('hidden'); return; }
+  try {
+    await sbInsert('dashboard_registry', {
+      room_id: roomId,
+      label,
+      owner: $('add-owner').value.trim() || null,
+      event: $('add-event').value.trim() || null,
+    });
+    closeAdd();
+    await refreshData();
+  } catch (e) {
+    // Duplicate primary key → already registered.
+    err.textContent = /duplicate|conflict|409/i.test(String(e.message))
+      ? 'That room is already registered.'
+      : String(e.message || e);
+    err.classList.remove('hidden');
+  }
+}
+
+// ── Wiring ───────────────────────────────────────────────────────────
+function showConfig() {
+  if (config) {
+    $('cfg-relay').value = config.relay || '';
+    $('cfg-supabase').value = config.supabase || '';
+    $('cfg-anon').value = config.anon || '';
+  }
+  $('dashboard').classList.add('hidden');
+  $('config-panel').classList.remove('hidden');
+}
+function showDashboard() {
+  $('config-panel').classList.add('hidden');
+  $('dashboard').classList.remove('hidden');
+}
+
+function refreshAll() {
+  if (!config) return;
+  refreshHealth();
+  refreshData();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  $('settings-btn').onclick = showConfig;
+  $('refresh-btn').onclick = refreshAll;
+  $('add-btn').onclick = openAdd;
+  $('add-cancel').onclick = closeAdd;
+  $('add-save').onclick = submitAdd;
+  $('cfg-cancel').onclick = () => { if (config) showDashboard(); };
+  $('add-code').addEventListener('input', () => {
+    const id = parseShareCode($('add-code').value);
+    $('add-parsed').textContent = id ? `Room ID kept: ${id.slice(0, 12)}…  (key discarded)` : '';
+  });
+  $('cfg-save').onclick = () => {
+    const cfg = {
+      relay: $('cfg-relay').value.trim(),
+      supabase: $('cfg-supabase').value.trim(),
+      anon: $('cfg-anon').value.trim(),
+    };
+    if (!cfg.relay || !cfg.supabase || !cfg.anon) { alert('All three fields are required.'); return; }
+    config = cfg;
+    saveConfig(cfg);
+    showDashboard();
+    refreshAll();
+  };
+
+  if (config) { showDashboard(); refreshAll(); }
+  else { showConfig(); }
+
+  // Auto-refresh every 60s while the tab is open.
+  setInterval(() => { if (config && !document.hidden) refreshAll(); }, 60000);
+});

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Debate Relay — Coach Dashboard</title>
+  <meta name="color-scheme" content="light dark" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <span class="dot" id="health-dot" title="Relay health"></span>
+      <h1>Debate Relay</h1>
+    </div>
+    <div class="topbar-actions">
+      <button id="refresh-btn" class="btn" type="button">Refresh</button>
+      <button id="settings-btn" class="btn ghost" type="button">Settings</button>
+    </div>
+  </header>
+
+  <!-- First-run / reconfigure screen -->
+  <section id="config-panel" class="config hidden">
+    <div class="card config-card">
+      <h2>Connect your dashboard</h2>
+      <p class="muted">
+        These stay in this browser only (localStorage) — nothing is sent
+        anywhere except the two services you name below. The Supabase
+        <strong>anon</strong> key is meant to be public; it is safe here
+        because Row-Level Security restricts it to reading room metadata.
+        Do <strong>not</strong> paste a Postgres connection string or a
+        service-role key.
+      </p>
+      <label>Relay base URL
+        <input id="cfg-relay" type="url" placeholder="https://debate-relay.onrender.com/relay" />
+        <small class="muted">Ends in <code>/relay</code>. The same URL your team pastes into CardMirror.</small>
+      </label>
+      <label>Supabase project URL
+        <input id="cfg-supabase" type="url" placeholder="https://abcdefgh.supabase.co" />
+      </label>
+      <label>Supabase anon (public) key
+        <input id="cfg-anon" type="text" placeholder="eyJhbGciOi..." />
+      </label>
+      <div class="config-actions">
+        <button id="cfg-save" class="btn primary" type="button">Save &amp; connect</button>
+        <button id="cfg-cancel" class="btn ghost" type="button">Cancel</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main dashboard -->
+  <main id="dashboard" class="grid hidden">
+
+    <section class="card" id="panel-health">
+      <h2>Health</h2>
+      <div class="health-line">
+        <span class="dot" id="health-dot-lg"></span>
+        <span id="health-text">Checking…</span>
+      </div>
+      <p class="muted" id="health-detail"></p>
+    </section>
+
+    <section class="card" id="panel-storage">
+      <h2>Storage</h2>
+      <div class="meter"><div class="meter-fill" id="storage-fill"></div></div>
+      <p id="storage-text" class="muted">Loading…</p>
+      <p id="storage-estimate" class="muted small"></p>
+    </section>
+
+    <section class="card wide" id="panel-sessions">
+      <div class="card-head">
+        <h2>Sessions</h2>
+        <button id="add-btn" class="btn primary small" type="button">+ Add session</button>
+      </div>
+      <table class="sessions">
+        <thead>
+          <tr><th>Label</th><th>Owner</th><th>Event</th><th>Size</th><th>Last activity</th><th>Status</th></tr>
+        </thead>
+        <tbody id="sessions-body">
+          <tr><td colspan="6" class="muted">Loading…</td></tr>
+        </tbody>
+      </table>
+      <p class="muted small" id="sessions-note"></p>
+    </section>
+
+    <section class="card wide" id="panel-stale">
+      <h2>Stale — approaching 7-day idle deletion</h2>
+      <table class="stale">
+        <thead>
+          <tr><th>Label / Room</th><th>Idle for</th><th>Days remaining</th></tr>
+        </thead>
+        <tbody id="stale-body">
+          <tr><td colspan="3" class="muted">Loading…</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+
+  <!-- Add-session modal -->
+  <div id="add-modal" class="modal hidden">
+    <div class="modal-card card">
+      <h2>Add a session</h2>
+      <p class="muted">
+        Paste the share code a partner sent you. We keep only the room ID
+        (segment two). The encryption key (segment three) is
+        <strong>discarded</strong> — that is what makes it impossible for
+        this dashboard to read student work.
+      </p>
+      <label>Share code
+        <input id="add-code" type="text" placeholder="cmshare2.930cd67c….NgE0QEdJ….1.0.0" />
+        <small class="muted" id="add-parsed"></small>
+      </label>
+      <label>Label <span class="req">*</span>
+        <input id="add-label" type="text" placeholder="1AC — Reproductive Services" />
+      </label>
+      <div class="row">
+        <label>Owner
+          <input id="add-owner" type="text" placeholder="Maya" />
+        </label>
+        <label>Event
+          <input id="add-event" type="text" placeholder="Michigan 2026" />
+        </label>
+      </div>
+      <p class="error hidden" id="add-error"></p>
+      <div class="config-actions">
+        <button id="add-save" class="btn primary" type="button">Add</button>
+        <button id="add-cancel" class="btn ghost" type="button">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <footer class="foot muted small">
+    Read-only metadata dashboard · document contents are never exposed to this page ·
+    <a href="https://github.com/ant981228/cardmirror" target="_blank" rel="noopener">source</a>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/dashboard/schema.sql
+++ b/dashboard/schema.sql
@@ -1,0 +1,74 @@
+-- Debate Relay dashboard — Supabase setup
+-- =========================================
+-- Run this ONCE in the Supabase SQL editor (Dashboard → SQL Editor →
+-- New query → paste → Run) AFTER the relay has started at least once,
+-- so the relay's own tables (relay_rooms, relay_room_updates, …) already
+-- exist. The relay creates those automatically on first boot.
+--
+-- What this does, and why it is safe:
+--
+--   * Creates dashboard_registry, the label/owner/event names the relay
+--     itself never stores (the relay mints anonymous random room IDs).
+--   * Turns on Row-Level Security everywhere and grants the browser's
+--     `anon` role EXACTLY two things: read relay_rooms, and read+insert
+--     dashboard_registry. Nothing else.
+--   * Leaves relay_room_updates / relay_room_snapshots / relay_messages
+--     unreadable, so document ciphertext is never exposed to the page —
+--     not even in encrypted form.
+--
+-- Why this does NOT break the relay: the relay connects to Postgres as
+-- the table OWNER (the `postgres` role in your pooler connection string).
+-- Table owners bypass RLS on their own tables, so every relay read and
+-- write keeps working. RLS only constrains the `anon` key the dashboard
+-- ships in browser JavaScript.
+
+-- 1. The registry the dashboard supplies -----------------------------------
+create table if not exists dashboard_registry (
+  room_id    text primary key,   -- share-code segment two; joins relay_rooms.id
+  label      text not null,       -- human name, e.g. "1AC — Reproductive Services"
+  owner      text,                -- who runs it, e.g. "Maya"
+  event      text,                -- e.g. "Michigan 2026"
+  created_at timestamptz default now()
+);
+-- NOTE: no foreign key to relay_rooms on purpose. A FK would block the
+-- relay's idle-GC deletes and forbid registering a room before its first
+-- update lands. The dashboard joins in the browser instead, which also
+-- lets it show registered rooms whose live room has already been swept
+-- (i.e. "dead" sessions).
+
+-- 2. Lock everything down with RLS -----------------------------------------
+alter table relay_rooms          enable row level security;
+alter table dashboard_registry   enable row level security;
+alter table relay_room_updates   enable row level security;
+alter table relay_room_snapshots enable row level security;
+alter table relay_messages       enable row level security;
+
+-- 3. Grant the anon role only what the dashboard needs ----------------------
+-- Belt-and-suspenders: explicit table grants AND policies. Supabase's
+-- default privileges may have already granted anon SELECT on new tables,
+-- so we REVOKE on the tables that must stay private.
+grant  select          on relay_rooms        to anon;
+grant  select, insert  on dashboard_registry to anon;
+revoke all             on relay_room_updates   from anon;
+revoke all             on relay_room_snapshots from anon;
+revoke all             on relay_messages       from anon;
+
+-- 4. Policies (the second gate, once RLS is on) -----------------------------
+-- relay_rooms: read-only.
+drop policy if exists "dashboard anon reads rooms" on relay_rooms;
+create policy "dashboard anon reads rooms"
+  on relay_rooms for select to anon using (true);
+
+-- dashboard_registry: read all, and add new entries. No update/delete.
+drop policy if exists "dashboard anon reads registry" on dashboard_registry;
+create policy "dashboard anon reads registry"
+  on dashboard_registry for select to anon using (true);
+
+drop policy if exists "dashboard anon adds registry" on dashboard_registry;
+create policy "dashboard anon adds registry"
+  on dashboard_registry for insert to anon with check (true);
+
+-- relay_room_updates / relay_room_snapshots / relay_messages: RLS is on
+-- and NO policy grants anon anything, so every anon query returns zero
+-- rows. Ciphertext stays private. (Ending a session — a DELETE — is done
+-- from inside CardMirror in v1; the dashboard never writes to these.)

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1,0 +1,113 @@
+/* Debate Relay dashboard — no framework, no build step. */
+:root {
+  --bg: #0f1117;
+  --panel: #171a23;
+  --panel-2: #1e222d;
+  --border: #2a2f3d;
+  --text: #e6e8ee;
+  --muted: #98a0b3;
+  --accent: #5b8cff;
+  --green: #3fb950;
+  --red: #f85149;
+  --amber: #d29922;
+  --radius: 12px;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f5f6f8; --panel: #ffffff; --panel-2: #f0f2f5;
+    --border: #e1e4ea; --text: #1b1f27; --muted: #5c6472;
+  }
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+h1 { font-size: 18px; margin: 0; }
+h2 { font-size: 15px; margin: 0 0 10px; letter-spacing: .01em; }
+a { color: var(--accent); }
+code { background: var(--panel-2); padding: 1px 5px; border-radius: 5px; font-size: .9em; }
+.muted { color: var(--muted); }
+.small { font-size: 13px; }
+.hidden { display: none !important; }
+.req { color: var(--red); }
+
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 20px; border-bottom: 1px solid var(--border);
+  background: var(--panel); position: sticky; top: 0; z-index: 5;
+}
+.brand { display: flex; align-items: center; gap: 10px; }
+.topbar-actions { display: flex; gap: 8px; }
+
+.dot {
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--muted); display: inline-block; flex: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--muted) 25%, transparent);
+}
+.dot.ok  { background: var(--green); box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 25%, transparent); }
+.dot.bad { background: var(--red);   box-shadow: 0 0 0 3px color-mix(in srgb, var(--red) 25%, transparent); }
+#health-dot-lg { width: 16px; height: 16px; }
+
+.btn {
+  border: 1px solid var(--border); background: var(--panel-2); color: var(--text);
+  padding: 7px 14px; border-radius: 8px; cursor: pointer; font-size: 14px;
+}
+.btn:hover { border-color: var(--accent); }
+.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn.ghost { background: transparent; }
+.btn.small { padding: 5px 10px; font-size: 13px; }
+
+.grid {
+  display: grid; gap: 16px; padding: 20px; max-width: 1100px; margin: 0 auto;
+  grid-template-columns: 1fr 1fr;
+}
+.card {
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 18px;
+}
+.card.wide { grid-column: 1 / -1; }
+.card-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.card-head h2 { margin: 0; }
+
+.health-line { display: flex; align-items: center; gap: 10px; font-size: 16px; font-weight: 600; }
+
+.meter { height: 12px; background: var(--panel-2); border-radius: 6px; overflow: hidden; margin: 4px 0 10px; }
+.meter-fill { height: 100%; width: 0; background: var(--green); transition: width .3s, background .3s; }
+.meter-fill.warn { background: var(--amber); }
+.meter-fill.crit { background: var(--red); }
+
+table { width: 100%; border-collapse: collapse; font-size: 14px; }
+th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); }
+th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+tbody tr:last-child td { border-bottom: none; }
+.status-live { color: var(--green); font-weight: 600; }
+.status-dead { color: var(--muted); }
+.status-warn { color: var(--amber); font-weight: 600; }
+.room-id { font-family: ui-monospace, monospace; color: var(--muted); font-size: 12px; }
+
+.config { padding: 40px 20px; max-width: 560px; margin: 0 auto; }
+.config-card label, .modal-card label { display: block; margin: 14px 0; font-size: 14px; font-weight: 600; }
+.config-card input, .modal-card input {
+  display: block; width: 100%; margin-top: 6px; padding: 9px 11px;
+  background: var(--panel-2); border: 1px solid var(--border);
+  border-radius: 8px; color: var(--text); font: inherit;
+}
+.config-card input:focus, .modal-card input:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+.config-card small, .modal-card small { display: block; margin-top: 5px; font-weight: 400; }
+.config-actions { display: flex; gap: 10px; margin-top: 18px; }
+.row { display: flex; gap: 12px; }
+.row label { flex: 1; }
+
+.modal {
+  position: fixed; inset: 0; background: rgba(0,0,0,.5);
+  display: flex; align-items: center; justify-content: center; padding: 20px; z-index: 20;
+}
+.modal-card { width: 100%; max-width: 480px; }
+.error { color: var(--red); font-size: 14px; margin: 8px 0 0; }
+
+.foot { text-align: center; padding: 24px; }
+@media (max-width: 720px) { .grid { grid-template-columns: 1fr; } .row { flex-direction: column; } }

--- a/docs/findings.md
+++ b/docs/findings.md
@@ -1,0 +1,88 @@
+# Findings
+
+These came from testing Debate Relay on live hardware, and are not
+documented anywhere else. They are the reason this repo is worth reading —
+the setup steps you can reconstruct; these you can't.
+
+---
+
+## Rooms survive the host leaving
+
+Force-killing the machine that *created* a session does not end the room.
+A joiner can connect and edit while the host's machine is powered off, and
+the host picks up those edits on return.
+
+**Why it matters:** this makes asynchronous shared editing real. Partners
+work whenever they want, independently, in the same document — not just in
+a synchronous "we're both online now" window.
+
+## Ending a session is safe
+
+Whoever remains keeps the work as an **editable local document**, backed
+by CardMirror's crash-recovery journaling even if it was never saved.
+
+**Why it matters:** saving is about making work *visible to teammates*,
+not about preventing loss. Nobody has to panic about ending a session.
+
+## Reopening rejoins the live room
+
+Confirmed: a partner's edits made while you were closed are **present when
+you return**, rather than a stale local draft overwriting them.
+
+**Why it matters:** it's safe to close and come back. The room, not your
+last local state, is the source of truth while a session is live.
+
+## Storage runs about 3.5× document size
+
+A 1.5 MB file produced ~5.3 MB of database growth — roughly a **3.5×**
+multiplier.
+
+**Caveat:** measured *before* client-side compaction had run, so steady
+state is likely lower. On a 500 MB free tier that's roughly **30–40
+concurrent documents** with comfortable headroom — far more than a
+program needs. (The dashboard's Storage panel uses this 3.5× figure to
+estimate on-disk usage from the relay's reported content bytes.)
+
+## Session capacity is 10
+
+Enforced **at stream connect**, returning **HTTP 409** to the eleventh
+participant. Plenty for a working group; not a lecture hall.
+
+---
+
+## Traps that cost hours
+
+- **CardMirror Lite has no collaboration.** The Collaboration settings
+  tab does not exist in it. Install the full desktop build.
+- **Supabase: use the Session pooler string, not Direct connection.**
+  Direct resolves IPv6-only; Render connects over IPv4. The failure is
+  *silent* until the last step.
+- **All machines must run the same CardMirror version.** Older builds
+  can't read the current session format, and the failure looks exactly
+  like a broken relay.
+- **The web editor needs a desktop-layout window.** Narrow windows switch
+  to mobile layout, which has no collaboration.
+- **Share codes are credentials.** The code carries the room's encryption
+  key — read *and* write. Never in a group chat.
+
+See [`troubleshooting.md`](./troubleshooting.md) for the error-to-cause
+table.
+
+---
+
+## Open questions
+
+Honest unknowns, not hidden bugs. Each is a small experiment away from an
+answer.
+
+- **Chromebook save-in-place.** Can the web editor save back to a
+  Drive-mounted location, or does it produce a download? Determines
+  whether Chromebook students *own* files or only join sessions. A
+  ten-minute test.
+- **Post-compaction storage.** Re-measure `relay_room_updates` after a
+  week of real editing to establish the *steady-state* multiplier rather
+  than the pre-compaction 3.5×.
+- **Tournament-weekend load.** Behavior with eight-plus concurrent rooms
+  and heavy churn is untested.
+- **Idle GC reclamation.** Confirm that expired rooms actually free
+  database space on the sweep, closing the loop on storage management.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,144 @@
+# Setup — a 35-minute coach walkthrough
+
+You are going to stand up a free, always-on collaboration relay for your
+team. No credit card, no server to babysit. At the end you will have two
+values to hand out: a **relay URL** and a **relay token**.
+
+The order matters. Do the database first, because the relay needs its
+connection string at deploy time.
+
+---
+
+## What you'll end up with
+
+- A **relay** on Render's free tier that stores and forwards encrypted
+  edits (and never reads them).
+- A **Postgres database** on Supabase's free tier that keeps those edits
+  permanently (Render's own free Postgres is deleted after 30 days —
+  don't use it).
+- A **keepalive** on UptimeRobot so the relay never goes to sleep.
+- Optionally, the **coach dashboard** to see it all at a glance.
+
+Total cost: **$0**. Credit cards required: **none**.
+
+---
+
+## Before you start
+
+- You need the **full CardMirror desktop build** on every machine.
+  **CardMirror Lite has no collaboration** — the Collaboration settings
+  tab does not exist in it.
+- Every machine must run the **same CardMirror version**. Older builds
+  can't read the current session format, and the failure looks exactly
+  like a broken relay.
+- Have a browser, a GitHub account (for the Render one-click button), and
+  15 minutes of uninterrupted attention for the connection-string step —
+  that's the one place people slip.
+
+---
+
+## Step 1 — Create the database (Supabase) · ~10 min
+
+1. Go to <https://supabase.com>, sign up (GitHub login is fine), and
+   **New project**. Pick a name and a strong database password —
+   **save the password**, you'll need it in a moment.
+2. Wait for the project to finish provisioning (~2 min).
+3. Go to **Project Settings → Database → Connection string**.
+4. Select the **Session pooler** tab. **This is the load-bearing
+   choice.** Copy that URI. It contains `pooler.supabase.com`.
+
+   > ⚠️ **Do NOT use "Direct connection."** Direct resolves to an
+   > IPv6-only host; Render connects over IPv4. The failure is
+   > *silent* — the relay just never becomes healthy — and it will cost
+   > you an hour. If your string does not say `pooler`, you have the
+   > wrong one.
+
+5. Replace `[YOUR-PASSWORD]` in the copied string with the database
+   password from step 1. Keep this final string handy for Step 2.
+
+---
+
+## Step 2 — Deploy the relay (Render) · ~10 min
+
+1. Push this repository to your own GitHub account, or use the public
+   repo directly — **no fork required** to deploy.
+2. Go to <https://render.com>, sign up, and choose **New → Blueprint**.
+3. Point it at the repository. Render reads [`render.yaml`](../render.yaml)
+   and proposes a single web service, `debate-relay`, on the free plan.
+4. It will **prompt for `DATABASE_URL`** (that's the `sync: false` field).
+   Paste the Session pooler string from Step 1. It does **not** prompt
+   for `RELAY_TOKEN` — Render generates a unique random one for you.
+5. Click **Apply / Deploy**. First build takes a few minutes.
+6. Wait until the service shows **Live** and the health check at
+   `/relay/health` is passing.
+
+Now copy your two values:
+
+- **Relay URL:** your service's URL with `/relay` appended, e.g.
+  `https://debate-relay.onrender.com/relay`.
+- **Relay token:** Render → your service → **Environment** →
+  `RELAY_TOKEN` → reveal and copy.
+
+---
+
+## Step 3 — Keep it awake (UptimeRobot) · ~5 min
+
+Render's free tier sleeps after ~15 minutes idle, and waking takes ~60s —
+long enough to look broken mid-session. A free pinger prevents it.
+
+1. Go to <https://uptimerobot.com> and sign up.
+2. **Add New Monitor** → type **HTTP(s)**.
+3. URL = your relay URL **+ `/health`**, e.g.
+   `https://debate-relay.onrender.com/relay/health`.
+4. Monitoring interval = **5 minutes**. Save.
+
+That's it — the relay now stays warm 24/7.
+
+---
+
+## Step 4 — Point CardMirror at your relay · ~2 min per machine
+
+On **every** machine (full desktop build):
+
+1. **Settings → Collaboration.**
+   - If you don't see this tab, you're on **Lite** — install the full
+     build.
+2. **Custom relay URL** = your relay URL (ending in `/relay`).
+3. **Custom relay token** = the `RELAY_TOKEN` value.
+4. Save. Repeat, *identically*, on each machine. A single typo here is
+   indistinguishable from a dead relay.
+
+Test it: on one machine start a session and copy the share code; on a
+second machine, join with it. If the document appears, you're done.
+
+> **Web editor note:** use a **desktop-width window**. Narrow windows
+> switch CardMirror to a mobile layout that has no collaboration.
+
+---
+
+## Step 5 (optional) — The coach dashboard · ~8 min
+
+1. In Supabase → **SQL Editor → New query**, paste the contents of
+   [`../dashboard/schema.sql`](../dashboard/schema.sql) and **Run**. This
+   creates the registry table and locks down the anon key with
+   Row-Level Security. It does **not** affect the relay.
+2. Open [`../dashboard/index.html`](../dashboard/) (locally, or host the
+   `dashboard/` folder — see its README).
+3. On the connect screen paste:
+   - **Relay base URL** (ends in `/relay`)
+   - **Supabase project URL** (Settings → API → *Project URL*)
+   - **Supabase anon key** (Settings → API → *anon public*)
+
+   > Paste the **anon** key only — never the service-role key, never a
+   > connection string.
+
+---
+
+## Sharing with your team
+
+Give each student **two things**: the relay URL and the relay token, for
+their **Settings → Collaboration**. Then read
+[`workflow.md`](./workflow.md) together — especially *who saves*.
+
+> **Share codes are credentials.** A code carries the room's encryption
+> key — read *and* write. Never post one in a group chat.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,73 @@
+# Troubleshooting
+
+Start with the error-to-cause table. Most "the relay is broken" reports
+are one of the first three rows.
+
+## Error → cause
+
+| What you see | Almost always means | Fix |
+|---|---|---|
+| Relay never goes **Live** on Render; deploy hangs or health check fails | You used Supabase's **Direct connection** string (IPv6-only) instead of the **Session pooler** | Redeploy with the pooler URI (host contains `pooler.supabase.com`); see [setup Step 1](./setup.md#step-1--create-the-database-supabase--10-min) |
+| No **Collaboration** tab in Settings | You're running **CardMirror Lite** | Install the **full desktop build** |
+| Session join fails / "can't read session" between machines that both point at the relay | **Version mismatch** — one machine is on an older CardMirror | Update every machine to the **same** version |
+| Collaboration controls missing in the **web editor** | Window is in **mobile layout** | Widen to a **desktop-width** window |
+| Eleventh person can't join; **HTTP 409** | Session capacity is **10**, enforced at connect | Start a second room, or drop an idle participant |
+| First edit after a quiet period is slow (~60s), then fine | Render **cold start** — the instance had gone to sleep | Set up the **UptimeRobot** keepalive ([setup Step 3](./setup.md#step-3--keep-it-awake-uptimerobot--5-min)) |
+| Dashboard shows **"Relay is unreachable"** | Relay waking from sleep, or wrong relay URL | Click **Refresh** after ~60s; verify the URL ends in `/relay` |
+| Dashboard Supabase error `401` / `permission denied` | Wrong key, or `schema.sql` not run | Paste the **anon** key (Settings → API); run [`schema.sql`](../dashboard/schema.sql) once |
+| Duplicate `.cmir (1)` files appearing in Drive | **Two machines saving** the same file | Only the **host** saves — see [workflow.md](./workflow.md#who-saves-the-one-rule) |
+| Work "disappeared" after ending a session | It didn't — it's an **editable local doc**, journaled | **Save** it to Drive; ending a session never loses work |
+
+---
+
+## Relay won't deploy or stay up
+
+1. **Confirm the connection string is the pooler.** This is the number
+   one cause. The host must contain `pooler.supabase.com`. If it says
+   anything about a direct/db host, it's wrong.
+2. **Confirm the password is filled in.** Render's `DATABASE_URL` must
+   have `[YOUR-PASSWORD]` replaced with your actual Supabase database
+   password.
+3. **Check the health path.** `GET https://<your-relay>/relay/health`
+   should return `{"ok": true}` with no auth. If the domain resolves but
+   this 404s, your URL is missing `/relay`.
+4. **Single worker only.** If you deployed by hand instead of via
+   `render.yaml`, make sure you did **not** pass `--workers` to uvicorn —
+   the live-push registry is in-process, and multiple workers break
+   pushes.
+
+## Collaboration doesn't work between two machines
+
+Work down this list; it's ordered by how often each is the culprit.
+
+1. **Same build?** Both on the *full* desktop app (not Lite).
+2. **Same version?** Update both to identical versions.
+3. **Same relay URL and token?** Re-check **Settings → Collaboration** on
+   both — character for character. A typo here is indistinguishable from a
+   dead relay.
+4. **Desktop-width window** if either side is on the web editor.
+5. **Relay actually up?** Hit `/relay/health` in a browser.
+
+## Dashboard problems
+
+- **Everything says "unreachable" / errors:** re-open **Settings** in the
+  dashboard and re-check all three values. The relay URL ends in
+  `/relay`; the Supabase URL is the `…supabase.co` project URL; the key
+  is the **anon public** key.
+- **`permission denied for table relay_rooms`:** you haven't run
+  [`schema.sql`](../dashboard/schema.sql), or you ran it before the relay
+  first started (so `relay_rooms` didn't exist yet). Start the relay
+  once, then run the SQL.
+- **Sessions show as "dead" right after creating them:** the room ID
+  didn't match. Re-check that you pasted the **full** share code into
+  *Add session* — the dashboard keeps segment two automatically.
+- **Storage number looks high:** it's an *estimate* (content bytes ×3.5),
+  and pre-compaction. It will read high until steady state; that's
+  expected, not a leak.
+
+## When in doubt
+
+Nothing here risks student work. The relay only holds encrypted edits,
+CardMirror journals locally, and Drive holds the last save. If a session
+gets weird: **end it, save the local doc to Drive, and start fresh** —
+new session, new share code.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,96 @@
+# Workflow — rooms vs. Drive, and who saves
+
+The single most important idea in this whole stack:
+
+> **Drive stores files. The relay carries edits. They never touch each
+> other.**
+
+Get that right and nothing else bites you. Get it wrong and you get Drive
+conflict copies and confusion about where the "real" file is. So read
+this once, as a team.
+
+---
+
+## The two halves
+
+**Google Shared Drive is permanent storage.** A `.cmir` file lives there
+like any document. A student opens it from a synced Drive folder exactly
+like a local file.
+
+**The relay is a live change log, not a file.** When two people work at
+once, their edits flow through a *room* on the relay — encrypted, and
+invisible to the server. The relay is **not backup**. It holds an
+encrypted session log, and idle rooms are deleted after 7 days.
+
+---
+
+## Who saves: the one rule
+
+**Only the host has the file open, so only the host saves.**
+
+- The **host** opens the `.cmir` from Drive and **starts a session**.
+  They send a **share code** to a partner.
+- The **joiner** receives the whole document *through the room*. They do
+  **not** open a file and do **not** save to Drive.
+- At the end of a real work session, **the host saves once** back to
+  Drive.
+
+This is what prevents Drive conflict copies: only one machine ever writes
+the file. Two people saving the "same" document from two machines is
+exactly how you get `document (1).cmir`.
+
+> If the original host isn't around to save, whoever is in the room can
+> **Save As** a fresh copy to Drive and make that the new canonical file.
+> Just agree on which file is canonical afterward.
+
+---
+
+## What happens when people come and go
+
+These behaviors are verified on live hardware (see
+[`findings.md`](./findings.md)); they're what make asynchronous partner
+work possible.
+
+- **The host can leave — even power off — and the room lives on.** A
+  joiner keeps editing. When the host returns, they pick up those edits.
+- **Reopening rejoins the live room.** You get your partner's edits made
+  while you were away, not a stale local draft.
+- **Ending a session is safe.** Whoever remains keeps the work as an
+  editable local document, protected by CardMirror's crash-recovery
+  journaling even if unsaved. Saving is about making work *visible to
+  teammates*, not about preventing loss.
+
+So: **saving ≠ safety, saving = visibility.** The relay and the local
+journal keep the work; saving to Drive is how a teammate gets the final
+version tomorrow.
+
+---
+
+## Team conventions worth adopting
+
+- **End every real session with a save to Drive.** The relay is not
+  backup. Make it a reflex: last thing before you close, host saves.
+- **One canonical file per doc.** Decide who "owns" saving each file so
+  two people don't both Save As.
+- **Everyone on the same CardMirror version.** A version mismatch reads
+  like a broken relay. Update together.
+- **Treat share codes like passwords.** They grant read *and* write.
+  Send them one-to-one (DM), never to a group channel. If a code leaks,
+  end the session and start a new one — a new code, new key.
+- **Desktop-width windows in the web editor.** Narrow = mobile layout =
+  no collaboration.
+- **Sessions hold up to 10 people**, enforced when you connect. An
+  eleventh join is refused (HTTP 409). For a working group that's plenty;
+  it's not a lecture hall.
+
+---
+
+## Chromebook students
+
+Chromebook students run the **web editor** and can fully **join**
+sessions and edit. Whether they can *save a file back into a Drive-mounted
+location* (versus getting a download) is an
+[open question](./findings.md#open-questions) still being tested. Until
+that's settled, the safe pattern is: **a Windows/Mac host owns the file
+and saves; Chromebook partners join and edit.** Nobody loses work either
+way — the host's save is the file of record.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,33 @@
+# Debate Relay — one-click Deploy to Render blueprint.
+#
+# Coach experience: click "Deploy to Render", paste ONE connection
+# string (Supabase → Session pooler, NOT Direct — see docs/setup.md),
+# wait for the service to go Live, then copy two values into CardMirror
+# (the relay URL and the generated RELAY_TOKEN).
+#
+# Everything below the relay's own source lives in /relay; rootDir points
+# Render at it so the Dockerfile there is the build context.
+
+services:
+  - type: web
+    name: debate-relay
+    runtime: docker
+    rootDir: relay
+    plan: free              # no credit card required
+    region: oregon          # any region is fine; keep it near your team
+    healthCheckPath: /relay/health
+    # UptimeRobot pings this same path every 5 min to prevent cold starts
+    # (Render free tier sleeps after ~15 min idle; waking takes ~60s).
+    envVars:
+      # Shared bearer token for every machine on the team. Render mints a
+      # unique random value per deployment, so no two teams share a token
+      # and nothing sensitive is committed to the repo.
+      - key: RELAY_TOKEN
+        generateValue: true
+      # Supabase Postgres connection string. sync:false means Render will
+      # PROMPT for it at deploy time rather than reading it from the repo.
+      # Paste the Session pooler URI (host contains "pooler.supabase.com"),
+      # NOT the Direct connection — Direct is IPv6-only and Render dials
+      # IPv4, which fails silently at the very last step.
+      - key: DATABASE_URL
+        sync: false


### PR DESCRIPTION
Implements the Debate Relay project spec on top of the existing relay:

- render.yaml: one-click Deploy-to-Render blueprint (rootDir relay, Docker, free plan, /relay/health, RELAY_TOKEN generateValue, DATABASE_URL sync:false).
- dashboard/: static coach dashboard (no backend/build) with Health, Sessions, Stale, Storage, and Add-session panels. Reads Supabase via the anon key under RLS; schema.sql creates dashboard_registry and grants anon SELECT on relay_rooms and SELECT+INSERT on the registry only. Add-session keeps share-code segment two and discards the key.
- docs/: setup (35-min walkthrough), workflow (Drive vs relay, who saves), findings (verified live-hardware behavior), troubleshooting.
- README.debate-relay.md: findings-first project readme (separate file; CardMirror's README.md left intact).