### PR TITLE
Word Count window shows how many cards the scope holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ see `DETAILED_CHANGELOG.md`.
 
 ### Added
 
+- **Card count in Word Count.** The Word Count window now shows how
+  many cards are in the full document, or how many cards intersect the
+  current selection.
 - **Reading view (Word-style paginated columns).** The new book
   button on the ribbon (in the navigation pane toggle's old spot)
   flips the current document into full-screen column pages for

--- a/src/editor/word-count-ui.ts
+++ b/src/editor/word-count-ui.ts
@@ -8,7 +8,7 @@
 
 import type { EditorView } from 'prosemirror-view';
 import { settings } from './settings.js';
-import { countReadAloudSplit, totalWords, formatReadTimeFor, formatNumber } from './word-count.js';
+import { countCards, countReadAloudSplit, totalWords, formatReadTimeFor, formatNumber } from './word-count.js';
 import { setIcon } from './icons';
 import { pushOverlay, popOverlay } from './overlay-stack.js';
 import {
@@ -100,12 +100,16 @@ class WordCountModal {
       ? countReadAloudSplit(view.state.doc, sel.from, sel.to)
       : countReadAloudSplit(view.state.doc);
     const words = totalWords(counts);
+    const cards = hasSelection
+      ? countCards(view.state.doc, sel.from, sel.to)
+      : countCards(view.state.doc);
+    const cardLabel = `${formatNumber(cards)} ${cards === 1 ? 'card' : 'cards'}`;
 
     const scope = document.createElement('p');
     scope.className = 'pmd-wc-scope';
     scope.textContent = hasSelection
-      ? `Selection: ${formatNumber(words)} read-aloud words`
-      : `Full document: ${formatNumber(words)} read-aloud words`;
+      ? `Selection: ${formatNumber(words)} read-aloud words · ${cardLabel}`
+      : `Full document: ${formatNumber(words)} read-aloud words · ${cardLabel}`;
     body.appendChild(scope);
 
     const readers = settings.get('readers');

--- a/src/editor/word-count.ts
+++ b/src/editor/word-count.ts
@@ -75,6 +75,21 @@ export function totalWords(counts: ReadAloudCounts): number {
   return counts.body + counts.other;
 }
 
+/** Count structural cards intersecting [from, to). When the range is
+ * omitted, count every card in the document. */
+export function countCards(doc: PMNode, from?: number, to?: number): number {
+  const lo = from ?? 0;
+  const hi = to ?? doc.content.size;
+  if (lo >= hi) return 0;
+  let cards = 0;
+  doc.nodesBetween(lo, hi, (node) => {
+    if (node.type.name !== 'card') return true;
+    cards++;
+    return false;
+  });
+  return cards;
+}
+
 function readAloudBucket(node: PMNode, parent: PMNode): 'body' | 'other' | null {
   const parentType = parent.type.name;
   if (parentType === 'tag' || parentType === 'analytic') return 'other';

--- a/tests/editor/dialog-key-capture.test.ts
+++ b/tests/editor/dialog-key-capture.test.ts
@@ -192,6 +192,8 @@ describe('read-only modals (word count, shortcuts reference)', () => {
     const view = mkView();
     const before = view.state.doc.toJSON();
     openWordCount(view);
+    expect(document.querySelector('.pmd-wc-scope')?.textContent)
+      .toBe('Full document: 1 read-aloud words · 1 card');
     expect(isAnyOverlayOpen()).toBe(true);
     pressOnEditor(view, 'Backspace');
     pressOnEditor(view, 'Enter');

--- a/tests/editor/word-count.test.ts
+++ b/tests/editor/word-count.test.ts
@@ -13,6 +13,7 @@ import { schema } from '../../src/schema/index.js';
 import {
   countReadAloudSplit,
   countReadAloudWords,
+  countCards,
   totalWords,
   readTimeSeconds,
   formatReadTimeFor,
@@ -67,6 +68,48 @@ describe('countReadAloudSplit', () => {
 
   it('empty range counts nothing', () => {
     expect(countReadAloudSplit(fixtureDoc(), 3, 3)).toEqual({ body: 0, other: 0 });
+  });
+});
+
+describe('countCards', () => {
+  function cardDoc(): PMNode {
+    const card = (id: string, text: string) =>
+      n['card']!.create(null, [
+        n['tag']!.create({ id }, schema.text(`Tag ${id}`)),
+        n['card_body']!.create(null, schema.text(text)),
+      ]);
+    return n['doc']!.create(null, [
+      card('one', 'First body'),
+      n['paragraph']!.create(null, schema.text('Loose text')),
+      card('two', 'Second body'),
+    ]);
+  }
+
+  it('counts every structural card in the full document', () => {
+    expect(countCards(cardDoc())).toBe(2);
+  });
+
+  it('counts each card intersecting a selected range once', () => {
+    const doc = cardDoc();
+    const positions: number[] = [];
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'card') positions.push(pos);
+      return true;
+    });
+
+    expect(countCards(doc, positions[0]! + 2, positions[0]! + 5)).toBe(1);
+    expect(countCards(doc, positions[0]! + 2, positions[1]! + 3)).toBe(2);
+  });
+
+  it('returns zero when the selected range intersects no card', () => {
+    const doc = cardDoc();
+    let looseParagraphPos = -1;
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph') looseParagraphPos = pos;
+      return true;
+    });
+
+    expect(countCards(doc, looseParagraphPos + 1, looseParagraphPos + 5)).toBe(0);
   });
 });
 


### PR DESCRIPTION
Adds a report to the word count modal that also lists how many cards are in the selection (or the whole document).