### PR TITLE
Add card read-mode conversion command

### DIFF
--- a/src/editor/convert-cards-to-read-mode.ts
+++ b/src/editor/convert-cards-to-read-mode.ts
@@ -1,7 +1,19 @@
-/** Destructively reduce cards to the text shown by default read mode. */
+/**
+ * Destructively reduce cards to the text read mode shows.
+ *
+ * Every rule here is read mode's own: which text is audible comes from
+ * the read-mode plugin (`isReadModeKeptText` — highlights, cites, the
+ * reading-marker color, whatever the settings say), and the paragraph
+ * shape follows the "Read mode: preserve paragraph integrity" setting —
+ * off, a card's body paragraphs flow together into one; on, each source
+ * paragraph with audible text keeps its own line and empty ones collapse.
+ * Undertags and cites keep their own node with only their audible text,
+ * as read mode displays them.
+ */
 import type { Mark, Node as PMNode } from 'prosemirror-model';
 import type { Command, EditorState } from 'prosemirror-state';
 import { isReadModeKeptText } from './read-mode-plugin.js';
+import { settings } from './settings.js';
 
 interface CardAt {
   node: PMNode;
@@ -64,6 +76,8 @@ function selectedCards(state: EditorState): CardAt[] {
 }
 
 function convertCard(card: PMNode): PMNode {
+  const schema = card.type.schema;
+  const separateParagraphs = settings.get('readModeParagraphIntegrity');
   const sourceTag = card.firstChild!;
   const tagContent: PMNode[] = [];
   sourceTag.forEach((child) => {
@@ -72,33 +86,48 @@ function convertCard(card: PMNode): PMNode {
   const tag = sourceTag.type.create(sourceTag.attrs, tagContent, sourceTag.marks);
   const children: PMNode[] = [tag];
   let body = new AudibleInlineBuilder();
+  const flushBody = (): void => {
+    if (body.nodes.length > 0) children.push(schema.nodes['card_body']!.create(null, body.nodes));
+    body = new AudibleInlineBuilder();
+  };
+  // A body-like source paragraph: joined into the running body (read
+  // mode's default flow), or — with paragraph integrity on — its own
+  // paragraph when it has audible text, nothing at all when it has none.
+  const addBodyParagraph = (node: PMNode): void => {
+    if (!separateParagraphs) {
+      body.addTextblock(node);
+      return;
+    }
+    const one = new AudibleInlineBuilder();
+    one.addTextblock(node);
+    if (one.nodes.length === 0) return;
+    flushBody();
+    children.push(schema.nodes['card_body']!.create(null, one.nodes));
+  };
 
   card.forEach((child, _offset, index) => {
     if (index === 0) return;
-    if (child.type.name === 'cite_paragraph') {
+    if (child.type.name === 'cite_paragraph' || child.type.name === 'undertag') {
+      // Their own node, audible text only — read mode shows an undertag's
+      // highlighted words just as it shows a cite's.
       const kept = new AudibleInlineBuilder();
       kept.addTextblock(child);
       if (kept.nodes.length > 0) {
-        if (body.nodes.length > 0) {
-          children.push(card.type.schema.nodes['card_body']!.create(null, body.nodes));
-          body = new AudibleInlineBuilder();
-        }
+        flushBody();
         children.push(child.type.create(child.attrs, kept.nodes));
       }
     } else if (child.type.name === 'card_body') {
-      body.addTextblock(child);
+      addBodyParagraph(child);
     } else if (child.type.name === 'table') {
       child.descendants((descendant) => {
         if (descendant.type.name !== 'paragraph') return true;
-        body.addTextblock(descendant);
+        addBodyParagraph(descendant);
         return false;
       });
     }
   });
 
-  if (body.nodes.length > 0) {
-    children.push(card.type.schema.nodes['card_body']!.create(null, body.nodes));
-  }
+  flushBody();
   return card.type.createChecked(card.attrs, children, card.marks);
 }
 

--- a/src/editor/convert-cards-to-read-mode.ts
+++ b/src/editor/convert-cards-to-read-mode.ts
@@ -1,0 +1,119 @@
+/** Destructively reduce cards to the text shown by default read mode. */
+import type { Mark, Node as PMNode } from 'prosemirror-model';
+import type { Command, EditorState } from 'prosemirror-state';
+import { isReadModeKeptText } from './read-mode-plugin.js';
+
+interface CardAt {
+  node: PMNode;
+  pos: number;
+}
+
+class AudibleInlineBuilder {
+  readonly nodes: PMNode[] = [];
+  private pendingSpaceMarks: readonly Mark[] | null = null;
+
+  addTextblock(node: PMNode): void {
+    node.forEach((child) => {
+      if (!child.isText || !child.text) return;
+      if (!isReadModeKeptText(child, node.type.name)) {
+        this.breakRun();
+        return;
+      }
+      for (const token of child.text.match(/\s+|\S+/gu) ?? []) {
+        if (/^\s+$/u.test(token)) {
+          if (this.nodes.length > 0) this.pendingSpaceMarks = child.marks;
+          continue;
+        }
+        this.flushSpace(child.type.schema);
+        this.nodes.push(child.type.schema.text(token, child.marks));
+      }
+    });
+    this.breakRun();
+  }
+
+  private breakRun(): void {
+    if (this.nodes.length > 0) this.pendingSpaceMarks = [];
+  }
+
+  private flushSpace(schema: PMNode['type']['schema']): void {
+    if (this.nodes.length > 0 && this.pendingSpaceMarks !== null) {
+      this.nodes.push(schema.text(' ', this.pendingSpaceMarks));
+    }
+    this.pendingSpaceMarks = null;
+  }
+}
+
+function selectedCards(state: EditorState): CardAt[] {
+  if (!state.selection.empty) {
+    const cards: CardAt[] = [];
+    state.doc.nodesBetween(state.selection.from, state.selection.to, (node, pos) => {
+      if (node.type.name === 'analytic_unit') return false;
+      if (node.type.name !== 'card') return true;
+      cards.push({ node, pos });
+      return false;
+    });
+    return cards;
+  }
+
+  const { $from } = state.selection;
+  for (let depth = $from.depth; depth > 0; depth--) {
+    const node = $from.node(depth);
+    if (node.type.name === 'card') return [{ node, pos: $from.before(depth) }];
+  }
+  return [];
+}
+
+function convertCard(card: PMNode): PMNode {
+  const sourceTag = card.firstChild!;
+  const tagContent: PMNode[] = [];
+  sourceTag.forEach((child) => {
+    if (child.type.name !== 'image') tagContent.push(child);
+  });
+  const tag = sourceTag.type.create(sourceTag.attrs, tagContent, sourceTag.marks);
+  const children: PMNode[] = [tag];
+  let body = new AudibleInlineBuilder();
+
+  card.forEach((child, _offset, index) => {
+    if (index === 0) return;
+    if (child.type.name === 'cite_paragraph') {
+      const kept = new AudibleInlineBuilder();
+      kept.addTextblock(child);
+      if (kept.nodes.length > 0) {
+        if (body.nodes.length > 0) {
+          children.push(card.type.schema.nodes['card_body']!.create(null, body.nodes));
+          body = new AudibleInlineBuilder();
+        }
+        children.push(child.type.create(child.attrs, kept.nodes));
+      }
+    } else if (child.type.name === 'card_body') {
+      body.addTextblock(child);
+    } else if (child.type.name === 'table') {
+      child.descendants((descendant) => {
+        if (descendant.type.name !== 'paragraph') return true;
+        body.addTextblock(descendant);
+        return false;
+      });
+    }
+  });
+
+  if (body.nodes.length > 0) {
+    children.push(card.type.schema.nodes['card_body']!.create(null, body.nodes));
+  }
+  return card.type.createChecked(card.attrs, children, card.marks);
+}
+
+export const convertCardsToReadMode: Command = (state, dispatch) => {
+  const replacements = selectedCards(state)
+    .map((target) => ({ ...target, converted: convertCard(target.node) }))
+    .filter((target) => !target.converted.eq(target.node));
+  if (replacements.length === 0) return false;
+  if (dispatch) {
+    const tr = state.tr;
+    for (let index = replacements.length - 1; index >= 0; index--) {
+      const target = replacements[index]!;
+      tr.replaceWith(target.pos, target.pos + target.node.nodeSize, target.converted);
+    }
+    dispatch(tr.scrollIntoView());
+  }
+  return true;
+};

--- a/src/editor/read-mode-plugin.ts
+++ b/src/editor/read-mode-plugin.ts
@@ -245,6 +245,15 @@ function readKeptKind(nodeName: string): readonly string[] | 'heading' | null {
   return null;
 }
 
+/** Whether read mode keeps this inline text node visible in `parentType`.
+ *  Shared with destructive conversions so their audible-text rule cannot
+ *  drift from the display-only mode. */
+export function isReadModeKeptText(child: PMNode, parentType: string): boolean {
+  if (!child.isText) return false;
+  const kind = readKeptKind(parentType);
+  return kind === 'heading' || (kind !== null && isReadKept(child, kind));
+}
+
 /**
  * The position of the text read mode keeps VISIBLE that is nearest to
  * `pos` — a highlighted run, a cite, or heading/label text. Read-mode

--- a/src/editor/ribbon-commands.ts
+++ b/src/editor/ribbon-commands.ts
@@ -39,6 +39,7 @@ import { Selection, TextSelection, type Command, type EditorState, type Transact
 import type { EditorView } from 'prosemirror-view';
 import { toggleMark } from 'prosemirror-commands';
 import { toggleReadingMarkerCommand } from './reading-marker.js';
+import { convertCardsToReadMode } from './convert-cards-to-read-mode.js';
 import { openFootnoteEditor } from './footnote-popover.js';
 import { flipQuoteDirection } from './flip-quote-direction.js';
 import {
@@ -4312,6 +4313,7 @@ export type RibbonCommandId =
   | 'standardizeShading'
   | 'standardizeHighlightExcept'
   | 'standardizeShadingExcept'
+  | 'convertCardsToReadMode'
   | 'toggleReadMode'
   | 'toggleReaderView'
   | 'openContainingFolder'
@@ -4544,6 +4546,7 @@ export const RIBBON_COMMAND_IDS: RibbonCommandId[] = [
   'standardizeShading',
   'standardizeHighlightExcept',
   'standardizeShadingExcept',
+  'convertCardsToReadMode',
   'toggleReadMode',
   'toggleReaderView',
   'openContainingFolder',
@@ -4728,6 +4731,7 @@ export const RIBBON_COMMAND_LABELS: Record<RibbonCommandId, string> = {
   standardizeShading: 'Standardize Background Color',
   standardizeHighlightExcept: 'Standardize Highlighting (with Exception)',
   standardizeShadingExcept: 'Standardize Background Color (with Exception)',
+  convertCardsToReadMode: 'Convert Cards to Read Mode',
   toggleReadMode: 'Toggle Read Mode',
   toggleReaderView: 'Toggle Reading View',
   openContainingFolder: 'Open Containing Folder',
@@ -4898,6 +4902,7 @@ export const RIBBON_COMMAND_ALIASES: Partial<Record<RibbonCommandId, readonly st
   // show/hide ⇄ toggle visibility pairs
   toggleCommentsVisible: ['toggle comments', 'comments'],
   toggleNavPane: ['toggle navigation pane', 'toggle nav pane', 'sidebar', 'outline pane'],
+  convertCardsToReadMode: ['zap card', 'zap cards'],
   toggleReadMode: ['show read mode', 'hide read mode', 'invisibility mode'],
   toggleReaderView: ['reading view', 'reader view', 'paginated view', 'read view', 'book view', 'columns'],
   openContainingFolder: ['reveal in finder', 'show in folder', 'show in explorer', 'reveal file', 'file location', 'containing folder'],
@@ -5072,6 +5077,7 @@ export const DEFAULT_RIBBON_KEYS: Record<RibbonCommandId, string | string[]> = {
   standardizeShading: '',
   standardizeHighlightExcept: '',
   standardizeShadingExcept: '',
+  convertCardsToReadMode: '',
   toggleReadMode: '',
   toggleReaderView: '',
   openContainingFolder: '',
@@ -5744,6 +5750,8 @@ function commandFor(id: RibbonCommandId, ctx: RibbonContext): Command {
           state.selection.empty ? 'document' : 'selection',
           () => settings.get('standardizeShadingException'),
         )(state, dispatch, view);
+    case 'convertCardsToReadMode':
+      return convertCardsToReadMode;
     case 'toggleReadMode':
       return (_state, dispatch) => {
         if (!dispatch) return true;

--- a/src/editor/ribbon-groups.ts
+++ b/src/editor/ribbon-groups.ts
@@ -112,6 +112,7 @@ export const RIBBON_GROUPS: RibbonGroup[] = [
       'smartShrink',
       'regrow',
       'copyPreviousCite',
+      'convertCardsToReadMode',
       'createReference',
       'extractUndertag',
       'insertImage',

--- a/tests/editor/convert-cards-to-read-mode.test.ts
+++ b/tests/editor/convert-cards-to-read-mode.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, afterEach } from 'vitest';
 import { EditorState, TextSelection } from 'prosemirror-state';
 import { schema } from '../../src/schema/index.js';
+import { settings } from '../../src/editor/settings.js';
 import {
   DEFAULT_RIBBON_KEYS,
   RIBBON_COMMAND_ALIASES,
@@ -238,6 +239,74 @@ describe('Convert Cards to Read Mode command', () => {
     expect(Array.from({ length: converted.childCount }, (_, index) =>
       converted.child(index).textContent,
     )).toEqual(['Ordered card', 'before', 'source', 'after']);
+  });
+
+  it('keeps an undertag\'s highlighted text as an undertag, the way read mode reads it', () => {
+    const highlight = schema.marks['highlight']!.create({ color: 'yellow' });
+    const card = schema.nodes['card']!.createChecked(null, [
+      schema.nodes['tag']!.create({ id: 'under-card' }, schema.text('Under card')),
+      schema.nodes['undertag']!.create(null, [
+        schema.text('unread under '),
+        schema.text('kept under', [highlight]),
+      ]),
+      schema.nodes['card_body']!.create(null, [
+        schema.text('unread '),
+        schema.text('kept body', [highlight]),
+      ]),
+    ]);
+    const doc = schema.nodes['doc']!.createChecked(null, [card]);
+    const base = EditorState.create({ doc });
+    const state = base.apply(base.tr.setSelection(TextSelection.create(doc, 2)));
+    let next: EditorState | null = null;
+
+    getRibbonCommand('convertCardsToReadMode')(
+      state,
+      (tr) => { next = state.apply(tr); },
+    );
+
+    const converted = next!.doc.firstChild!;
+    expect(Array.from({ length: converted.childCount }, (_, index) => converted.child(index).type.name))
+      .toEqual(['tag', 'undertag', 'card_body']);
+    expect(converted.child(1).textContent).toBe('kept under');
+    expect(converted.child(2).textContent).toBe('kept body');
+  });
+
+  describe('follows read mode\'s paragraph-integrity setting', () => {
+    const before = settings.get('readModeParagraphIntegrity');
+    afterEach(() => settings.set('readModeParagraphIntegrity', before));
+
+    function twoBodyCard() {
+      const highlight = schema.marks['highlight']!.create({ color: 'yellow' });
+      const card = schema.nodes['card']!.createChecked(null, [
+        schema.nodes['tag']!.create({ id: 'para-card' }, schema.text('Paragraphs')),
+        schema.nodes['card_body']!.create(null, [schema.text('unread '), schema.text('first', [highlight])]),
+        schema.nodes['card_body']!.create(null, schema.text('nothing read here')),
+        schema.nodes['card_body']!.create(null, [schema.text('second', [highlight]), schema.text(' unread')]),
+      ]);
+      const doc = schema.nodes['doc']!.createChecked(null, [card]);
+      const base = EditorState.create({ doc });
+      return base.apply(base.tr.setSelection(TextSelection.create(doc, 2)));
+    }
+    function convert(state: EditorState): EditorState {
+      let next: EditorState | null = null;
+      getRibbonCommand('convertCardsToReadMode')(state, (tr) => { next = state.apply(tr); });
+      return next!;
+    }
+
+    it('off: the body paragraphs flow together into one', () => {
+      settings.set('readModeParagraphIntegrity', false);
+      const converted = convert(twoBodyCard()).doc.firstChild!;
+      expect(converted.childCount).toBe(2);
+      expect(converted.child(1).textContent).toBe('first second');
+    });
+
+    it('on: each paragraph with audible text keeps its own line; empty ones collapse', () => {
+      settings.set('readModeParagraphIntegrity', true);
+      const converted = convert(twoBodyCard()).doc.firstChild!;
+      expect(converted.childCount).toBe(3);
+      expect(converted.child(1).textContent).toBe('first');
+      expect(converted.child(2).textContent).toBe('second');
+    });
   });
 
   it('removes inline images that read mode hides from tags', () => {

--- a/tests/editor/convert-cards-to-read-mode.test.ts
+++ b/tests/editor/convert-cards-to-read-mode.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState, TextSelection } from 'prosemirror-state';
+import { schema } from '../../src/schema/index.js';
+import {
+  DEFAULT_RIBBON_KEYS,
+  RIBBON_COMMAND_ALIASES,
+  RIBBON_COMMAND_IDS,
+  RIBBON_COMMAND_LABELS,
+  getRibbonCommand,
+} from '../../src/editor/ribbon-commands.js';
+
+describe('Convert Cards to Read Mode command', () => {
+  it('is available from the command palette without claiming a default shortcut', () => {
+    const id = 'convertCardsToReadMode' as const;
+
+    expect(RIBBON_COMMAND_IDS).toContain(id);
+    expect(RIBBON_COMMAND_LABELS).toHaveProperty(id, 'Convert Cards to Read Mode');
+    expect(DEFAULT_RIBBON_KEYS).toHaveProperty(id, '');
+    expect(RIBBON_COMMAND_ALIASES).toHaveProperty(id, expect.arrayContaining(['zap card', 'zap cards']));
+    expect(getRibbonCommand(id as never)).toEqual(expect.any(Function));
+  });
+
+  it('converts the cursor card to the same audible content as default read mode', () => {
+    const highlight = schema.marks['highlight']!.create({ color: 'yellow' });
+    const cite = schema.marks['cite_mark']!.create();
+    const emphasis = schema.marks['emphasis_mark']!.create();
+    const tag = schema.nodes['tag']!.create({ id: 'tag-1' }, schema.text('Tag stays'));
+    const source = schema.nodes['cite_paragraph']!.create(null, [
+      schema.text('ignore '),
+      schema.text('Smith 24', [cite]),
+      schema.text(' noise '),
+      schema.text('p. 3', [highlight]),
+    ]);
+    const card = schema.nodes['card']!.createChecked(
+      { numRole: 'number', numRestart: true },
+      [
+        tag,
+        schema.nodes['undertag']!.create(null, schema.text('Undertag disappears')),
+        source,
+        schema.nodes['card_body']!.create(null, [
+          schema.text('unread '),
+          schema.text('first card text', [highlight]),
+        ]),
+        schema.nodes['card_body']!.create(null, [
+          schema.text('more noise '),
+          schema.text('second card text', [highlight, emphasis]),
+        ]),
+        schema.nodes['card_body']!.create(null, schema.text('all unread')),
+      ],
+    );
+    const doc = schema.nodes['doc']!.createChecked(null, [card]);
+    const base = EditorState.create({ doc });
+    const state = base.apply(base.tr.setSelection(TextSelection.create(doc, 2)));
+    let next: EditorState | null = null;
+
+    const handled = getRibbonCommand('convertCardsToReadMode')(
+      state,
+      (tr) => { next = state.apply(tr); },
+    );
+
+    expect(handled).toBe(true);
+    expect(next).not.toBeNull();
+    const converted = next!.doc.firstChild!;
+    expect(converted.attrs).toMatchObject({ numRole: 'number', numRestart: true });
+    expect(converted.childCount).toBe(3);
+    expect(converted.child(0).type.name).toBe('tag');
+    expect(converted.child(0).attrs['id']).toBe('tag-1');
+    expect(converted.child(0).textContent).toBe('Tag stays');
+    expect(converted.child(1).type.name).toBe('cite_paragraph');
+    expect(converted.child(1).textContent).toBe('Smith 24 p. 3');
+    expect(converted.child(2).type.name).toBe('card_body');
+    expect(converted.child(2).textContent).toBe('first card text second card text');
+    expect(converted.child(2).lastChild!.marks.map((mark) => mark.type.name)).toEqual([
+      'emphasis_mark',
+      'highlight',
+    ]);
+  });
+
+  it('converts every selected card in one transaction without converting analytics', () => {
+    const highlight = schema.marks['highlight']!.create({ color: 'yellow' });
+    const makeCard = (id: string, kept: string) =>
+      schema.nodes['card']!.createChecked(null, [
+        schema.nodes['tag']!.create({ id }, schema.text(id)),
+        schema.nodes['card_body']!.create(null, [
+          schema.text('unread '),
+          schema.text(kept, [highlight]),
+        ]),
+      ]);
+    const analytic = schema.nodes['analytic_unit']!.createChecked(null, [
+      schema.nodes['analytic']!.create({ id: 'analytic-1' }, schema.text('Analysis')),
+      schema.nodes['card_body']!.create(null, [
+        schema.text('analytic unread '),
+        schema.text('analytic kept', [highlight]),
+      ]),
+    ]);
+    const doc = schema.nodes['doc']!.createChecked(null, [
+      makeCard('card-a', 'alpha'),
+      analytic,
+      makeCard('card-b', 'bravo'),
+      makeCard('card-c', 'charlie'),
+    ]);
+    let cardBPos = -1;
+    doc.forEach((node, offset) => {
+      if (node.type.name === 'card' && node.firstChild!.attrs['id'] === 'card-b') cardBPos = offset;
+    });
+    const base = EditorState.create({ doc });
+    const state = base.apply(
+      base.tr.setSelection(TextSelection.create(doc, 2, cardBPos + 2)),
+    );
+    let next: EditorState | null = null;
+    let dispatches = 0;
+
+    const handled = getRibbonCommand('convertCardsToReadMode')(
+      state,
+      (tr) => {
+        dispatches++;
+        next = state.apply(tr);
+      },
+    );
+
+    expect(handled).toBe(true);
+    expect(dispatches).toBe(1);
+    expect(next!.doc.child(0).lastChild!.textContent).toBe('alpha');
+    expect(next!.doc.child(1).eq(analytic)).toBe(true);
+    expect(next!.doc.child(2).lastChild!.textContent).toBe('bravo');
+    expect(next!.doc.child(3).lastChild!.textContent).toBe('unread charlie');
+  });
+
+  it('collects every audible body source into document order', () => {
+    const highlight = schema.marks['highlight']!.create({ color: 'yellow' });
+    const marker = schema.marks['font_color']!.create({ color: 'FF0000' });
+    const firstCell = schema.nodes['table_cell']!.create(null, [
+      schema.nodes['paragraph']!.create(null, [
+        schema.text('cell noise '),
+        schema.text('table alpha', [highlight]),
+      ]),
+    ]);
+    const secondCell = schema.nodes['table_cell']!.create(null, [
+      schema.nodes['paragraph']!.create(null, [
+        schema.text('table bravo', [highlight]),
+        schema.text(' more noise'),
+      ]),
+    ]);
+    const table = schema.nodes['table']!.create(null, [
+      schema.nodes['table_row']!.create(null, [
+        firstCell,
+        secondCell,
+      ]),
+    ]);
+    const card = schema.nodes['card']!.createChecked(null, [
+      schema.nodes['tag']!.create({ id: 'table-card' }, schema.text('Table card')),
+      schema.nodes['card_body']!.create(null, [
+        schema.text('body', [highlight]),
+        schema.text(' hidden '),
+        schema.text('marker', [marker]),
+      ]),
+      table,
+    ]);
+    const doc = schema.nodes['doc']!.createChecked(null, [card]);
+    const base = EditorState.create({ doc });
+    const state = base.apply(base.tr.setSelection(TextSelection.create(doc, 2)));
+    let next: EditorState | null = null;
+
+    const handled = getRibbonCommand('convertCardsToReadMode')(
+      state,
+      (tr) => { next = state.apply(tr); },
+    );
+
+    expect(handled).toBe(true);
+    expect(next!.doc.firstChild!.childCount).toBe(2);
+    expect(next!.doc.firstChild!.lastChild!.textContent).toBe(
+      'body marker table alpha table bravo',
+    );
+  });
+
+  it('expands a within-card text selection to the whole card', () => {
+    const highlight = schema.marks['highlight']!.create({ color: 'yellow' });
+    const card = schema.nodes['card']!.createChecked(null, [
+      schema.nodes['tag']!.create({ id: 'selected-card' }, schema.text('Selected card')),
+      schema.nodes['card_body']!.create(null, [
+        schema.text('unread prefix '),
+        schema.text('kept words', [highlight]),
+        schema.text(' unread suffix'),
+      ]),
+    ]);
+    const doc = schema.nodes['doc']!.createChecked(null, [card]);
+    let bodyStart = -1;
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'card_body') bodyStart = pos + 1;
+    });
+    const base = EditorState.create({ doc });
+    const state = base.apply(
+      base.tr.setSelection(TextSelection.create(doc, bodyStart + 2, bodyStart + 5)),
+    );
+    let next: EditorState | null = null;
+
+    const handled = getRibbonCommand('convertCardsToReadMode')(
+      state,
+      (tr) => { next = state.apply(tr); },
+    );
+
+    expect(handled).toBe(true);
+    expect(next!.doc.firstChild!.lastChild!.textContent).toBe('kept words');
+  });
+
+  it('preserves audible body and cite order', () => {
+    const highlight = schema.marks['highlight']!.create({ color: 'yellow' });
+    const cite = schema.marks['cite_mark']!.create();
+    const card = schema.nodes['card']!.createChecked(null, [
+      schema.nodes['tag']!.create({ id: 'ordered-card' }, schema.text('Ordered card')),
+      schema.nodes['card_body']!.create(null, [
+        schema.text('ignore '),
+        schema.text('before', [highlight]),
+      ]),
+      schema.nodes['cite_paragraph']!.create(null, [
+        schema.text('source', [cite]),
+        schema.text(' ignored'),
+      ]),
+      schema.nodes['card_body']!.create(null, [
+        schema.text('after', [highlight]),
+        schema.text(' ignored'),
+      ]),
+    ]);
+    const doc = schema.nodes['doc']!.createChecked(null, [card]);
+    const base = EditorState.create({ doc });
+    const state = base.apply(base.tr.setSelection(TextSelection.create(doc, 2)));
+    let next: EditorState | null = null;
+
+    getRibbonCommand('convertCardsToReadMode')(
+      state,
+      (tr) => { next = state.apply(tr); },
+    );
+
+    const converted = next!.doc.firstChild!;
+    expect(Array.from({ length: converted.childCount }, (_, index) =>
+      converted.child(index).type.name,
+    )).toEqual(['tag', 'card_body', 'cite_paragraph', 'card_body']);
+    expect(Array.from({ length: converted.childCount }, (_, index) =>
+      converted.child(index).textContent,
+    )).toEqual(['Ordered card', 'before', 'source', 'after']);
+  });
+
+  it('removes inline images that read mode hides from tags', () => {
+    const image = schema.nodes['image']!.create({
+      data: 'aGVsbG8=',
+      contentType: 'image/png',
+      widthEmu: 9525,
+      heightEmu: 9525,
+      alt: 'hidden image',
+    });
+    const tag = schema.nodes['tag']!.create({ id: 'image-tag' }, [
+      schema.text('Visible '),
+      image,
+      schema.text('tag'),
+    ]);
+    const card = schema.nodes['card']!.createChecked(null, [
+      tag,
+      schema.nodes['card_body']!.create(null, schema.text('unread')),
+    ]);
+    const doc = schema.nodes['doc']!.createChecked(null, [card]);
+    const base = EditorState.create({ doc });
+    const state = base.apply(base.tr.setSelection(TextSelection.create(doc, 2)));
+    let next: EditorState | null = null;
+
+    getRibbonCommand('convertCardsToReadMode')(
+      state,
+      (tr) => { next = state.apply(tr); },
+    );
+
+    const convertedTag = next!.doc.firstChild!.firstChild!;
+    expect(convertedTag.textContent).toBe('Visible tag');
+    expect(convertedTag.childCount).toBe(1);
+    expect(convertedTag.firstChild!.isText).toBe(true);
+  });
+});


### PR DESCRIPTION
This adds functionality comparable to the [ZapCard](https://github.com/shreerammodi/debate-scripts/blob/main/zapper.bas) macro. The function accepts a selection, and destructively converts all cards in that selection to a zapped (read) version.

This is useful for:
- seeing and quickly judging highlighting of evidence
- pulling lines from cards
- identifying poorly highlighted evidence in speeches