### PR TITLE
Features list and app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ preview** in any browser for trying it out or working from a Chromebook
 or locked-down school machine.
 
 **▶ Try the live web preview: <https://cardmirror.app/>**
+https://d.ebate.app/debate
+https://debate-ai.com/debate
+
+**▶ Debate-AI.com hosts CardMirror with cloud storage sidebar, live rounds, flows, videos, and AI research.**: <https://debate-ai.com/debate> (also <https://d.ebate.app/debate>).
+
 
 > **Keep backups.** CardMirror is stable and used daily, but no
 > editor is bug-free — keep a copy of anything critical in a second
@@ -27,6 +32,48 @@ or locked-down school machine.
 > **Desktop builds are unsigned**, so Windows and macOS warn you the
 > first time you launch. The one-time workaround for each is in the
 > install steps below.
+
+## Features
+
+### A. Document & files
+
+1. 📝 **Structured outline:** Pockets, hats, blocks, tags, cards, analytics, and undertags as first-class node types; includes footnotes, tables, and live/transcluded zones.
+
+2. 💾 **Lossless `.docx` and `.cmir` round-trip:** Verbatim Word interoperability plus a native gzip save format, including encrypted `.docx` decryption and damaged-file salvage.
+
+3. 🔁 **Bulk conversion and compression:** Automatic style cleanup on import, plus a headless `cardmirror-read` CLI/MCP tool for AI-assistant access to files outside the app.
+
+### B. Cutting & formatting
+
+1. 🏷️ **One-click structural styles:** Pocket, Hat, Block, Tag, Analytic, and Undertag styles, plus citation, underline, and emphasis marks with acronym-aware variants.
+
+2. 🎨 **Color and highlighting controls:** Highlight, shading, and font-color pickers; standardization commands; paintbrush mode; and highlight locking.
+
+3. 🔢 **Editing utilities:** Card numbering, multiple condense modes, shrink/regrow, short citations, live-zone refresh, and heading move/copy/delete controls.
+
+### C. Collaboration & workflow
+
+1. 👥 **Real-time collaboration:** CRDT-backed collaboration via Loro with share codes, invite links, and version recovery.
+
+2. 🎤 **Speech-document targeting:** Mark a document as the live send target, send content at the cursor or document end, and retain a persistent send history.
+
+3. 🌊 **Flow integration:** Send cards or headings directly to a Flow column or cell, or pull content back into the document.
+
+4. 📇 **Card exchange and command search:** Dropzone card exchange, Quick Cards, and a unified command bar that searches cards, commands, settings, and roughly 50 additional site tools.
+
+### D. AI, learning & chrome
+
+1. 🤖 **AI tools:** Ask questions about selected text, generate citations, translate content, and repair text or formatting with AI assistance.
+
+2. 🗂️ **Learning tools:** Flashcards with spaced-repetition review, a card-cutter panel, voice dictation, and reading-marker mode.
+
+3. 🧩 **Customization and extensibility:** Runtime plugin registry, a 12-category menu bar, customizable keybindings, and per-user preferences synced to account settings.
+
+4. 🖥️ **Native desktop and mobile app:** A Tauri wrapper running the same editor experience without browser chrome.
+
+   
+
+## Support
 
 See [`MANUAL.md`](./MANUAL.md) for the full user
 manual; [`PRIVACY.md`](./PRIVACY.md) for how CardMirror handles your data;
@@ -37,7 +84,6 @@ manual; [`PRIVACY.md`](./PRIVACY.md) for how CardMirror handles your data;
 
 You can find a video walkthrough of CardMirror's basic functions [here](https://www.youtube.com/playlist?list=PLXM5iwKNQkSs). 
 
-## Support
 
 The core CardMirror editor is free, and built and maintained by one
 person. If it's useful to you, two ways to help keep it going:


### PR DESCRIPTION
## Add CardMirror Feature Overview and DebateAI Link

This PR expands the README with a clearer overview of CardMirror’s current feature set and adds a direct link to **DebateAI**, the platform that hosts the application.

### README updates

- Added a structured “Features” section covering document/file support, editing and formatting tools, collaboration workflows, AI capabilities, learning tools, extensibility, and native-app support.

- Documented first-class outline nodes including pockets, hats, blocks, tags, cards, analytics, undertags, footnotes, tables, and live/transcluded zones.

- Highlighted `.docx` and `.cmir` round-tripping, file recovery, encrypted Word-document handling, conversion/compression workflows, and the headless `cardmirror-read` CLI/MCP tool.

- Added collaboration, Flow integration, speech-document targeting, Dropzone exchange, Quick Cards, and unified command-bar discovery features.

- Included AI-assisted citation generation, translation, selection Q&A, text/formatting repair, spaced-repetition flashcards, voice dictation, plugins, keybindings, and the native Tauri wrapper.

- Added a link to [DebateAI](https://debate-ai.com), where CardMirror is hosted and available to use.


PS. Consider that open source devs should please respect all contributions and PRs and not ignore out of dislike. if someone cannot handle free speech they do not belong in debate. We do not want to see debate fail to grow if eveyrone is so toxic and looks to exclude over trivial differences then people don't work together and societies fall apart. Don't contribute to that