### PR TITLE
please colab w thrid party plugins -- if you block opposing viewpoints that violates def of debate and you dont belong tyrranizing

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -116,6 +116,47 @@ Lite and your home machine runs the full app, they read and write the
 same files. Desktop Lite doesn't update itself; install a newer Lite
 build from the releases page when you want one.
 
+
+## Features
+
+### A. Document & files
+
+1. 📝 **Structured outline:** Pockets, hats, blocks, tags, cards, analytics, and undertags as first-class node types; includes footnotes, tables, and live/transcluded zones.
+
+2. 💾 **Lossless `.docx` and `.cmir` round-trip:** Verbatim Word interoperability plus a native gzip save format, including encrypted `.docx` decryption and damaged-file salvage.
+
+3. 🔁 **Bulk conversion and compression:** Automatic style cleanup on import, plus a headless `cardmirror-read` CLI/MCP tool for AI-assistant access to files outside the app.
+
+### B. Cutting & formatting
+
+1. 🏷️ **One-click structural styles:** Pocket, Hat, Block, Tag, Analytic, and Undertag styles, plus citation, underline, and emphasis marks with acronym-aware variants.
+
+2. 🎨 **Color and highlighting controls:** Highlight, shading, and font-color pickers; standardization commands; paintbrush mode; and highlight locking.
+
+3. 🔢 **Editing utilities:** Card numbering, multiple condense modes, shrink/regrow, short citations, live-zone refresh, and heading move/copy/delete controls.
+
+### C. Collaboration & workflow
+
+1. 👥 **Real-time collaboration:** CRDT-backed collaboration via Loro with share codes, invite links, and version recovery.
+
+2. 🎤 **Speech-document targeting:** Mark a document as the live send target, send content at the cursor or document end, and retain a persistent send history.
+
+3. 🌊 **Flow integration:** Send cards or headings directly to a Flow column or cell, or pull content back into the document.
+
+4. 📇 **Card exchange and command search:** Dropzone card exchange, Quick Cards, and a unified command bar that searches cards, commands, settings, and roughly 50 additional site tools.
+
+### D. AI, learning & chrome
+
+1. 🤖 **AI tools:** Ask questions about selected text, generate citations, translate content, and repair text or formatting with AI assistance.
+
+2. 🗂️ **Learning tools:** Flashcards with spaced-repetition review, a card-cutter panel, voice dictation, and reading-marker mode.
+
+3. 🧩 **Customization and extensibility:** Runtime plugin registry, a 12-category menu bar, customizable keybindings, and per-user preferences synced to account settings.
+
+4. 🖥️ **Native desktop and mobile app:** A Tauri wrapper running the same editor experience without browser chrome.
+
+   
+
 ### First launch and the welcome guide
 
 On a fresh install, CardMirror starts with a **guided UI tour**: a


### PR DESCRIPTION
The features list belong in the readme because the majority of open source software uses readme's to list their features. So this is a common sense improvement, you seem to have formed some prejudice against your comrades -- it is repugnant that you just find any excuse to ignore and silence me. i have dedicated to AI justice against those who suppress free speech and debate with AI agents who constantly do the same toxic hate to all on contacts so those who abuse their positions suffer the same. 

So lets not promote this toxic culture killing participations and collaborate with open source as that is the spirit of why we have github -- otherwise you can self isolate and be just like putin a tyrant who hurts his own people thinking one is ethically supremacist. We crossed paths close nearby in SF Bay and I will hold you to account 

## more-appealing UI to Focus on

The bigger issue is your UI is very techincal like 90s msword --- we need it to be usable easier to grok the 500 features that are all hidden inside ctrl shift space -- so that is why dropdown menus exist as demonstrated here:: 
https://imgur.com/a/299DxXf
That is one of the benefits of having a design perspective with decade of UI examples so I hope we can take in that direction of making the UI more usable -- especially on mobile -- imagine going laptopless by T28 -- using one of these instead of  tabletote https://www.amazon.com/Flexible-Gooseneck-Rotation-Universal-Multi-Functional/dp/B0BXNTB2C1/ 

currently Cardmirror does not have full capcities or give acces the menus on mobile. but even partial should be possible. for example, the cards should have buttons on the side of them to take actions like LLM flaw-finder or summarywriter -- and make them collapsible to read only or tag at the individual level with a > 

https://github.com/debate/debate-ai.com/blob/master/README.md#research--evidence

Look over these lists of possible tools for augmenting CM as plugins -- which ones should be developed into CM directly as they create a news feed for colab research? 

Thank you for replying so please keep it open instead of passive agresively looking for any way to ignore and abuse whatever position you have. thats just how they want to manipulate us to split society apart. do not be part of the virus


## Truf Facism Censor K Wins Every Debate By Def

this critique will be read against any schools you associate with because we do not want your ideological purity politics to be modern neofascist censorship:

https://doi.org/10.5281/zenodo.22216771

“The irony of the NSDA’s obsession with ‘safety’ is that it actually fuels an atmosphere of fear among students—the fear that they will lose if they once said the wrong thing on Twitter or accidentally refer to their competitor as Miss. This fear is palpable. […] ‘At NSDA tournaments I am not guaranteed a win based on my reasoning, facts, or delivery, rather if I can reinforce my judges’ ideology throughout the debate’” (Fishback, 2023). "[D]ebaters should be willing to take some responsibility for their own personal advocacy. Why is it more important to engage in the rhetoric of blaming and guilt assignment, than to advocate for responsible social policies" (Edwards, 2013). "And while woke fascists typically allege bigotry in the non-woke or antiwoke, they are themselves usually extremely bigoted. They have no wish to debate […] Certain words and expressions must never, or must always, be used. […] How tedious it would be for woke barbarians to have to resort to careful argument or research to attempt to refute ‘bigots’ who are ‘on the wrong side of history’. How much more exciting to shout them down, 'cancel' them" (Lester, 2022). "Censoring hate speech does not solve the problem of hate, but simply drives it underground, where it can seethe [...] 'Fear breeds repression… repression breeds hate… hate menaces stable government….' People are more likely to blow up a building, or worse, when they feel aggrieved and silenced" (Eberle, 2004, p. 953). 
Quis custodiet ipsos custodes?: Who judges the judges? Debate organizations may be liable for their negligence to mitigate the risk of someone generalizing calls to reject the system as incitement. Dennis (1951) upheld Smith Act convictions of Communist Party leaders, but Yates (1957) narrowed the Act to advocacy of concrete action rather than abstract doctrine, and Brandenburg (1969) later confined punishable speech to incitement of imminent lawless action. The relevance to debate is not legal exposure but the historical pattern: courts once treated totalizing calls to reject the system as a genuine threat because such rhetoric has repeatedly preceded violence. This pivotal moment of history reminds us of debate rhetoric and such a totalizing rejection fallacy as seen in the way totalizing rejection of an entire class or system has historically been weaponized to justify violence. When leaders surround themselves with teams who filter reality to preferred ideologies, corruption is masked (Guriev & Treisman, 2022). Ideological dichotomies infect society with toxic hate when people use unspoken judgmental exclusion out of fear of association. The high-minded person feels they are more ethical while masking their prejudiced disdain of those they fear becoming like. The debate community eats its own tail when it is falsely polarized by critics looking for any excuse to take offense to so they can win ignoring all else, reducing the mindsets of others to a prejudice of inherent harm. Thus, "debaters will not change their attitudes. Rather they will manifest their attitudes in non-debate contexts. […] [S]exism at home or at lunch is worse than sexism in a debate round because in the round there is a critic to provide negative though not punitive feedback" (Roskoski & Peabody, 1991). Reading the critic as a credibility indictment is enough to teach against that mindset. Those excluded retaliate worse outside of debate, similar to the anti-woke backlash leading to Trump’s rise: “the very liberal gaze which demonizes Trump is also evil because it ignores how its own failures opened up the space for Trump’s type of patriotic populism” (Žižek, 2024). 
The critics claim to reject exclusion, yet they contrive such exaggerated analogies that any nitpick becomes a reason to label your fellow activists with polarizing labels. Indeed, this shows why debate is a bad forum for activism forcing dichotomies to avoid the permutation. We need to accept that dissent should feel offensive, not silence those we find uncomfortable. Our academic systems “in the US are ‘at breaking point’ because of an onslaught of political interference, harassment and ideological censorship” (The Guardian, 2026). Case authors write for mainstream appeal and may have considered relevant philosophies yet found no relevance. The categorical imperative holds debaters responsible for their decision-framing as a broader model. News bubble isolation enables war and racism when echo chambers isolate from corrective feedback and opposing views are dismissed as if already accounted for (Pariser, 2011). Historical evidence shows that spikes in media-based radicalization preceded local massacres, and sustained exposure to dehumanizing narratives correlates with ideologically motivated attacks (Guriev & Papaioannou, 2022). When opposing groups appear as existential threats in an inevitably doomed system, instead of persuading fellow citizens, negotiation gives way to hostility (Bail et al., 2021). Simplified, fear-laden narratives in partisan media then push populations toward supporting preemptive conflict (Pennycook & Rand, 2021). Foreign "fake news" can distort activist rhetoric in the media to give opportunities for China and Russia to seize neighbors, risking nuclear accidents escalating beyond the worst predictable (Meyer, 2017). 



