### PR TITLE
Last workspace: reopen the documents you had open last time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,11 @@ see `DETAILED_CHANGELOG.md`.
   whole list, so coming back to a 15-document workspace doesn't have to
   mean reopening all 15. In the three-pane workspace each document
   returns to the pane it was in; in single-document mode each gets its
-  own window. Turn on **Settings → General → Workspace → Reopen last
-  workspace at launch** to have it happen automatically at every start —
-  and because unticking a document is a standing choice rather than a
-  one-off filter, the automatic reopen honours it too: untick a file
-  once and it stops coming back every launch, without having to turn
-  the whole feature off. Since launch skips the Home screen, each
-  automatic reopen leaves a note in the status bar's ⚠ chip saying what
-  it opened and where to change it.
+  own window. Nothing is reopened behind your back — a launch with no
+  file lands on the Home screen as it always has, and the set waits
+  there until you click. Ticks are remembered between sessions, so a
+  document you untick stays unticked as the set changes from one
+  session to the next.
   Closing everything before you quit clears the set — a clean quit
   means a clean start — unless you deliberately saved it with the new
   **Save Workspace** command, which keeps a working set on offer until

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ changes in each release, written for users of the editor. For
 in-depth rationale and implementation context behind each entry,
 see `DETAILED_CHANGELOG.md`.
 
+## Unreleased
+
+### Added
+
+- **Last workspace — reopen everything you had open.** CardMirror now
+  remembers the documents open when you last quit and offers them back
+  on the Home screen under **Last workspace**: one click reopens the
+  whole set. In the three-pane workspace each document returns to the
+  pane it was in; in single-document mode each gets its own window.
+  Turn on **Settings → General → Workspace → Reopen last workspace at
+  launch** to have it happen automatically at every start. Two new
+  command-bar commands go with it (both unbound by default): **Save
+  Workspace**, which snapshots what's open right now so you can return
+  to a particular working set later, and **Reopen Last Workspace**,
+  which restores it without going via the Home screen. **Forget** on
+  the Home screen drops the snapshot. Desktop only — reopening needs
+  files on disk — and documents you never saved aren't included; a file
+  that has since moved or been deleted is skipped with a note, and one
+  that's already open (here or in another window) is never duplicated.
+
 ## 1.9.0 — 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,25 @@ see `DETAILED_CHANGELOG.md`.
 
 ### Added
 
-- **Last workspace — reopen everything you had open.** CardMirror now
-  remembers the documents open when you last quit and offers them back
-  on the Home screen under **Last workspace**: one click reopens the
-  whole set. In the three-pane workspace each document returns to the
-  pane it was in; in single-document mode each gets its own window.
-  Turn on **Settings → General → Workspace → Reopen last workspace at
-  launch** to have it happen automatically at every start. Two new
-  command-bar commands go with it (both unbound by default): **Save
-  Workspace**, which snapshots what's open right now so you can return
-  to a particular working set later, and **Reopen Last Workspace**,
-  which restores it without going via the Home screen. **Forget** on
-  the Home screen drops the snapshot. Desktop only — reopening needs
-  files on disk — and documents you never saved aren't included; a file
-  that has since moved or been deleted is skipped with a note, and one
-  that's already open (here or in another window) is never duplicated.
+- **Last workspace — reopen what you had open last time.** CardMirror
+  now remembers the documents open when you last quit and lists them on
+  the Home screen under **Last workspace**, each with a tick box:
+  **Reopen** opens the ticked ones, and **All** / **None** flip the
+  whole list, so coming back to a 15-document workspace doesn't have to
+  mean reopening all 15. In the three-pane workspace each document
+  returns to the pane it was in; in single-document mode each gets its
+  own window. Turn on **Settings → General → Workspace → Reopen last
+  workspace at launch** to have it happen automatically at every start.
+  Closing everything before you quit clears the set — a clean quit
+  means a clean start — unless you deliberately saved it with the new
+  **Save Workspace** command, which keeps a working set on offer until
+  you quit with other documents open. **Reopen Last Workspace**
+  restores it without going via the Home screen, and **Forget** drops
+  it. (Both commands are unbound by default.) Desktop only — reopening
+  needs files on disk — and documents you never saved aren't included;
+  a file that has since moved or been deleted is skipped with a note,
+  and one that's already open (here or in another window) is never
+  duplicated.
 
 ## 1.9.0 — 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ see `DETAILED_CHANGELOG.md`.
   mean reopening all 15. In the three-pane workspace each document
   returns to the pane it was in; in single-document mode each gets its
   own window. Turn on **Settings → General → Workspace → Reopen last
-  workspace at launch** to have it happen automatically at every start.
+  workspace at launch** to have it happen automatically at every start —
+  and because unticking a document is a standing choice rather than a
+  one-off filter, the automatic reopen honours it too: untick a file
+  once and it stops coming back every launch, without having to turn
+  the whole feature off. Since launch skips the Home screen, each
+  automatic reopen leaves a note in the status bar's ⚠ chip saying what
+  it opened and where to change it.
   Closing everything before you quit clears the set — a clean quit
   means a clean start — unless you deliberately saved it with the new
   **Save Workspace** command, which keeps a working set on offer until

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -5,6 +5,58 @@ behavior, rationale, and (where useful) the implementation context
 behind a change. For a shorter, jargon-free summary of what's new
 in each release, see `CHANGELOG.md`.
 
+## Unreleased
+
+### Added: Last workspace (reopen the documents you had open)
+
+Recents reopened one file at a time; the only machinery that ever
+reopened a SET of documents was the internal mode-switch reload. This
+generalizes that idea into a user-facing feature, without touching the
+mode-switch path.
+
+`workspace-store.ts` keeps two localStorage records. The LIVE map is
+windowId → the docs that window currently has open: every window
+rewrites its own entry whenever its open set changes (single-doc from
+`updateWindowTitle` / `setCurrentDocHandle`, which every doc-identity
+change funnels through — memoized on a path|name|format key so the
+hot dirty-marker refresh doesn't hammer storage; three-pane from
+`refreshLayout`, where every open / close / send-to-slot already
+lands, plus `setFocusedFile` for Save As). Nothing clears LIVE on
+quit — a killed app leaves exactly what was open, which is the point.
+The first window of an app session folds LIVE into the LAST snapshot
+at boot (`rolloverLastWorkspace`) and empties it, so LAST is always
+"the previous session", and the roll-over runs BEFORE this window
+mounts anything (then re-reports) so a doc mounted first isn't swept
+back out. A fold that finds nothing open keeps the previous snapshot:
+launch → close everything → quit shouldn't destroy the set the user
+might still want back. Windows merge oldest-first, de-duplicated by
+path and capped at 24; live entries older than 30 days are dropped on
+read, bounding the map against windows that vanished on a machine
+whose next launch never came.
+
+Restoring is mode-aware. Three-pane hands the whole set to the shell,
+which reads each file by path and loads it into the slot it was saved
+from (a snapshot taken in single-doc mode has no slots, so those fill
+slot1 → slot2 → slot3 in turn). Single-doc mounts the first document
+in place when this window still holds the pristine starter and spawns
+a window for each of the rest — the one-doc-per-window convention every
+other desktop flow follows. Both paths run the existing duplicate-open
+guards (`findOpenRecordByHandle` / `openPathCheck`), so a document
+already open here or in another window is skipped rather than opened
+twice, and both substitute blank-document bytes for a genuinely-empty
+file the way the Open dialog's `resolveOpenedFile` does. Files that
+moved or were deleted are counted and reported in one toast.
+
+The launch restore is opt-in (`reopenWorkspaceOnLaunch`, default off —
+a launch that silently reopens six files is a surprise unless it was
+asked for) and runs AFTER startup recovery, so a recovered draft keeps
+this window and the restore skips it as already open. It never fires on
+a mode-switch reload, which reopens an exact doc set of its own. The
+feature is gated on the Electron host throughout: the web edition can't
+serialize a `FileSystemFileHandle`, exactly as in `recents-store.ts`,
+so docs with no string path are never recorded and the Home screen
+section is omitted rather than shown dead.
+
 ## 1.9.0 — 2026-09-09
 
 ### Added: Word-style Repeat on Mod-Y (setting, off by default)

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -27,12 +27,16 @@ The first window of an app session folds LIVE into the LAST snapshot
 at boot (`rolloverLastWorkspace`) and empties it, so LAST is always
 "the previous session", and the roll-over runs BEFORE this window
 mounts anything (then re-reports) so a doc mounted first isn't swept
-back out. A fold that finds nothing open keeps the previous snapshot:
-launch → close everything → quit shouldn't destroy the set the user
-might still want back. Windows merge oldest-first, de-duplicated by
-path and capped at 24; live entries older than 30 days are dropped on
-read, bounding the map against windows that vanished on a machine
-whose next launch never came.
+back out. A fold that finds nothing open CLEARS the snapshot —
+closing every document before quitting is taken at face value — with
+one exception: a snapshot written by the explicit Save Workspace
+command is `pinned` and survives an empty quit, which is the whole
+reason to reach for that command. Pinning protects against erasure,
+it doesn't freeze the row: a session that ends WITH documents open
+replaces the snapshot either way. Windows merge oldest-first,
+de-duplicated by path and capped at 24; live entries older than 30
+days are dropped on read, bounding the map against windows that
+vanished on a machine whose next launch never came.
 
 Restoring is mode-aware. Three-pane hands the whole set to the shell,
 which reads each file by path and loads it into the slot it was saved
@@ -46,6 +50,20 @@ already open here or in another window is skipped rather than opened
 twice, and both substitute blank-document bytes for a genuinely-empty
 file the way the Open dialog's `resolveOpenedFile` does. Files that
 moved or were deleted are counted and reported in one toast.
+
+The home-screen section lists the whole set as a checklist rather than
+a single all-or-nothing row: reopening 15 documents (15 windows, in
+single-doc mode) is rarely what the user wants, and seeing what's in
+the set is half the value. Ticks are tracked as an EXCLUSION set keyed
+to the snapshot's `savedAt`, so a snapshot that gains documents
+defaults them to ticked and a genuinely new snapshot resets the
+selection; All / None flip every row at once, and the summary label
+plus the Reopen button's disabled state are re-derived in place rather
+than by re-rendering (which would rebuild the list under the user's
+cursor). The button hands the callback a snapshot carrying only the
+ticked documents, so the renderer opens exactly what it's given. The
+list scrolls past ~18rem, like the sessions list, so a 24-document
+workspace can't push the utilities off screen.
 
 The launch restore is opt-in (`reopenWorkspaceOnLaunch`, default off —
 a launch that silently reopens six files is a surprise unless it was

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -65,6 +65,27 @@ ticked documents, so the renderer opens exactly what it's given. The
 list scrolls past ~18rem, like the sessions list, so a 24-document
 workspace can't push the utilities off screen.
 
+Ticks are durable, not a per-click filter: the untick list (`excluded`)
+lives on the snapshot in the store, so the home screen's Reopen button
+and the at-launch restore both go through one `selectedDocs` helper and
+can't drift apart. It carries across roll-overs for paths still in the
+set — untick a document once and it stops reopening every launch — and
+is pruned of everything else, so a document that leaves the set and
+returns months later comes back ticked rather than silently suppressed.
+One wrinkle worth recording: ticking a box deliberately does NOT
+re-render the list (that would rebuild it under the user's cursor), so
+the captured snapshot's `excluded` is stale by the time Reopen is
+clicked; the button sends what's on screen rather than what it was
+rendered from. A unit test covers exactly that (it caught the bug).
+
+Because a launch restore never lands on the home screen, the checklist
+that governs it would otherwise be somewhere the user has to go hunting
+for — so each automatic reopen files a status-bar notice naming what it
+opened and where the tick boxes are. Deliberately `postNotice`, not a
+toast: nothing floats over the page (toast audit, 2026-08-17), and at
+launch the pointer hasn't moved, so a cursor-anchored tooltip would
+land in the corner.
+
 The launch restore is opt-in (`reopenWorkspaceOnLaunch`, default off —
 a launch that silently reopens six files is a surprise unless it was
 asked for) and runs AFTER startup recovery, so a recovered draft keeps

--- a/DETAILED_CHANGELOG.md
+++ b/DETAILED_CHANGELOG.md
@@ -66,32 +66,26 @@ list scrolls past ~18rem, like the sessions list, so a 24-document
 workspace can't push the utilities off screen.
 
 Ticks are durable, not a per-click filter: the untick list (`excluded`)
-lives on the snapshot in the store, so the home screen's Reopen button
-and the at-launch restore both go through one `selectedDocs` helper and
-can't drift apart. It carries across roll-overs for paths still in the
-set — untick a document once and it stops reopening every launch — and
-is pruned of everything else, so a document that leaves the set and
-returns months later comes back ticked rather than silently suppressed.
-One wrinkle worth recording: ticking a box deliberately does NOT
-re-render the list (that would rebuild it under the user's cursor), so
-the captured snapshot's `excluded` is stale by the time Reopen is
-clicked; the button sends what's on screen rather than what it was
-rendered from. A unit test covers exactly that (it caught the bug).
+lives on the snapshot in the store, carried across roll-overs for paths
+still in the set and pruned of everything else — so a document that
+leaves the set and returns months later comes back ticked rather than
+silently suppressed. One wrinkle worth recording: ticking a box
+deliberately does NOT re-render the list (that would rebuild it under
+the user's cursor), so the captured snapshot's `excluded` is stale by
+the time Reopen is clicked; the button sends what's on screen rather
+than what it was rendered from. A unit test covers exactly that (it
+caught the bug).
 
-Because a launch restore never lands on the home screen, the checklist
-that governs it would otherwise be somewhere the user has to go hunting
-for — so each automatic reopen files a status-bar notice naming what it
-opened and where the tick boxes are. Deliberately `postNotice`, not a
-toast: nothing floats over the page (toast audit, 2026-08-17), and at
-launch the pointer hasn't moved, so a cursor-anchored tooltip would
-land in the corner.
+Nothing reopens at launch. An at-launch restore was built first, behind
+an opt-in setting, and then removed after field use: with it on you
+never land on the home screen, so the checklist that decides WHAT comes
+back is somewhere you have to go hunting for — and a status-bar notice
+pointing at it was a workaround for a design that shouldn't need one.
+The roll-over now only MINTS the snapshot; the home screen is the single
+place that decides what reopens, which is also what a blank launch has
+always shown. `reopenWorkspaceOnLaunch` is gone with it.
 
-The launch restore is opt-in (`reopenWorkspaceOnLaunch`, default off —
-a launch that silently reopens six files is a surprise unless it was
-asked for) and runs AFTER startup recovery, so a recovered draft keeps
-this window and the restore skips it as already open. It never fires on
-a mode-switch reload, which reopens an exact doc set of its own. The
-feature is gated on the Electron host throughout: the web edition can't
+The feature is gated on the Electron host throughout: the web edition can't
 serialize a `FileSystemFileHandle`, exactly as in `recents-store.ts`,
 so docs with no string path are never recorded and the Home screen
 section is omitted rather than shown dead.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1964,15 +1964,20 @@ prompt, and focusing a copy that's already open). Other file types are ignored,
 and dragging cards around inside the editor is unaffected.
 
 **Reopening your last set of documents.** CardMirror remembers which files
-you had open when you last quit. The Home screen shows them under **Last
-workspace** — one click reopens the whole set (in the three-pane workspace,
-each document goes back to the pane it was in; in single-document mode each
-gets its own window). Turn on **Settings → General → Workspace → Reopen last
-workspace at launch** to have that happen automatically every time you start
-CardMirror. **Save Workspace** (command bar — try "save session") snapshots
-what's open right now, so you can come back to a particular working set even
-after opening other things; **Reopen Last Workspace** restores it without going
-via the Home screen, and **Forget** on the Home screen drops the snapshot.
+you had open when you last quit and lists them on the Home screen under
+**Last workspace**, each with a tick box. **Reopen** opens the ticked ones —
+untick the ones you don't want, or use **All** / **None** to flip the whole
+list. In the three-pane workspace each document goes back to the pane it was
+in; in single-document mode each gets its own window. Turn on **Settings →
+General → Workspace → Reopen last workspace at launch** to reopen the set
+automatically every time you start CardMirror.
+
+Close every document before you quit and there's nothing to offer, so the
+section disappears — a clean quit means a clean start. To keep a particular
+working set regardless, run **Save Workspace** (command bar — try "save
+session"): a saved set survives quitting with nothing open, and stays on offer
+until you open other documents and quit with those. **Reopen Last Workspace**
+restores it without going via the Home screen, and **Forget** drops it.
 Documents that have never been saved aren't included — there's no file to
 reopen — and one that has moved or been deleted is skipped with a note.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1963,6 +1963,19 @@ home screen — to open it, exactly like File → Open (including the unsaved-ch
 prompt, and focusing a copy that's already open). Other file types are ignored,
 and dragging cards around inside the editor is unaffected.
 
+**Reopening your last set of documents.** CardMirror remembers which files
+you had open when you last quit. The Home screen shows them under **Last
+workspace** — one click reopens the whole set (in the three-pane workspace,
+each document goes back to the pane it was in; in single-document mode each
+gets its own window). Turn on **Settings → General → Workspace → Reopen last
+workspace at launch** to have that happen automatically every time you start
+CardMirror. **Save Workspace** (command bar — try "save session") snapshots
+what's open right now, so you can come back to a particular working set even
+after opening other things; **Reopen Last Workspace** restores it without going
+via the Home screen, and **Forget** on the Home screen drops the snapshot.
+Documents that have never been saved aren't included — there's no file to
+reopen — and one that has moved or been deleted is skipped with a note.
+
 **Password-protected Word files.** If you open a `.docx` that Word encrypted
 with a password, CardMirror asks for the password and opens it. Saving writes
 a normal, unencrypted file — CardMirror doesn't re-apply the password. (Only

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1970,14 +1970,11 @@ untick the ones you don't want, or use **All** / **None** to flip the whole
 list. In the three-pane workspace each document goes back to the pane it was
 in; in single-document mode each gets its own window.
 
-Turn on **Settings → General → Workspace → Reopen last workspace at launch**
-and CardMirror opens that set for you at every start, without stopping at the
-Home screen. It opens the **ticked** documents only: unticking one is a
-standing choice, so a file you've unticked stops coming back at launch (and
-stays unticked as the set changes from session to session) until you tick it
-again. Because launch skips the Home screen, each automatic reopen files a
-note in the status bar's ⚠ chip saying what it opened and where the tick
-boxes live.
+CardMirror never reopens documents behind your back: a launch with no file
+lands on the Home screen, where the list is waiting, and nothing opens until
+you say so. Your ticks are remembered between sessions, so a document you
+untick stays unticked as the set changes from one session to the next until
+you tick it again.
 
 Close every document before you quit and there's nothing to offer, so the
 section disappears — a clean quit means a clean start. To keep a particular

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1968,9 +1968,16 @@ you had open when you last quit and lists them on the Home screen under
 **Last workspace**, each with a tick box. **Reopen** opens the ticked ones —
 untick the ones you don't want, or use **All** / **None** to flip the whole
 list. In the three-pane workspace each document goes back to the pane it was
-in; in single-document mode each gets its own window. Turn on **Settings →
-General → Workspace → Reopen last workspace at launch** to reopen the set
-automatically every time you start CardMirror.
+in; in single-document mode each gets its own window.
+
+Turn on **Settings → General → Workspace → Reopen last workspace at launch**
+and CardMirror opens that set for you at every start, without stopping at the
+Home screen. It opens the **ticked** documents only: unticking one is a
+standing choice, so a file you've unticked stops coming back at launch (and
+stays unticked as the set changes from session to session) until you tick it
+again. Because launch skips the Home screen, each automatic reopen files a
+note in the status bar's ⚠ chip saying what it opened and where the tick
+boxes live.
 
 Close every document before you quit and there's nothing to offer, so the
 section disappears — a clean quit means a clean start. To keep a particular

--- a/src/editor/home-screen.ts
+++ b/src/editor/home-screen.ts
@@ -24,6 +24,12 @@ import {
   clearRecents,
   type RecentFile,
 } from './recents-store.js';
+import {
+  lastWorkspace,
+  subscribeLastWorkspace,
+  clearLastWorkspace,
+  type WorkspaceSnapshot,
+} from './workspace-store.js';
 import { learnStore, localToday } from './learn-store-host.js';
 import { getElectronHost } from './host/index.js';
 import { openLearnSession } from './learn-session-ui.js';
@@ -49,6 +55,10 @@ export interface HomeScreenCallbacks {
   /** Reopen a recent file in-place. The renderer reads the
    *  handle, mounts the doc, and prunes the entry on failure. */
   openRecent: (recent: RecentFile) => void;
+  /** Reopen every document from the last saved workspace. Omitted on
+   *  hosts that can't reopen by path (the web edition), in which case
+   *  the Workspace section isn't rendered at all. */
+  reopenWorkspace?: (snapshot: WorkspaceSnapshot) => void;
   /** Open the Quick Cards manage overlay. */
   manageQuickCards: () => void;
   /** Open the .docx style cleaner. Electron-only (recursive folder I/O +
@@ -69,6 +79,8 @@ export interface HomeScreenCallbacks {
 class HomeScreen {
   private root!: HTMLDivElement;
   private recentsEl!: HTMLDivElement;
+  private workspaceSection!: HTMLElement;
+  private workspaceEl!: HTMLDivElement;
   private sessionsSection!: HTMLElement;
   private sessionsEl!: HTMLDivElement;
   private learnEl!: HTMLDivElement;
@@ -181,6 +193,32 @@ class HomeScreen {
       this.actionCard('Open…', 'Browse for a .cmir or .docx file.', this.actionRunners[2]!),
     );
     inner.appendChild(actions);
+
+    // Last workspace — "pick up where you left off", above Recent
+    // because it restores a whole working set in one click where
+    // Recent reopens one file. Hidden when there's no snapshot, and
+    // omitted entirely on hosts that can't reopen by path.
+    this.workspaceSection = document.createElement('section');
+    this.workspaceSection.className = 'pmd-home-workspace-section';
+    this.workspaceSection.hidden = true;
+    const wsHeader = document.createElement('div');
+    wsHeader.className = 'pmd-home-recents-header';
+    const wsTitle = document.createElement('h2');
+    wsTitle.className = 'pmd-home-section-title';
+    wsTitle.textContent = 'Last workspace';
+    wsHeader.appendChild(wsTitle);
+    const wsForget = document.createElement('button');
+    wsForget.type = 'button';
+    wsForget.className = 'pmd-home-recents-clear';
+    wsForget.textContent = 'Forget';
+    wsForget.title = 'Forget the saved workspace';
+    wsForget.addEventListener('click', () => clearLastWorkspace());
+    wsHeader.appendChild(wsForget);
+    this.workspaceSection.appendChild(wsHeader);
+    this.workspaceEl = document.createElement('div');
+    this.workspaceEl.className = 'pmd-home-workspace';
+    this.workspaceSection.appendChild(this.workspaceEl);
+    inner.appendChild(this.workspaceSection);
 
     // Recent files.
     const recentsSection = document.createElement('section');
@@ -307,6 +345,8 @@ class HomeScreen {
     parent.appendChild(this.root);
 
     this.unsubscribe = subscribeRecents(() => this.renderRecents());
+    subscribeLastWorkspace(() => this.renderWorkspace());
+    this.renderWorkspace();
     learnStore.subscribe(() => this.renderLearn());
     subscribeSessionRecords(() => void this.renderSessions());
     this.renderRecents();
@@ -335,6 +375,7 @@ class HomeScreen {
     // opened a file); re-read. Same for the learn counts (cards may
     // have been created while a doc was open).
     this.renderRecents();
+    this.renderWorkspace();
     void this.renderSessions();
     this.renderLearn();
     this.notifyVisibility(true);
@@ -623,6 +664,37 @@ class HomeScreen {
       }
       this.learnEl.appendChild(list);
     }
+  }
+
+  /** Rebuild the Last-workspace section from the store. One button
+   *  that reopens the whole set, labeled with the count and the
+   *  filenames it holds. */
+  private renderWorkspace(): void {
+    if (!this.workspaceSection) return;
+    const snapshot = this.callbacks?.reopenWorkspace ? lastWorkspace() : null;
+    this.workspaceSection.hidden = snapshot === null;
+    this.workspaceEl.replaceChildren();
+    if (!snapshot) return;
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'pmd-home-workspace-open';
+    const count = document.createElement('span');
+    count.className = 'pmd-home-recent-format';
+    count.textContent = String(snapshot.docs.length);
+    row.appendChild(count);
+    const name = document.createElement('span');
+    name.className = 'pmd-home-recent-name';
+    name.textContent =
+      snapshot.docs.length === 1 ? 'Reopen 1 document' : `Reopen ${snapshot.docs.length} documents`;
+    row.appendChild(name);
+    const files = document.createElement('span');
+    files.className = 'pmd-home-workspace-files';
+    const names = snapshot.docs.map((d) => stripKnownExt(d.filename));
+    files.textContent = names.join(' · ');
+    row.appendChild(files);
+    row.title = `Saved ${relativeTime(snapshot.savedAt)}\n${snapshot.docs.map((d) => d.path).join('\n')}`;
+    row.addEventListener('click', () => this.callbacks?.reopenWorkspace?.(snapshot));
+    this.workspaceEl.appendChild(row);
   }
 
   private recentRow(recent: RecentFile): HTMLButtonElement {

--- a/src/editor/home-screen.ts
+++ b/src/editor/home-screen.ts
@@ -28,6 +28,7 @@ import {
   lastWorkspace,
   subscribeLastWorkspace,
   clearLastWorkspace,
+  setWorkspaceExcluded,
   type WorkspaceDoc,
   type WorkspaceSnapshot,
 } from './workspace-store.js';
@@ -56,11 +57,11 @@ export interface HomeScreenCallbacks {
   /** Reopen a recent file in-place. The renderer reads the
    *  handle, mounts the doc, and prunes the entry on failure. */
   openRecent: (recent: RecentFile) => void;
-  /** Reopen the documents from the last saved workspace. The snapshot
-   *  passed in carries only the documents the user left ticked, so the
-   *  renderer opens exactly what it's given. Omitted on hosts that
-   *  can't reopen by path (the web edition), in which case the
-   *  Workspace section isn't rendered at all. */
+  /** Reopen the ticked documents from the last saved workspace. The
+   *  whole snapshot is passed; the renderer re-derives the ticked set
+   *  (`selectedDocs`) so this and the at-launch restore can't drift
+   *  apart. Omitted on hosts that can't reopen by path (the web
+   *  edition), in which case the Workspace section isn't rendered. */
   reopenWorkspace?: (snapshot: WorkspaceSnapshot) => void;
   /** Open the Quick Cards manage overlay. */
   manageQuickCards: () => void;
@@ -84,12 +85,10 @@ class HomeScreen {
   private recentsEl!: HTMLDivElement;
   private workspaceSection!: HTMLElement;
   private workspaceEl!: HTMLDivElement;
-  /** Paths the user has UNticked, plus the snapshot they belong to.
-   *  Tracked as the exclusion set so a snapshot arriving with new
-   *  documents defaults them to ticked; reset when the snapshot
-   *  changes underneath us. */
-  private workspaceUnchecked = new Set<string>();
-  private workspaceSelectionFor = 0;
+  /** Set while THIS screen is writing the untick list, so the store's
+   *  change notification doesn't rebuild the list under the user's
+   *  cursor (the row states are already updated in place). */
+  private workspaceSelfWrite = false;
   private sessionsSection!: HTMLElement;
   private sessionsEl!: HTMLDivElement;
   private learnEl!: HTMLDivElement;
@@ -354,7 +353,9 @@ class HomeScreen {
     parent.appendChild(this.root);
 
     this.unsubscribe = subscribeRecents(() => this.renderRecents());
-    subscribeLastWorkspace(() => this.renderWorkspace());
+    subscribeLastWorkspace(() => {
+      if (!this.workspaceSelfWrite) this.renderWorkspace();
+    });
     this.renderWorkspace();
     learnStore.subscribe(() => this.renderLearn());
     subscribeSessionRecords(() => void this.renderSessions());
@@ -680,21 +681,28 @@ class HomeScreen {
    *  list is always visible rather than folded away — seeing what's in
    *  the set is the point, and a 15-document set restored wholesale is
    *  rarely what the user wants. All / None flip every tick at once.
-   *  The list scrolls past ~8 rows so a big workspace can't push the
-   *  rest of the home screen off the page. */
+   *  Ticks persist through the store, so they also govern what the
+   *  at-launch restore opens. The list scrolls past ~8 rows so a big
+   *  workspace can't push the rest of the home screen off the page. */
   private renderWorkspace(): void {
     if (!this.workspaceSection) return;
     const snapshot = this.callbacks?.reopenWorkspace ? lastWorkspace() : null;
     this.workspaceSection.hidden = snapshot === null;
     this.workspaceEl.replaceChildren();
     if (!snapshot) return;
-    // A different snapshot means the old exclusions are meaningless.
-    if (this.workspaceSelectionFor !== snapshot.savedAt) {
-      this.workspaceSelectionFor = snapshot.savedAt;
-      this.workspaceUnchecked.clear();
-    }
-    const selected = (): WorkspaceDoc[] =>
-      snapshot.docs.filter((d) => !this.workspaceUnchecked.has(d.path));
+    // The untick list lives in the store, not in this screen: the
+    // at-launch restore honours the same list, so one untick is
+    // durable rather than a filter that only applies to this click.
+    const unchecked = new Set(snapshot.excluded);
+    const persist = (): void => {
+      this.workspaceSelfWrite = true;
+      try {
+        setWorkspaceExcluded(unchecked);
+      } finally {
+        this.workspaceSelfWrite = false;
+      }
+    };
+    const selected = (): WorkspaceDoc[] => snapshot.docs.filter((d) => !unchecked.has(d.path));
 
     const row = document.createElement('div');
     row.className = 'pmd-home-workspace-row';
@@ -708,17 +716,21 @@ class HomeScreen {
     openBtn.append(count, name);
     openBtn.title = `Saved ${relativeTime(snapshot.savedAt)}`;
     openBtn.addEventListener('click', () => {
-      const docs = selected();
-      if (docs.length === 0) return;
-      this.callbacks?.reopenWorkspace?.({ ...snapshot, docs });
+      if (selected().length === 0) return;
+      // `snapshot` was captured when this list was built, and ticking a
+      // box deliberately does NOT re-render (that would rebuild the
+      // list under the cursor) — so its `excluded` is stale by now.
+      // Send what's on screen; the renderer filters on it.
+      this.callbacks?.reopenWorkspace?.({ ...snapshot, excluded: [...unchecked] });
     });
     row.appendChild(openBtn);
 
     const boxes: HTMLInputElement[] = [];
     const selectAll = (checked: boolean): void => {
-      this.workspaceUnchecked.clear();
-      if (!checked) for (const d of snapshot.docs) this.workspaceUnchecked.add(d.path);
+      unchecked.clear();
+      if (!checked) for (const d of snapshot.docs) unchecked.add(d.path);
       for (const b of boxes) b.checked = checked;
+      persist();
       syncSummary();
     };
     const allBtn = document.createElement('button');
@@ -760,10 +772,11 @@ class HomeScreen {
       item.title = doc.path;
       const box = document.createElement('input');
       box.type = 'checkbox';
-      box.checked = !this.workspaceUnchecked.has(doc.path);
+      box.checked = !unchecked.has(doc.path);
       box.addEventListener('change', () => {
-        if (box.checked) this.workspaceUnchecked.delete(doc.path);
-        else this.workspaceUnchecked.add(doc.path);
+        if (box.checked) unchecked.delete(doc.path);
+        else unchecked.add(doc.path);
+        persist();
         syncSummary();
       });
       boxes.push(box);

--- a/src/editor/home-screen.ts
+++ b/src/editor/home-screen.ts
@@ -28,6 +28,7 @@ import {
   lastWorkspace,
   subscribeLastWorkspace,
   clearLastWorkspace,
+  type WorkspaceDoc,
   type WorkspaceSnapshot,
 } from './workspace-store.js';
 import { learnStore, localToday } from './learn-store-host.js';
@@ -55,9 +56,11 @@ export interface HomeScreenCallbacks {
   /** Reopen a recent file in-place. The renderer reads the
    *  handle, mounts the doc, and prunes the entry on failure. */
   openRecent: (recent: RecentFile) => void;
-  /** Reopen every document from the last saved workspace. Omitted on
-   *  hosts that can't reopen by path (the web edition), in which case
-   *  the Workspace section isn't rendered at all. */
+  /** Reopen the documents from the last saved workspace. The snapshot
+   *  passed in carries only the documents the user left ticked, so the
+   *  renderer opens exactly what it's given. Omitted on hosts that
+   *  can't reopen by path (the web edition), in which case the
+   *  Workspace section isn't rendered at all. */
   reopenWorkspace?: (snapshot: WorkspaceSnapshot) => void;
   /** Open the Quick Cards manage overlay. */
   manageQuickCards: () => void;
@@ -81,6 +84,12 @@ class HomeScreen {
   private recentsEl!: HTMLDivElement;
   private workspaceSection!: HTMLElement;
   private workspaceEl!: HTMLDivElement;
+  /** Paths the user has UNticked, plus the snapshot they belong to.
+   *  Tracked as the exclusion set so a snapshot arriving with new
+   *  documents defaults them to ticked; reset when the snapshot
+   *  changes underneath us. */
+  private workspaceUnchecked = new Set<string>();
+  private workspaceSelectionFor = 0;
   private sessionsSection!: HTMLElement;
   private sessionsEl!: HTMLDivElement;
   private learnEl!: HTMLDivElement;
@@ -666,35 +675,114 @@ class HomeScreen {
     }
   }
 
-  /** Rebuild the Last-workspace section from the store. One button
-   *  that reopens the whole set, labeled with the count and the
-   *  filenames it holds. */
+  /** Rebuild the Last-workspace section from the store: a Reopen
+   *  button over the full checklist of documents in the snapshot. The
+   *  list is always visible rather than folded away — seeing what's in
+   *  the set is the point, and a 15-document set restored wholesale is
+   *  rarely what the user wants. All / None flip every tick at once.
+   *  The list scrolls past ~8 rows so a big workspace can't push the
+   *  rest of the home screen off the page. */
   private renderWorkspace(): void {
     if (!this.workspaceSection) return;
     const snapshot = this.callbacks?.reopenWorkspace ? lastWorkspace() : null;
     this.workspaceSection.hidden = snapshot === null;
     this.workspaceEl.replaceChildren();
     if (!snapshot) return;
-    const row = document.createElement('button');
-    row.type = 'button';
-    row.className = 'pmd-home-workspace-open';
+    // A different snapshot means the old exclusions are meaningless.
+    if (this.workspaceSelectionFor !== snapshot.savedAt) {
+      this.workspaceSelectionFor = snapshot.savedAt;
+      this.workspaceUnchecked.clear();
+    }
+    const selected = (): WorkspaceDoc[] =>
+      snapshot.docs.filter((d) => !this.workspaceUnchecked.has(d.path));
+
+    const row = document.createElement('div');
+    row.className = 'pmd-home-workspace-row';
+    const openBtn = document.createElement('button');
+    openBtn.type = 'button';
+    openBtn.className = 'pmd-home-workspace-open';
     const count = document.createElement('span');
     count.className = 'pmd-home-recent-format';
-    count.textContent = String(snapshot.docs.length);
-    row.appendChild(count);
     const name = document.createElement('span');
     name.className = 'pmd-home-recent-name';
-    name.textContent =
-      snapshot.docs.length === 1 ? 'Reopen 1 document' : `Reopen ${snapshot.docs.length} documents`;
-    row.appendChild(name);
-    const files = document.createElement('span');
-    files.className = 'pmd-home-workspace-files';
-    const names = snapshot.docs.map((d) => stripKnownExt(d.filename));
-    files.textContent = names.join(' · ');
-    row.appendChild(files);
-    row.title = `Saved ${relativeTime(snapshot.savedAt)}\n${snapshot.docs.map((d) => d.path).join('\n')}`;
-    row.addEventListener('click', () => this.callbacks?.reopenWorkspace?.(snapshot));
-    this.workspaceEl.appendChild(row);
+    openBtn.append(count, name);
+    openBtn.title = `Saved ${relativeTime(snapshot.savedAt)}`;
+    openBtn.addEventListener('click', () => {
+      const docs = selected();
+      if (docs.length === 0) return;
+      this.callbacks?.reopenWorkspace?.({ ...snapshot, docs });
+    });
+    row.appendChild(openBtn);
+
+    const boxes: HTMLInputElement[] = [];
+    const selectAll = (checked: boolean): void => {
+      this.workspaceUnchecked.clear();
+      if (!checked) for (const d of snapshot.docs) this.workspaceUnchecked.add(d.path);
+      for (const b of boxes) b.checked = checked;
+      syncSummary();
+    };
+    const allBtn = document.createElement('button');
+    allBtn.type = 'button';
+    allBtn.className = 'pmd-home-workspace-select';
+    allBtn.textContent = 'All';
+    allBtn.title = 'Select every document';
+    allBtn.addEventListener('click', () => selectAll(true));
+    const noneBtn = document.createElement('button');
+    noneBtn.type = 'button';
+    noneBtn.className = 'pmd-home-workspace-select';
+    noneBtn.textContent = 'None';
+    noneBtn.title = 'Deselect every document';
+    noneBtn.addEventListener('click', () => selectAll(false));
+    row.append(allBtn, noneBtn);
+
+    // The summary label is derived from the ticks, so a change updates
+    // it in place rather than re-rendering (which would rebuild the
+    // list under the user's cursor).
+    const syncSummary = (): void => {
+      const docs = selected();
+      count.textContent = String(docs.length);
+      openBtn.disabled = docs.length === 0;
+      name.textContent =
+        docs.length === 0
+          ? 'Nothing selected'
+          : docs.length === 1
+            ? 'Reopen 1 document'
+            : `Reopen ${docs.length} documents`;
+      allBtn.disabled = docs.length === snapshot.docs.length;
+      noneBtn.disabled = docs.length === 0;
+    };
+
+    const list = document.createElement('div');
+    list.className = 'pmd-home-workspace-list';
+    for (const doc of snapshot.docs) {
+      const item = document.createElement('label');
+      item.className = 'pmd-home-workspace-item';
+      item.title = doc.path;
+      const box = document.createElement('input');
+      box.type = 'checkbox';
+      box.checked = !this.workspaceUnchecked.has(doc.path);
+      box.addEventListener('change', () => {
+        if (box.checked) this.workspaceUnchecked.delete(doc.path);
+        else this.workspaceUnchecked.add(doc.path);
+        syncSummary();
+      });
+      boxes.push(box);
+      const fmt = document.createElement('span');
+      fmt.className = `pmd-home-recent-format pmd-home-recent-format-${doc.format ?? 'unknown'}`;
+      fmt.textContent = (doc.format ?? '?').toUpperCase();
+      const label = document.createElement('span');
+      label.className = 'pmd-home-recent-name';
+      label.textContent = stripKnownExt(doc.filename);
+      const path = document.createElement('span');
+      path.className = 'pmd-home-recent-path';
+      // Left-truncating path cell, same LRM guards as the recent rows.
+      path.textContent = `\u{200e}${doc.path}\u{200e}`;
+      item.append(box, fmt, label, path);
+      list.appendChild(item);
+    }
+
+    syncSummary();
+    this.workspaceEl.append(row, list);
   }
 
   private recentRow(recent: RecentFile): HTMLButtonElement {

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -133,6 +133,7 @@ import {
   rolloverLastWorkspace,
   lastWorkspace,
   saveWorkspaceNow,
+  selectedDocs,
   type WorkspaceSnapshot,
 } from './workspace-store.js';
 import { isAutosaveOnForPath, setAutosaveForPath } from './autosave-prefs-store.js';
@@ -1673,6 +1674,10 @@ const ribbonContext: RibbonContext = {
     const snapshot = lastWorkspace();
     if (!snapshot) {
       showToast('No saved workspace yet.');
+      return;
+    }
+    if (selectedDocs(snapshot).length === 0) {
+      showToast('Nothing ticked in your last workspace — tick a document on the home screen.');
       return;
     }
     void (async () => {
@@ -7409,8 +7414,10 @@ async function readFileForReopen(
   return file;
 }
 
-/** Reopen a saved workspace. Three-pane hands the whole set to the
- *  shell, which restores each doc into the slot it was saved from.
+/** Reopen a saved workspace — the TICKED documents only, re-derived
+ *  from the store so the home screen's button and the at-launch
+ *  restore can't drift apart. Three-pane hands the set to the shell,
+ *  which restores each doc into the slot it was saved from.
  *  Single-doc mounts the first doc in THIS window when it still holds
  *  the pristine starter, and spawns a window for each of the rest —
  *  the one-doc-per-window convention every other desktop flow follows.
@@ -7422,6 +7429,8 @@ async function restoreWorkspace(snapshot: WorkspaceSnapshot): Promise<number> {
     showToast('Reopening a workspace requires the desktop edition.');
     return 0;
   }
+  const wanted = selectedDocs(snapshot);
+  if (wanted.length === 0) return 0;
   homeScreen.hide();
   if (multiDocActive) {
     const { restoreWorkspaceIntoSlots } = await import('./multi-pane-shell.js');
@@ -7429,7 +7438,7 @@ async function restoreWorkspace(snapshot: WorkspaceSnapshot): Promise<number> {
     // three-pane mode; one taken in single-doc mode fills the slots
     // in order instead.
     return restoreWorkspaceIntoSlots(
-      snapshot.docs.map((d) => ({
+      wanted.map((d) => ({
         path: d.path,
         filename: d.filename,
         slot: snapshot.mode === 'panes' ? d.slot : null,
@@ -7439,7 +7448,7 @@ async function restoreWorkspace(snapshot: WorkspaceSnapshot): Promise<number> {
   let opened = 0;
   let missing = 0;
   let inPlaceAvailable = isPristineStarter;
-  for (const doc of snapshot.docs) {
+  for (const doc of wanted) {
     if (currentDocHandle != null && (await isSameOpenHandle(currentDocHandle, doc.path))) {
       continue;
     }
@@ -7490,6 +7499,28 @@ async function restoreWorkspace(snapshot: WorkspaceSnapshot): Promise<number> {
     );
   }
   return opened;
+}
+
+/** The at-launch restore, plus the notice that makes its one control
+ *  findable. With `reopenWorkspaceOnLaunch` on, boot never lands on the
+ *  home screen — so the checklist that decides WHAT comes back would
+ *  otherwise be somewhere the user has to go hunting for. A status-bar
+ *  notice (not a toast: nothing floats over the page, and at launch the
+ *  pointer hasn't moved, so a cursor-anchored tooltip would land in the
+ *  corner) says what happened and where to change it. */
+async function runLaunchWorkspaceRestore(snapshot: WorkspaceSnapshot): Promise<void> {
+  const opened = await restoreWorkspace(snapshot);
+  if (opened === 0) return;
+  postNotice({
+    severity: 'info',
+    title: opened === 1 ? 'Reopened 1 document' : `Reopened ${opened} documents`,
+    body:
+      'From your last workspace. To stop a document coming back at every launch, ' +
+      'untick it under Last workspace on the home screen — or turn off ' +
+      '"Reopen last workspace at launch" in Settings → General → Workspace.',
+    key: 'workspace-launch-restore',
+    toast: false,
+  });
 }
 
 /** Reopen a recent file in-place via its stored path handle.
@@ -9938,7 +9969,7 @@ if (BOOT_MULTI_DOC_WORKSPACE) {
       // Opt-in launch restore, after recovery so a recovered draft
       // keeps its slot and the restore skips that doc as already open.
       if (lastSession && settings.get('reopenWorkspaceOnLaunch')) {
-        await restoreWorkspace(lastSession);
+        await runLaunchWorkspaceRestore(lastSession);
       }
     }
   })();
@@ -10052,7 +10083,7 @@ async function initSingleDocBoot(): Promise<void> {
     // Opt-in launch restore. A mode-switch reload already reopens an
     // exact doc set of its own, so it never doubles up with this.
     if (lastSession && !modeSwitchPending && settings.get('reopenWorkspaceOnLaunch')) {
-      await restoreWorkspace(lastSession);
+      await runLaunchWorkspaceRestore(lastSession);
     }
   }
   if (isFirst) {

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -7501,28 +7501,6 @@ async function restoreWorkspace(snapshot: WorkspaceSnapshot): Promise<number> {
   return opened;
 }
 
-/** The at-launch restore, plus the notice that makes its one control
- *  findable. With `reopenWorkspaceOnLaunch` on, boot never lands on the
- *  home screen — so the checklist that decides WHAT comes back would
- *  otherwise be somewhere the user has to go hunting for. A status-bar
- *  notice (not a toast: nothing floats over the page, and at launch the
- *  pointer hasn't moved, so a cursor-anchored tooltip would land in the
- *  corner) says what happened and where to change it. */
-async function runLaunchWorkspaceRestore(snapshot: WorkspaceSnapshot): Promise<void> {
-  const opened = await restoreWorkspace(snapshot);
-  if (opened === 0) return;
-  postNotice({
-    severity: 'info',
-    title: opened === 1 ? 'Reopened 1 document' : `Reopened ${opened} documents`,
-    body:
-      'From your last workspace. To stop a document coming back at every launch, ' +
-      'untick it under Last workspace on the home screen — or turn off ' +
-      '"Reopen last workspace at launch" in Settings → General → Workspace.',
-    key: 'workspace-launch-restore',
-    toast: false,
-  });
-}
-
 /** Reopen a recent file in-place via its stored path handle.
  *  Prunes the entry if the file is gone / unreadable. */
 async function openRecentInPlace(recent: RecentFile): Promise<void> {
@@ -9951,8 +9929,11 @@ if (BOOT_MULTI_DOC_WORKSPACE) {
     // Roll the previous session's open set into the offerable
     // snapshot BEFORE anything mounts (the roll-over empties the live
     // map, so a doc reported first would be swept back out), then
-    // re-report whatever this window ends up holding.
-    const lastSession = rolloverLastWorkspace();
+    // re-report whatever this window ends up holding. Nothing is
+    // reopened here: launch always lands on the home screen, where the
+    // Last workspace checklist is the single place that decides what
+    // comes back.
+    rolloverLastWorkspace();
     // If this window was spawned for an OS open (cold launch), route
     // its initial doc through the slot picker instead of booting
     // blank. Skip recovery when we did — a spawned-for-a-file window
@@ -9966,11 +9947,6 @@ if (BOOT_MULTI_DOC_WORKSPACE) {
       // auto-reopened docs hide it via the slot-populated hook.
       homeScreen.show();
       await runStartupRecovery();
-      // Opt-in launch restore, after recovery so a recovered draft
-      // keeps its slot and the restore skips that doc as already open.
-      if (lastSession && settings.get('reopenWorkspaceOnLaunch')) {
-        await runLaunchWorkspaceRestore(lastSession);
-      }
     }
   })();
 } else {
@@ -10016,8 +9992,11 @@ async function initSingleDocBoot(): Promise<void> {
   }
   // Only the first window rolls the previous session's set over, and
   // it does so before its own doc is reported (the roll-over empties
-  // the live map). Later windows just keep reporting.
-  const lastSession = isFirst ? rolloverLastWorkspace() : null;
+  // the live map). Later windows just keep reporting. The roll-over
+  // only MINTS the snapshot — nothing is reopened at launch; the home
+  // screen's Last workspace checklist is the single place that decides
+  // what comes back.
+  if (isFirst) rolloverLastWorkspace();
   // A spawned window carries an initial-doc payload. Check regardless of THIS
   // window's own `canSpawnWindow`: a web window spawned into a plain browser tab
   // isn't itself standalone, but must still mount the doc it was opened with.
@@ -10080,11 +10059,6 @@ async function initSingleDocBoot(): Promise<void> {
     // no-recovery launch lands on the hub rather than a blank doc.
     homeScreen.show();
     await runStartupRecovery();
-    // Opt-in launch restore. A mode-switch reload already reopens an
-    // exact doc set of its own, so it never doubles up with this.
-    if (lastSession && !modeSwitchPending && settings.get('reopenWorkspaceOnLaunch')) {
-      await runLaunchWorkspaceRestore(lastSession);
-    }
   }
   if (isFirst) {
     const electron = getElectronHost();

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -128,6 +128,13 @@ import { bulkCompressEnabled } from './bulk-compress-gate.js';
 import { openClean, runCleanSingleFileWeb } from './clean-ui.js';
 import { homeScreen, type HomeScreenCallbacks } from './home-screen.js';
 import { recordRecent, removeRecent, listRecents, type RecentFile } from './recents-store.js';
+import {
+  reportWindowWorkspace,
+  rolloverLastWorkspace,
+  lastWorkspace,
+  saveWorkspaceNow,
+  type WorkspaceSnapshot,
+} from './workspace-store.js';
 import { isAutosaveOnForPath, setAutosaveForPath } from './autosave-prefs-store.js';
 import {
   settings,
@@ -1642,6 +1649,37 @@ const ribbonContext: RibbonContext = {
     if (view) openWordCount(view);
   },
   toggleReaderView: () => toggleReaderViewCommand(),
+  saveWorkspace: () => {
+    if (!getElectronHost()) {
+      showToast('Saving a workspace requires the desktop edition.');
+      return;
+    }
+    const saved = saveWorkspaceNow();
+    if (!saved) {
+      showToast('Nothing to save — no saved documents are open.');
+      return;
+    }
+    showToast(
+      saved.docs.length === 1
+        ? 'Workspace saved (1 document).'
+        : `Workspace saved (${saved.docs.length} documents).`,
+    );
+  },
+  reopenWorkspace: () => {
+    if (!getElectronHost()) {
+      showToast('Reopening a workspace requires the desktop edition.');
+      return;
+    }
+    const snapshot = lastWorkspace();
+    if (!snapshot) {
+      showToast('No saved workspace yet.');
+      return;
+    }
+    void (async () => {
+      const opened = await restoreWorkspace(snapshot);
+      if (opened === 0) showToast('Every document in that workspace is already open.');
+    })();
+  },
   openContainingFolder: () => {
     const host = getElectronHost();
     if (!host) {
@@ -6117,6 +6155,7 @@ function setCurrentDocHandle(next: unknown | null): void {
   if (prev === next) return;
   if (typeof prev === 'string' && prev) releaseDocPath(prev);
   if (typeof next === 'string' && next) void registerDocPath(next);
+  reportSingleDocWorkspace();
 }
 /** On-disk format of the current single-doc file. Drives whether
  *  "Save" routes through `toDocx` or `serializeNative`. `null` for
@@ -6870,6 +6909,15 @@ const homeCallbacks: HomeScreenCallbacks = {
   openRecent: (recent: RecentFile) => {
     void openRecentInPlace(recent);
   },
+  // Reopen-by-path is desktop-only (the web edition can't persist
+  // file handles), so the home screen omits the section without it.
+  ...(getElectronHost()
+    ? {
+        reopenWorkspace: (snapshot: WorkspaceSnapshot): void => {
+          void restoreWorkspace(snapshot);
+        },
+      }
+    : {}),
   resumeSession: (roomId: string) => {
     void (async (): Promise<void> => {
       // Duplicate guards BEFORE any spawn, so a redundant click never mints
@@ -7314,6 +7362,136 @@ async function routeInitialDocIntoWorkspace(): Promise<boolean> {
   return true;
 }
 
+/** Last workspace tuple this window published, so the report hook can
+ *  sit on the (hot) window-title path without hammering localStorage
+ *  on every keystroke-driven dirty-marker refresh. */
+let lastReportedWorkspaceKey = '';
+
+/** Publish this single-doc window's open doc to the workspace store.
+ *  No-op in three-pane mode, where the shell reports all three slots
+ *  itself. Called from `updateWindowTitle` (every doc-identity change
+ *  funnels through it) and from `setCurrentDocHandle`. */
+function reportSingleDocWorkspace(): void {
+  if (multiDocActive) return;
+  const path = typeof currentDocHandle === 'string' ? currentDocHandle : null;
+  const key = `${path ?? ''}|${currentDocFilename ?? ''}|${currentDocFormat ?? ''}`;
+  if (key === lastReportedWorkspaceKey) return;
+  lastReportedWorkspaceKey = key;
+  reportWindowWorkspace('windows', [
+    { path, filename: currentDocFilename, format: currentDocFormat },
+  ]);
+}
+
+/** Read a file for a reopen-by-path flow (recents, workspace restore).
+ *  Returns null when the file is gone. A genuinely-empty file (stat
+ *  size 0) is substituted with blank-document bytes, the same way the
+ *  Open dialog's `resolveOpenedFile` does — these paths bypass it. */
+async function readFileForReopen(
+  path: string,
+): Promise<Awaited<ReturnType<NonNullable<ReturnType<typeof getElectronHost>>['readFileAtPath']>>> {
+  const electron = getElectronHost();
+  if (!electron) return null;
+  let file: Awaited<ReturnType<typeof electron.readFileAtPath>>;
+  try {
+    file = await electron.readFileAtPath(path);
+  } catch {
+    return null;
+  }
+  if (!file) return null;
+  if (opensAsBlank(file)) {
+    file = {
+      ...file,
+      bytes: await blankDocumentBytes(file.format, makeBlankNewDoc(), {
+        defaultFont: settings.get('bodyFont'),
+      }),
+    };
+  }
+  return file;
+}
+
+/** Reopen a saved workspace. Three-pane hands the whole set to the
+ *  shell, which restores each doc into the slot it was saved from.
+ *  Single-doc mounts the first doc in THIS window when it still holds
+ *  the pristine starter, and spawns a window for each of the rest —
+ *  the one-doc-per-window convention every other desktop flow follows.
+ *  Docs already open (here or in another window) are skipped rather
+ *  than duplicated. Resolves with how many actually opened. */
+async function restoreWorkspace(snapshot: WorkspaceSnapshot): Promise<number> {
+  const electron = getElectronHost();
+  if (!electron) {
+    showToast('Reopening a workspace requires the desktop edition.');
+    return 0;
+  }
+  homeScreen.hide();
+  if (multiDocActive) {
+    const { restoreWorkspaceIntoSlots } = await import('./multi-pane-shell.js');
+    // Slot assignments only mean something for a snapshot taken in
+    // three-pane mode; one taken in single-doc mode fills the slots
+    // in order instead.
+    return restoreWorkspaceIntoSlots(
+      snapshot.docs.map((d) => ({
+        path: d.path,
+        filename: d.filename,
+        slot: snapshot.mode === 'panes' ? d.slot : null,
+      })),
+    );
+  }
+  let opened = 0;
+  let missing = 0;
+  let inPlaceAvailable = isPristineStarter;
+  for (const doc of snapshot.docs) {
+    if (currentDocHandle != null && (await isSameOpenHandle(currentDocHandle, doc.path))) {
+      continue;
+    }
+    let takenByOther = false;
+    try {
+      takenByOther = (await electron.openPathCheck(doc.path)).takenByOther;
+    } catch {
+      /* old preload — fall through and let the open proceed */
+    }
+    if (takenByOther) continue;
+    const file = await readFileForReopen(doc.path);
+    if (!file) {
+      missing += 1;
+      continue;
+    }
+    try {
+      if (inPlaceAvailable) {
+        inPlaceAvailable = false;
+        await loadFileInPlace({
+          filename: file.name,
+          bytes: file.bytes,
+          handle: file.handle,
+          format: file.format,
+        });
+      } else if (electron.canSpawnWindow) {
+        await electron.spawnWindow({
+          filename: file.name,
+          bytes: file.bytes,
+          handle: file.handle,
+          format: file.format,
+          uid: null,
+        });
+      } else {
+        break; // nowhere left to put the rest
+      }
+      opened += 1;
+    } catch (err) {
+      if (err instanceof OpenCancelledError) continue; // password box dismissed
+      console.error(`Reopening "${doc.filename}" failed:`, err);
+      missing += 1;
+    }
+  }
+  if (missing > 0) {
+    showToast(
+      missing === 1
+        ? "1 document couldn't be reopened — it may have moved or been deleted."
+        : `${missing} documents couldn't be reopened — they may have moved or been deleted.`,
+    );
+  }
+  return opened;
+}
+
 /** Reopen a recent file in-place via its stored path handle.
  *  Prunes the entry if the file is gone / unreadable. */
 async function openRecentInPlace(recent: RecentFile): Promise<void> {
@@ -7527,6 +7705,7 @@ function pushSingleDocInfo(): void {
 function updateWindowTitle(): void {
   const focused = activeFile();
   pushSingleDocInfo();
+  reportSingleDocWorkspace();
   if (multiDocActive && multiDocGetAllFilenames) {
     const names = multiDocGetAllFilenames().filter((n): n is string => !!n);
     document.title = names.length > 0
@@ -9738,11 +9917,17 @@ if (BOOT_MULTI_DOC_WORKSPACE) {
     // window), and wire the forward channel.
     void getElectronHost()?.registerMultipane(true);
     installExternalOpenListener();
+    // Roll the previous session's open set into the offerable
+    // snapshot BEFORE anything mounts (the roll-over empties the live
+    // map, so a doc reported first would be swept back out), then
+    // re-report whatever this window ends up holding.
+    const lastSession = rolloverLastWorkspace();
     // If this window was spawned for an OS open (cold launch), route
     // its initial doc through the slot picker instead of booting
     // blank. Skip recovery when we did — a spawned-for-a-file window
     // isn't the place to surface unrelated drafts (matches single-doc).
     const routedInitialDoc = await routeInitialDocIntoWorkspace();
+    m.reportShellWorkspace();
     if (!routedInitialDoc) {
       // Blank multi-pane launch → land on the home screen, matching
       // single-pane. Shown BEFORE recovery (same order as single-pane):
@@ -9750,6 +9935,11 @@ if (BOOT_MULTI_DOC_WORKSPACE) {
       // auto-reopened docs hide it via the slot-populated hook.
       homeScreen.show();
       await runStartupRecovery();
+      // Opt-in launch restore, after recovery so a recovered draft
+      // keeps its slot and the restore skips that doc as already open.
+      if (lastSession && settings.get('reopenWorkspaceOnLaunch')) {
+        await restoreWorkspace(lastSession);
+      }
     }
   })();
 } else {
@@ -9780,6 +9970,23 @@ if (BOOT_MULTI_DOC_WORKSPACE) {
  *  If no payload, mount the starter and run normal recovery. */
 async function initSingleDocBoot(): Promise<void> {
   const host = getHost();
+  // Firstness is settled before anything else so the workspace
+  // roll-over below runs even on the OS-open path (which returns
+  // early with a spawn payload). Otherwise a launch that started by
+  // double-clicking a file in Finder would never roll the previous
+  // session over, and the next roll-over would fold two sessions'
+  // docs together. The main-process answer is a pure comparison —
+  // asking early costs nothing and never changes.
+  let isFirst = true;
+  try {
+    isFirst = await host.isFirstWindow();
+  } catch (err) {
+    console.warn('isFirstWindow failed; defaulting to true:', err);
+  }
+  // Only the first window rolls the previous session's set over, and
+  // it does so before its own doc is reported (the roll-over empties
+  // the live map). Later windows just keep reporting.
+  const lastSession = isFirst ? rolloverLastWorkspace() : null;
   // A spawned window carries an initial-doc payload. Check regardless of THIS
   // window's own `canSpawnWindow`: a web window spawned into a plain browser tab
   // isn't itself standalone, but must still mount the doc it was opened with.
@@ -9817,12 +10024,6 @@ async function initSingleDocBoot(): Promise<void> {
   // overlay: when it's covering the editor (fresh launches that land on
   // Home), keystrokes belong to it, not to the doc underneath.
   if (!homeScreen.isVisible()) view?.focus();
-  let isFirst = true;
-  try {
-    isFirst = await getHost().isFirstWindow();
-  } catch (err) {
-    console.warn('isFirstWindow failed; defaulting to true:', err);
-  }
   // A mode-switch reload must run recovery in THIS window no matter
   // what: it's the switch's surviving window, but frequently NOT the
   // app session's first window — every single→multi switch closes
@@ -9834,6 +10035,12 @@ async function initSingleDocBoot(): Promise<void> {
   if (modeSwitchPending) {
     console.log(`[cardmirror] modeswitch: single-pane boot, isFirst=${isFirst}`);
   }
+  if (isFirst) {
+    // Re-report after the roll-over emptied the live map, so this
+    // window is represented again straight away.
+    lastReportedWorkspaceKey = '';
+    reportSingleDocWorkspace();
+  }
   if (isFirst || modeSwitchPending) {
     // Launched with no file → show the home screen over the
     // (blank) starter doc. Recovery still runs underneath; if the
@@ -9842,6 +10049,11 @@ async function initSingleDocBoot(): Promise<void> {
     // no-recovery launch lands on the hub rather than a blank doc.
     homeScreen.show();
     await runStartupRecovery();
+    // Opt-in launch restore. A mode-switch reload already reopens an
+    // exact doc set of its own, so it never doubles up with this.
+    if (lastSession && !modeSwitchPending && settings.get('reopenWorkspaceOnLaunch')) {
+      await restoreWorkspace(lastSession);
+    }
   }
   if (isFirst) {
     const electron = getElectronHost();

--- a/src/editor/multi-pane-shell.ts
+++ b/src/editor/multi-pane-shell.ts
@@ -99,6 +99,7 @@ import {
 } from './text-prompt.js';
 import { showToast } from './toast.js';
 import { recordRecent } from './recents-store.js';
+import { reportWindowWorkspace, type WorkspaceDoc } from './workspace-store.js';
 import { maybeDecryptForOpen, OpenCancelledError } from './open-encrypted.js';
 import {
   checkSessionRejoinForOpenedDoc,
@@ -1698,6 +1699,23 @@ class MultiPaneShell {
     this.navRailEl.dataset['active'] = String(active);
     // Active-count change → pane widths change → re-sync.
     this.scheduleSyncAllCardIntrinsicWidths();
+    // Every open / close / send-to-slot lands here, so this is the one
+    // place the workspace snapshot needs refreshing (Save As renames go
+    // through `setFocusedFile`, which reports separately).
+    this.reportWorkspace();
+  }
+
+  /** Publish this window's open set to the workspace store, so
+   *  "Reopen last workspace" can rebuild it — including which slot
+   *  each doc sat in. Unsaved docs (no path) drop out in the store. */
+  reportWorkspace(): void {
+    const docs: Array<Pick<WorkspaceDoc, 'filename' | 'format' | 'slot'> & { path: unknown }> = [];
+    for (const id of SLOT_IDS) {
+      for (const rec of this.slots[id].stack) {
+        docs.push({ path: rec.handle, filename: rec.filename, format: rec.format, slot: id });
+      }
+    }
+    reportWindowWorkspace('panes', docs);
   }
 
   /** Toggle expand mode on `slot`. If the same slot is already
@@ -2389,6 +2407,9 @@ class MultiPaneShell {
     rec.format = file.format;
     slot.refreshChipFilename();
     pushPaneDocInfo(rec.uid, rec.filename);
+    // Save As moved the doc (or gave a never-saved doc its first
+    // path) — the snapshot's paths are now out of date.
+    this.reportWorkspace();
   }
 
   /** Journal every DocRecord across every slot's stack. Called by
@@ -2648,6 +2669,57 @@ class MultiPaneShell {
     if (record) {
       requestAnimationFrame(() => scrollRecordToDescriptor(record, req.descriptor, req.name));
     }
+  }
+
+  /** Reopen a saved workspace into this window's slots. Each doc is
+   *  read straight from its recorded path — no picker — and lands in
+   *  the slot it was saved from; docs saved in single-doc mode (no
+   *  slot) fill slot1 → slot2 → slot3 in turn. Docs already open here
+   *  or held by another window are skipped rather than duplicated,
+   *  and a file that moved or was deleted is skipped with a toast.
+   *  Resolves with the number of docs actually opened. */
+  async restoreWorkspaceDocs(
+    docs: Array<{ path: string; filename: string; slot: SlotId | null }>,
+  ): Promise<number> {
+    const electron = getElectronHost();
+    if (!electron) return 0;
+    let opened = 0;
+    let missing = 0;
+    let nextSlot = 0;
+    for (const doc of docs) {
+      if (await this.findOpenRecordByHandle(doc.path)) continue;
+      if (await isFileOpenInAnotherWindow(doc.path)) continue;
+      let file: Awaited<ReturnType<typeof electron.readFileAtPath>>;
+      try {
+        file = await electron.readFileAtPath(doc.path);
+      } catch {
+        file = null;
+      }
+      if (!file) {
+        missing += 1;
+        continue;
+      }
+      const target = doc.slot ?? SLOT_IDS[nextSlot % SLOT_IDS.length]!;
+      nextSlot += 1;
+      try {
+        await this.loadOpenedIntoSlot(
+          { name: file.name, bytes: file.bytes, handle: file.handle },
+          target,
+        );
+        opened += 1;
+      } catch (err) {
+        console.error(`Reopening "${doc.filename}" failed:`, err);
+        missing += 1;
+      }
+    }
+    if (missing > 0) {
+      showToast(
+        missing === 1
+          ? "1 document couldn't be reopened — it may have moved or been deleted."
+          : `${missing} documents couldn't be reopened — they may have moved or been deleted.`,
+      );
+    }
+    return opened;
   }
 
   /** Duplicate-open guard: if `opened` is already loaded in the
@@ -3099,6 +3171,23 @@ export function focusSlotByIndex(idx: 0 | 1 | 2): void {
 export function sendVisibleToSlotByIndex(idx: 0 | 1 | 2): void {
   if (!shell) return;
   shell.sendVisibleToSlotByIndex(idx);
+}
+
+/** Re-publish the shell's open set to the workspace store. Called at
+ *  boot right after the roll-over (which empties the live map) so this
+ *  window's docs are represented again straight away. */
+export function reportShellWorkspace(): void {
+  shell?.reportWorkspace();
+}
+
+/** Reopen a saved workspace into the three-pane shell. No-op (0) in
+ *  single-doc mode, where `index.ts` restores by spawning a window
+ *  per doc instead. */
+export async function restoreWorkspaceIntoSlots(
+  docs: Array<{ path: string; filename: string; slot: SlotId | null }>,
+): Promise<number> {
+  if (!shell) return 0;
+  return shell.restoreWorkspaceDocs(docs);
 }
 
 /** Toggle expand-mode on the focused slot. No-op when no slot is

--- a/src/editor/ribbon-commands.ts
+++ b/src/editor/ribbon-commands.ts
@@ -4317,6 +4317,8 @@ export type RibbonCommandId =
   | 'toggleReadMode'
   | 'toggleReaderView'
   | 'openContainingFolder'
+  | 'saveWorkspace'
+  | 'reopenWorkspace'
   | 'toggleCommentsVisible'
   | 'addCommentToSelection'
   | 'addNoteToSelection'
@@ -4552,6 +4554,8 @@ export const RIBBON_COMMAND_IDS: RibbonCommandId[] = [
   'toggleReadMode',
   'toggleReaderView',
   'openContainingFolder',
+  'saveWorkspace',
+  'reopenWorkspace',
   'toggleCommentsVisible',
   'addCommentToSelection',
   'addNoteToSelection',
@@ -4739,6 +4743,8 @@ export const RIBBON_COMMAND_LABELS: Record<RibbonCommandId, string> = {
   toggleReadMode: 'Toggle Read Mode',
   toggleReaderView: 'Toggle Reading View',
   openContainingFolder: 'Open Containing Folder',
+  saveWorkspace: 'Save Workspace',
+  reopenWorkspace: 'Reopen Last Workspace',
   toggleCommentsVisible: 'Show / Hide Comments',
   addCommentToSelection: 'Add Comment to Selection',
   addNoteToSelection: 'Add Note to Selection',
@@ -4913,6 +4919,8 @@ export const RIBBON_COMMAND_ALIASES: Partial<Record<RibbonCommandId, readonly st
   toggleReadMode: ['show read mode', 'hide read mode', 'invisibility mode'],
   toggleReaderView: ['reading view', 'reader view', 'paginated view', 'read view', 'book view', 'columns'],
   openContainingFolder: ['reveal in finder', 'show in folder', 'show in explorer', 'reveal file', 'file location', 'containing folder'],
+  saveWorkspace: ['save session', 'save open documents', 'remember open documents', 'save tabs'],
+  reopenWorkspace: ['restore session', 'reopen session', 'open previous session', 'reopen last session', 'restore workspace', 'reopen documents', 'reopen tabs'],
   toggleAutosave: ['enable autosave', 'disable autosave', 'turn on autosave', 'turn off autosave'],
   markActiveAsSpeech: ['toggle speech doc', 'set speech document'],
   // vague / Word-flavored labels
@@ -5089,6 +5097,8 @@ export const DEFAULT_RIBBON_KEYS: Record<RibbonCommandId, string | string[]> = {
   toggleReadMode: '',
   toggleReaderView: '',
   openContainingFolder: '',
+  saveWorkspace: '',
+  reopenWorkspace: '',
   toggleCommentsVisible: '',
   addCommentToSelection: '',
   addNoteToSelection: 'Mod-Shift-n',
@@ -5332,6 +5342,8 @@ export interface RibbonContext {
   toggleReadMode: () => void;
   toggleReaderView: () => void;
   openContainingFolder: () => void;
+  saveWorkspace: () => void;
+  reopenWorkspace: () => void;
   openShortcutsReference: () => void;
   toggleCommentsVisible: () => void;
   addCommentToSelection: () => void;
@@ -5527,6 +5539,8 @@ const DEFAULT_RIBBON_CONTEXT: RibbonContext = {
   toggleReadMode: () => {},
   toggleReaderView: () => {},
   openContainingFolder: () => {},
+  saveWorkspace: () => {},
+  reopenWorkspace: () => {},
   openShortcutsReference: () => {},
   toggleCommentsVisible: () => {},
   addCommentToSelection: () => {},
@@ -5784,6 +5798,18 @@ function commandFor(id: RibbonCommandId, ctx: RibbonContext): Command {
       return (_state, dispatch) => {
         if (!dispatch) return true;
         ctx.openContainingFolder();
+        return true;
+      };
+    case 'saveWorkspace':
+      return (_state, dispatch) => {
+        if (!dispatch) return true;
+        ctx.saveWorkspace();
+        return true;
+      };
+    case 'reopenWorkspace':
+      return (_state, dispatch) => {
+        if (!dispatch) return true;
+        ctx.reopenWorkspace();
         return true;
       };
     case 'toggleCommentsVisible':

--- a/src/editor/ribbon-groups.ts
+++ b/src/editor/ribbon-groups.ts
@@ -18,7 +18,7 @@ export interface RibbonGroup {
 export const RIBBON_GROUPS: RibbonGroup[] = [
   {
     title: 'File',
-    commands: ['newDocument', 'openFile', 'save', 'saveAs', 'saveSendDoc', 'saveReadDoc', 'saveMarkedCards', 'toggleAutosave', 'openContainingFolder', 'goHome'],
+    commands: ['newDocument', 'openFile', 'save', 'saveAs', 'saveSendDoc', 'saveReadDoc', 'saveMarkedCards', 'toggleAutosave', 'openContainingFolder', 'saveWorkspace', 'reopenWorkspace', 'goHome'],
   },
   {
     title: 'Speech',

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -1466,13 +1466,6 @@ export interface Settings {
    *  page reload to (re)build the editor shell. Comments are
    *  unavailable while this is on. See SPEC-multi-pane.md. */
   multiDocWorkspace: boolean;
-  /** When on, launching CardMirror reopens the documents the previous
-   *  session ended with — the ones still TICKED in the home screen's
-   *  Last workspace checklist, which is the same list the manual
-   *  Reopen honours. Off by default — a launch that silently reopens
-   *  six files is a surprise unless it was asked for. Desktop only:
-   *  reopening needs on-disk paths. */
-  reopenWorkspaceOnLaunch: boolean;
   /** Which UI shell the web edition uses on this device. `'auto'`
    *  picks the mobile shell on coarse-pointer screens narrower than
    *  1024px (resolved once per load — rotating mid-session doesn't
@@ -1883,7 +1876,6 @@ const DEFAULTS: Settings = {
   googleTranslateApiKey: '',
   prependTranslationMarker: true,
   multiDocWorkspace: false,
-  reopenWorkspaceOnLaunch: false,
   mobileLayout: 'auto',
   multiDocLayoutMode: 'compact',
   quickCardActiveTags: [],
@@ -2133,16 +2125,6 @@ export const SETTING_METADATA: SettingMeta[] = [
     category: 'general',
     section: 'Workspace',
     aliases: ['split view', 'split screen', 'multi pane', 'multi-doc'],
-  },
-  {
-    key: 'reopenWorkspaceOnLaunch',
-    label: 'Reopen last workspace at launch',
-    description:
-      'Start CardMirror with the documents you had open when you last quit — in the same panes, or one window each in single-document mode. Only the documents still ticked under "Last workspace" on the home screen are reopened, so unticking one stops it coming back at every launch. With this off, the same set is still one click away on the home screen.',
-    kind: 'toggle',
-    category: 'general',
-    section: 'Workspace',
-    aliases: ['restore session', 'reopen documents', 'restore workspace', 'session restore', 'reopen tabs'],
   },
   {
     key: 'multiDocLayoutMode',
@@ -4766,7 +4748,6 @@ function sanitize(s: Settings): Settings {
       typeof s.googleTranslateApiKey === 'string' ? s.googleTranslateApiKey.trim() : '',
     prependTranslationMarker: s.prependTranslationMarker === false ? false : true,
     multiDocWorkspace: !!s.multiDocWorkspace,
-    reopenWorkspaceOnLaunch: !!s.reopenWorkspaceOnLaunch,
     mobileLayout:
       s.mobileLayout === 'mobile' || s.mobileLayout === 'desktop'
         ? s.mobileLayout

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -1467,9 +1467,10 @@ export interface Settings {
    *  unavailable while this is on. See SPEC-multi-pane.md. */
   multiDocWorkspace: boolean;
   /** When on, launching CardMirror reopens the documents the previous
-   *  session ended with (the same set the home screen's Last workspace
-   *  row offers). Off by default — a launch that silently reopens six
-   *  files is a surprise unless it was asked for. Desktop only:
+   *  session ended with — the ones still TICKED in the home screen's
+   *  Last workspace checklist, which is the same list the manual
+   *  Reopen honours. Off by default — a launch that silently reopens
+   *  six files is a surprise unless it was asked for. Desktop only:
    *  reopening needs on-disk paths. */
   reopenWorkspaceOnLaunch: boolean;
   /** Which UI shell the web edition uses on this device. `'auto'`
@@ -2137,7 +2138,7 @@ export const SETTING_METADATA: SettingMeta[] = [
     key: 'reopenWorkspaceOnLaunch',
     label: 'Reopen last workspace at launch',
     description:
-      'Start CardMirror with the documents you had open when you last quit — in the same panes, or one window each in single-document mode. With this off, the same set is still one click away on the home screen under "Last workspace".',
+      'Start CardMirror with the documents you had open when you last quit — in the same panes, or one window each in single-document mode. Only the documents still ticked under "Last workspace" on the home screen are reopened, so unticking one stops it coming back at every launch. With this off, the same set is still one click away on the home screen.',
     kind: 'toggle',
     category: 'general',
     section: 'Workspace',

--- a/src/editor/settings.ts
+++ b/src/editor/settings.ts
@@ -1466,6 +1466,12 @@ export interface Settings {
    *  page reload to (re)build the editor shell. Comments are
    *  unavailable while this is on. See SPEC-multi-pane.md. */
   multiDocWorkspace: boolean;
+  /** When on, launching CardMirror reopens the documents the previous
+   *  session ended with (the same set the home screen's Last workspace
+   *  row offers). Off by default — a launch that silently reopens six
+   *  files is a surprise unless it was asked for. Desktop only:
+   *  reopening needs on-disk paths. */
+  reopenWorkspaceOnLaunch: boolean;
   /** Which UI shell the web edition uses on this device. `'auto'`
    *  picks the mobile shell on coarse-pointer screens narrower than
    *  1024px (resolved once per load — rotating mid-session doesn't
@@ -1876,6 +1882,7 @@ const DEFAULTS: Settings = {
   googleTranslateApiKey: '',
   prependTranslationMarker: true,
   multiDocWorkspace: false,
+  reopenWorkspaceOnLaunch: false,
   mobileLayout: 'auto',
   multiDocLayoutMode: 'compact',
   quickCardActiveTags: [],
@@ -2125,6 +2132,16 @@ export const SETTING_METADATA: SettingMeta[] = [
     category: 'general',
     section: 'Workspace',
     aliases: ['split view', 'split screen', 'multi pane', 'multi-doc'],
+  },
+  {
+    key: 'reopenWorkspaceOnLaunch',
+    label: 'Reopen last workspace at launch',
+    description:
+      'Start CardMirror with the documents you had open when you last quit — in the same panes, or one window each in single-document mode. With this off, the same set is still one click away on the home screen under "Last workspace".',
+    kind: 'toggle',
+    category: 'general',
+    section: 'Workspace',
+    aliases: ['restore session', 'reopen documents', 'restore workspace', 'session restore', 'reopen tabs'],
   },
   {
     key: 'multiDocLayoutMode',
@@ -4748,6 +4765,7 @@ function sanitize(s: Settings): Settings {
       typeof s.googleTranslateApiKey === 'string' ? s.googleTranslateApiKey.trim() : '',
     prependTranslationMarker: s.prependTranslationMarker === false ? false : true,
     multiDocWorkspace: !!s.multiDocWorkspace,
+    reopenWorkspaceOnLaunch: !!s.reopenWorkspaceOnLaunch,
     mobileLayout:
       s.mobileLayout === 'mobile' || s.mobileLayout === 'desktop'
         ? s.mobileLayout

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -4407,6 +4407,41 @@ html.pmd-home-active #speech-doc-banner {
      if it must. */
 }
 
+/* Last workspace — one row above Recent that reopens the whole set of
+   documents the previous session ended with. Borrows the recent row's
+   chip / name scaffolding; the file list takes the path cell's slot. */
+.pmd-home-workspace-section {
+  margin-bottom: 1.1rem;
+}
+.pmd-home-workspace-open {
+  appearance: none;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--pmd-c-border);
+  border-radius: 6px;
+  padding: 0.5rem 0.6rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--pmd-c-text);
+  width: 100%;
+}
+.pmd-home-workspace-open:hover {
+  background: var(--pmd-c-hover);
+}
+.pmd-home-workspace-files {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.78rem;
+  color: var(--pmd-c-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+}
+
 /* Collaboration sessions — dedicated section below Recent. Scrolls
    past ~6 rows so a long list never pushes the utilities off screen,
    and a session can never be displaced the way recents rotate. */

--- a/src/editor/style.css
+++ b/src/editor/style.css
@@ -4407,11 +4407,20 @@ html.pmd-home-active #speech-doc-banner {
      if it must. */
 }
 
-/* Last workspace — one row above Recent that reopens the whole set of
-   documents the previous session ended with. Borrows the recent row's
-   chip / name scaffolding; the file list takes the path cell's slot. */
+/* Last workspace — above Recent: a Reopen button over the checklist of
+   documents the previous session ended with. Rows borrow the recent
+   row's chip / name / path scaffolding, so a path still left-truncates
+   to keep its tail visible. The list scrolls past ~8 rows (like the
+   sessions list) so a 24-document workspace can't push the utilities
+   off screen. */
 .pmd-home-workspace-section {
   margin-bottom: 1.1rem;
+}
+.pmd-home-workspace-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
 }
 .pmd-home-workspace-open {
   appearance: none;
@@ -4426,20 +4435,59 @@ html.pmd-home-active #speech-doc-banner {
   align-items: center;
   gap: 0.6rem;
   color: var(--pmd-c-text);
-  width: 100%;
-}
-.pmd-home-workspace-open:hover {
-  background: var(--pmd-c-hover);
-}
-.pmd-home-workspace-files {
   flex: 1 1 auto;
   min-width: 0;
+}
+.pmd-home-workspace-open:hover:not(:disabled) {
+  background: var(--pmd-c-hover);
+}
+.pmd-home-workspace-open:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+.pmd-home-workspace-select {
+  appearance: none;
+  font: inherit;
   font-size: 0.78rem;
+  background: transparent;
+  border: none;
   color: var(--pmd-c-text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-align: right;
+  cursor: pointer;
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  flex: 0 0 auto;
+}
+.pmd-home-workspace-select:hover:not(:disabled) {
+  background: var(--pmd-c-hover);
+  color: var(--pmd-c-text);
+}
+.pmd-home-workspace-select:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+.pmd-home-workspace-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 18rem;
+  overflow-y: auto;
+}
+.pmd-home-workspace-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--pmd-c-text);
+}
+.pmd-home-workspace-item:hover {
+  background: var(--pmd-c-hover);
+}
+.pmd-home-workspace-item input {
+  flex: 0 0 auto;
+  margin: 0;
+  cursor: pointer;
 }
 
 /* Collaboration sessions — dedicated section below Recent. Scrolls

--- a/src/editor/workspace-store.ts
+++ b/src/editor/workspace-store.ts
@@ -1,0 +1,236 @@
+/**
+ * Workspace store — "reopen the documents I had open last time."
+ *
+ * Two localStorage records, both host-agnostic in shape but only
+ * useful where handles are serializable (Electron paths; the web
+ * edition's `FileSystemFileHandle` can't be stored, exactly as in
+ * `recents-store.ts`, so web docs are skipped):
+ *
+ *  - LIVE (`pmd-live-workspace`): a map of windowId → the docs that
+ *    window currently has open. Every window rewrites its OWN entry
+ *    whenever its open set changes (single-doc: on handle change;
+ *    three-pane: on every slot composition change). Nothing clears
+ *    it on quit — a killed app leaves exactly what was open, which
+ *    is the point.
+ *
+ *  - LAST (`pmd-last-workspace`): the snapshot offered to the user.
+ *    The first window of an app session calls `rolloverLastWorkspace()`
+ *    at boot, which folds the LIVE map (i.e. the previous session's
+ *    survivors) into LAST and empties LIVE so this session starts
+ *    accumulating from scratch. `saveWorkspaceNow()` does the same
+ *    fold mid-session for the explicit Save Workspace command.
+ *
+ * A rollover that finds nothing open KEEPS the previous snapshot
+ * rather than blanking it: launching, closing everything, and
+ * quitting shouldn't destroy the set the user might still want back.
+ *
+ * The mode (`panes` / `windows`) is recorded so a restore can honour
+ * slot assignments when the user is still in three-pane mode, and
+ * ignore them when they've since switched.
+ */
+
+const LIVE_KEY = 'pmd-live-workspace';
+const LAST_KEY = 'pmd-last-workspace';
+
+/** Cap on a snapshot's size — a workspace bigger than this is
+ *  almost certainly stale entries from windows that never got
+ *  pruned, and reopening 40 documents would be hostile anyway. */
+const MAX_DOCS = 24;
+
+/** Live entries older than this are dropped on read. Bounds the map
+ *  against windowIds that vanished without a rollover (a crash on a
+ *  machine where the next launch never happened, say). */
+const LIVE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export type WorkspaceSlotId = 'slot1' | 'slot2' | 'slot3';
+
+export interface WorkspaceDoc {
+  /** Absolute path (Electron). Docs without a serializable handle
+   *  are never recorded, so this is always a non-empty string. */
+  path: string;
+  filename: string;
+  format: 'cmir' | 'docx' | null;
+  /** Three-pane only: which slot held the doc. Null in single-doc
+   *  mode, and ignored by a restore running in the other mode. */
+  slot: WorkspaceSlotId | null;
+}
+
+export interface WorkspaceSnapshot {
+  savedAt: number;
+  mode: 'panes' | 'windows';
+  docs: WorkspaceDoc[];
+}
+
+interface LiveEntry {
+  updatedAt: number;
+  mode: 'panes' | 'windows';
+  docs: WorkspaceDoc[];
+}
+
+/** Identity for THIS window inside the LIVE map, minted per load.
+ *  Deliberately NOT persisted: a reloaded window is a new window as
+ *  far as the map is concerned, and its old entry is swept by the
+ *  next rollover. */
+const WINDOW_ID =
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `w${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+
+type Listener = (snapshot: WorkspaceSnapshot | null) => void;
+const listeners = new Set<Listener>();
+
+function isDoc(d: unknown): d is WorkspaceDoc {
+  if (!d || typeof d !== 'object') return false;
+  const doc = d as WorkspaceDoc;
+  return typeof doc.path === 'string' && !!doc.path && typeof doc.filename === 'string';
+}
+
+function normalizeDoc(d: WorkspaceDoc): WorkspaceDoc {
+  return {
+    path: d.path,
+    filename: d.filename,
+    format: d.format === 'cmir' || d.format === 'docx' ? d.format : null,
+    slot: d.slot === 'slot1' || d.slot === 'slot2' || d.slot === 'slot3' ? d.slot : null,
+  };
+}
+
+function readJson(key: string): unknown {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(key: string, value: unknown): void {
+  try {
+    if (value === null) localStorage.removeItem(key);
+    else localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Storage disabled / quota — the feature degrades to "no
+    // snapshot", which every caller already handles.
+  }
+}
+
+function readLive(): Record<string, LiveEntry> {
+  const parsed = readJson(LIVE_KEY);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+  const out: Record<string, LiveEntry> = {};
+  const cutoff = Date.now() - LIVE_MAX_AGE_MS;
+  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!value || typeof value !== 'object') continue;
+    const e = value as LiveEntry;
+    if (typeof e.updatedAt !== 'number' || e.updatedAt < cutoff) continue;
+    if (!Array.isArray(e.docs)) continue;
+    out[id] = {
+      updatedAt: e.updatedAt,
+      mode: e.mode === 'panes' ? 'panes' : 'windows',
+      docs: e.docs.filter(isDoc).map(normalizeDoc),
+    };
+  }
+  return out;
+}
+
+/** Fold the LIVE map into one snapshot: oldest window first (so the
+ *  set reads in the order the user built it), de-duplicated by path.
+ *  Mode comes from the newest contributing entry — every window in a
+ *  session runs the same mode, so this only matters after a toggle. */
+function foldLive(live: Record<string, LiveEntry>): WorkspaceSnapshot | null {
+  const entries = Object.values(live)
+    .filter((e) => e.docs.length > 0)
+    .sort((a, b) => a.updatedAt - b.updatedAt);
+  if (entries.length === 0) return null;
+  const seen = new Set<string>();
+  const docs: WorkspaceDoc[] = [];
+  for (const entry of entries) {
+    for (const doc of entry.docs) {
+      if (seen.has(doc.path)) continue;
+      seen.add(doc.path);
+      docs.push(doc);
+      if (docs.length >= MAX_DOCS) break;
+    }
+    if (docs.length >= MAX_DOCS) break;
+  }
+  const newest = entries.reduce((a, b) => (b.updatedAt > a.updatedAt ? b : a));
+  return { savedAt: Date.now(), mode: newest.mode, docs };
+}
+
+/** Record what THIS window currently has open. Docs without a string
+ *  path (unsaved, or a web handle) are dropped — they can't be
+ *  reopened, and recording them would render dead rows. Cheap enough
+ *  to call from every open / close / Save As. */
+export function reportWindowWorkspace(
+  mode: 'panes' | 'windows',
+  docs: Array<{ path: unknown; filename: string | null; format: 'cmir' | 'docx' | null; slot?: WorkspaceSlotId | null }>,
+): void {
+  const kept: WorkspaceDoc[] = [];
+  for (const d of docs) {
+    if (typeof d.path !== 'string' || !d.path || !d.filename) continue;
+    kept.push({ path: d.path, filename: d.filename, format: d.format, slot: d.slot ?? null });
+  }
+  const live = readLive();
+  if (kept.length === 0) delete live[WINDOW_ID];
+  else live[WINDOW_ID] = { updatedAt: Date.now(), mode, docs: kept };
+  writeJson(LIVE_KEY, live);
+}
+
+/** The snapshot the user can reopen, or null when there is none. */
+export function lastWorkspace(): WorkspaceSnapshot | null {
+  const parsed = readJson(LAST_KEY);
+  if (!parsed || typeof parsed !== 'object') return null;
+  const s = parsed as WorkspaceSnapshot;
+  if (typeof s.savedAt !== 'number' || !Array.isArray(s.docs)) return null;
+  const docs = s.docs.filter(isDoc).map(normalizeDoc).slice(0, MAX_DOCS);
+  if (docs.length === 0) return null;
+  return { savedAt: s.savedAt, mode: s.mode === 'panes' ? 'panes' : 'windows', docs };
+}
+
+function publish(snapshot: WorkspaceSnapshot | null): void {
+  for (const fn of listeners) fn(snapshot);
+}
+
+/** Boot-time roll-over, run ONCE per app session by the first window:
+ *  the LIVE map still holds the previous session's open docs, so fold
+ *  it into LAST and empty it. Returns the resulting snapshot (which
+ *  may be a previous one, when the last session ended with nothing
+ *  open). */
+export function rolloverLastWorkspace(): WorkspaceSnapshot | null {
+  const folded = foldLive(readLive());
+  writeJson(LIVE_KEY, {});
+  if (folded) writeJson(LAST_KEY, folded);
+  const snapshot = folded ?? lastWorkspace();
+  publish(snapshot);
+  return snapshot;
+}
+
+/** Explicit "Save Workspace": fold what every live window reports
+ *  RIGHT NOW into LAST, without disturbing the live map. Returns the
+ *  saved snapshot, or null when nothing reopenable is open. */
+export function saveWorkspaceNow(): WorkspaceSnapshot | null {
+  const folded = foldLive(readLive());
+  if (!folded) return null;
+  writeJson(LAST_KEY, folded);
+  publish(folded);
+  return folded;
+}
+
+export function clearLastWorkspace(): void {
+  writeJson(LAST_KEY, null);
+  publish(null);
+}
+
+export function subscribeLastWorkspace(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+// Cross-window sync, same mechanism recents use: a write from ANOTHER
+// window arrives as a `storage` event (never fired in the writing
+// window, which published to its own listeners above). Keeps a home
+// screen sitting visible in one window current when another saves.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key === LAST_KEY || e.key === null) publish(lastWorkspace());
+  });
+}

--- a/src/editor/workspace-store.ts
+++ b/src/editor/workspace-store.ts
@@ -32,6 +32,14 @@
  * The mode (`panes` / `windows`) is recorded so a restore can honour
  * slot assignments when the user is still in three-pane mode, and
  * ignore them when they've since switched.
+ *
+ * `excluded` is the user's standing "don't bother reopening this one"
+ * list, edited by the home screen's checklist and honoured by BOTH
+ * ways of reopening (the button and the at-launch restore) — so one
+ * untick is durable rather than a per-click filter. It carries across
+ * roll-overs for paths still in the set, and is pruned of everything
+ * else so a long-gone document can't silently suppress itself years
+ * later if it comes back.
  */
 
 const LIVE_KEY = 'pmd-live-workspace';
@@ -68,6 +76,8 @@ export interface WorkspaceSnapshot {
    *  rather than it being the automatic end-of-session capture. Only
    *  effect: an empty quit doesn't clear it. */
   pinned: boolean;
+  /** Paths the user unticked. Always a subset of `docs`'s paths. */
+  excluded: string[];
 }
 
 interface LiveEntry {
@@ -162,7 +172,27 @@ function foldLive(live: Record<string, LiveEntry>): WorkspaceSnapshot | null {
     if (docs.length >= MAX_DOCS) break;
   }
   const newest = entries.reduce((a, b) => (b.updatedAt > a.updatedAt ? b : a));
-  return { savedAt: Date.now(), mode: newest.mode, docs, pinned: false };
+  return { savedAt: Date.now(), mode: newest.mode, docs, pinned: false, excluded: [] };
+}
+
+/** Carry the standing unticks onto a freshly folded snapshot, keeping
+ *  only the paths that are actually in it. A document the user unticked
+ *  stays unticked as sessions roll over; one that has left the set
+ *  drops its exclusion rather than lying in wait. */
+function carryExclusions(next: WorkspaceSnapshot): WorkspaceSnapshot {
+  const standing = lastWorkspace()?.excluded ?? [];
+  if (standing.length === 0) return next;
+  const paths = new Set(next.docs.map((d) => d.path));
+  return { ...next, excluded: standing.filter((p) => paths.has(p)) };
+}
+
+/** The documents a reopen should actually open: everything still
+ *  ticked. Both the home screen's button and the at-launch restore go
+ *  through this, so they can't drift apart. */
+export function selectedDocs(snapshot: WorkspaceSnapshot): WorkspaceDoc[] {
+  if (snapshot.excluded.length === 0) return snapshot.docs;
+  const excluded = new Set(snapshot.excluded);
+  return snapshot.docs.filter((d) => !excluded.has(d.path));
 }
 
 /** Record what THIS window currently has open. Docs without a string
@@ -192,11 +222,15 @@ export function lastWorkspace(): WorkspaceSnapshot | null {
   if (typeof s.savedAt !== 'number' || !Array.isArray(s.docs)) return null;
   const docs = s.docs.filter(isDoc).map(normalizeDoc).slice(0, MAX_DOCS);
   if (docs.length === 0) return null;
+  const paths = new Set(docs.map((d) => d.path));
   return {
     savedAt: s.savedAt,
     mode: s.mode === 'panes' ? 'panes' : 'windows',
     docs,
     pinned: s.pinned === true,
+    excluded: Array.isArray(s.excluded)
+      ? s.excluded.filter((p): p is string => typeof p === 'string' && paths.has(p))
+      : [],
   };
 }
 
@@ -215,8 +249,9 @@ export function rolloverLastWorkspace(): WorkspaceSnapshot | null {
   writeJson(LIVE_KEY, {});
   let snapshot: WorkspaceSnapshot | null;
   if (folded) {
-    writeJson(LAST_KEY, folded);
-    snapshot = folded;
+    const carried = carryExclusions(folded);
+    writeJson(LAST_KEY, carried);
+    snapshot = carried;
   } else {
     const standing = lastWorkspace();
     snapshot = standing?.pinned ? standing : null;
@@ -232,10 +267,23 @@ export function rolloverLastWorkspace(): WorkspaceSnapshot | null {
 export function saveWorkspaceNow(): WorkspaceSnapshot | null {
   const folded = foldLive(readLive());
   if (!folded) return null;
-  const pinned: WorkspaceSnapshot = { ...folded, pinned: true };
+  const pinned: WorkspaceSnapshot = { ...carryExclusions(folded), pinned: true };
   writeJson(LAST_KEY, pinned);
   publish(pinned);
   return pinned;
+}
+
+/** Replace the standing untick list (home-screen checklist edits).
+ *  No-op when there's no snapshot to attach it to. Paths outside the
+ *  snapshot are dropped, so the invariant `excluded ⊆ docs` holds. */
+export function setWorkspaceExcluded(paths: Iterable<string>): void {
+  const snapshot = lastWorkspace();
+  if (!snapshot) return;
+  const inSet = new Set(snapshot.docs.map((d) => d.path));
+  const excluded = [...new Set(paths)].filter((p) => inSet.has(p));
+  const next: WorkspaceSnapshot = { ...snapshot, excluded };
+  writeJson(LAST_KEY, next);
+  publish(next);
 }
 
 export function clearLastWorkspace(): void {

--- a/src/editor/workspace-store.ts
+++ b/src/editor/workspace-store.ts
@@ -20,9 +20,14 @@
  *    accumulating from scratch. `saveWorkspaceNow()` does the same
  *    fold mid-session for the explicit Save Workspace command.
  *
- * A rollover that finds nothing open KEEPS the previous snapshot
- * rather than blanking it: launching, closing everything, and
- * quitting shouldn't destroy the set the user might still want back.
+ * Closing every document before quitting is taken at face value: the
+ * roll-over finds nothing and CLEARS the snapshot, so the next launch
+ * offers nothing to reopen. The exception is a snapshot the user saved
+ * deliberately (`pinned`, written by Save Workspace) — that survives an
+ * empty quit, which is the whole reason to reach for the command. A
+ * session that ends WITH documents open always replaces the snapshot,
+ * pinned or not; pinning protects against erasure, it doesn't freeze
+ * the row.
  *
  * The mode (`panes` / `windows`) is recorded so a restore can honour
  * slot assignments when the user is still in three-pane mode, and
@@ -59,6 +64,10 @@ export interface WorkspaceSnapshot {
   savedAt: number;
   mode: 'panes' | 'windows';
   docs: WorkspaceDoc[];
+  /** True when the user saved this set deliberately (Save Workspace)
+   *  rather than it being the automatic end-of-session capture. Only
+   *  effect: an empty quit doesn't clear it. */
+  pinned: boolean;
 }
 
 interface LiveEntry {
@@ -153,7 +162,7 @@ function foldLive(live: Record<string, LiveEntry>): WorkspaceSnapshot | null {
     if (docs.length >= MAX_DOCS) break;
   }
   const newest = entries.reduce((a, b) => (b.updatedAt > a.updatedAt ? b : a));
-  return { savedAt: Date.now(), mode: newest.mode, docs };
+  return { savedAt: Date.now(), mode: newest.mode, docs, pinned: false };
 }
 
 /** Record what THIS window currently has open. Docs without a string
@@ -183,7 +192,12 @@ export function lastWorkspace(): WorkspaceSnapshot | null {
   if (typeof s.savedAt !== 'number' || !Array.isArray(s.docs)) return null;
   const docs = s.docs.filter(isDoc).map(normalizeDoc).slice(0, MAX_DOCS);
   if (docs.length === 0) return null;
-  return { savedAt: s.savedAt, mode: s.mode === 'panes' ? 'panes' : 'windows', docs };
+  return {
+    savedAt: s.savedAt,
+    mode: s.mode === 'panes' ? 'panes' : 'windows',
+    docs,
+    pinned: s.pinned === true,
+  };
 }
 
 function publish(snapshot: WorkspaceSnapshot | null): void {
@@ -192,14 +206,22 @@ function publish(snapshot: WorkspaceSnapshot | null): void {
 
 /** Boot-time roll-over, run ONCE per app session by the first window:
  *  the LIVE map still holds the previous session's open docs, so fold
- *  it into LAST and empty it. Returns the resulting snapshot (which
- *  may be a previous one, when the last session ended with nothing
- *  open). */
+ *  it into LAST and empty it. A session that ended with nothing open
+ *  clears LAST — unless the standing snapshot was pinned by Save
+ *  Workspace, which is exactly the set the user asked to keep.
+ *  Returns the resulting snapshot. */
 export function rolloverLastWorkspace(): WorkspaceSnapshot | null {
   const folded = foldLive(readLive());
   writeJson(LIVE_KEY, {});
-  if (folded) writeJson(LAST_KEY, folded);
-  const snapshot = folded ?? lastWorkspace();
+  let snapshot: WorkspaceSnapshot | null;
+  if (folded) {
+    writeJson(LAST_KEY, folded);
+    snapshot = folded;
+  } else {
+    const standing = lastWorkspace();
+    snapshot = standing?.pinned ? standing : null;
+    if (!snapshot) writeJson(LAST_KEY, null);
+  }
   publish(snapshot);
   return snapshot;
 }
@@ -210,9 +232,10 @@ export function rolloverLastWorkspace(): WorkspaceSnapshot | null {
 export function saveWorkspaceNow(): WorkspaceSnapshot | null {
   const folded = foldLive(readLive());
   if (!folded) return null;
-  writeJson(LAST_KEY, folded);
-  publish(folded);
-  return folded;
+  const pinned: WorkspaceSnapshot = { ...folded, pinned: true };
+  writeJson(LAST_KEY, pinned);
+  publish(pinned);
+  return pinned;
 }
 
 export function clearLastWorkspace(): void {

--- a/tests/editor/home-screen-workspace.test.ts
+++ b/tests/editor/home-screen-workspace.test.ts
@@ -9,7 +9,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { homeScreen, type HomeScreenCallbacks } from '../../src/editor/home-screen.js';
-import { saveWorkspaceNow, reportWindowWorkspace } from '../../src/editor/workspace-store.js';
+import {
+  saveWorkspaceNow,
+  reportWindowWorkspace,
+  lastWorkspace,
+} from '../../src/editor/workspace-store.js';
 
 function makeCallbacks(): HomeScreenCallbacks & { reopenWorkspace: ReturnType<typeof vi.fn> } {
   return {
@@ -61,17 +65,20 @@ describe('home screen — last workspace', () => {
     expect(openBtn().textContent).toContain('Reopen 3 documents');
   });
 
-  it('reopens only the ticked documents', () => {
+  it('persists an untick to the store, where the launch restore reads it', () => {
     const [, second] = items();
     second!.checked = false;
     second!.dispatchEvent(new Event('change'));
     expect(openBtn().textContent).toContain('Reopen 2 documents');
+    // Durable, not a per-click filter: the at-launch restore honours
+    // the same list.
+    expect(lastWorkspace()!.excluded).toEqual(['/w/b.cmir']);
     openBtn().click();
     expect(cb.reopenWorkspace).toHaveBeenCalledTimes(1);
-    expect(cb.reopenWorkspace.mock.calls[0]![0].docs.map((d: { path: string }) => d.path)).toEqual([
-      '/w/a.cmir',
-      '/w/c.cmir',
-    ]);
+    // The whole snapshot goes over; the renderer re-derives the ticks.
+    const passed = cb.reopenWorkspace.mock.calls[0]![0];
+    expect(passed.docs).toHaveLength(3);
+    expect(passed.excluded).toEqual(['/w/b.cmir']);
   });
 
   it('None clears every tick and disables Reopen; All puts them back', () => {
@@ -79,17 +86,19 @@ describe('home screen — last workspace', () => {
     expect(items().some((b) => b.checked)).toBe(false);
     expect(openBtn().disabled).toBe(true);
     expect(openBtn().textContent).toContain('Nothing selected');
+    expect(lastWorkspace()!.excluded).toHaveLength(3);
     openBtn().click();
     expect(cb.reopenWorkspace).not.toHaveBeenCalled();
 
     selectBtn('All').click();
     expect(items().every((b) => b.checked)).toBe(true);
     expect(openBtn().disabled).toBe(false);
+    expect(lastWorkspace()!.excluded).toEqual([]);
     openBtn().click();
     expect(cb.reopenWorkspace.mock.calls[0]![0].docs).toHaveLength(3);
   });
 
-  it('keeps the ticks through a re-show, and resets them for a new snapshot', () => {
+  it('keeps the ticks through a re-show, and starts a fresh set ticked', () => {
     const [first] = items();
     first!.checked = false;
     first!.dispatchEvent(new Event('change'));
@@ -97,7 +106,8 @@ describe('home screen — last workspace', () => {
     homeScreen.show();
     expect(items()[0]!.checked).toBe(false);
 
-    // A different snapshot underneath: every document starts ticked.
+    // A snapshot of different documents: nothing carries over, so
+    // every row starts ticked.
     seedWorkspace(['/w/x.cmir', '/w/y.cmir']);
     homeScreen.hide();
     homeScreen.show();

--- a/tests/editor/home-screen-workspace.test.ts
+++ b/tests/editor/home-screen-workspace.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+/**
+ * Home screen's Last-workspace checklist. The set is always listed in
+ * full rather than folded away — reopening 15 documents wholesale is
+ * rarely what the user wants — so the interesting behaviour is that
+ * the Reopen button carries exactly the ticked subset, and that All /
+ * None flip every row at once.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { homeScreen, type HomeScreenCallbacks } from '../../src/editor/home-screen.js';
+import { saveWorkspaceNow, reportWindowWorkspace } from '../../src/editor/workspace-store.js';
+
+function makeCallbacks(): HomeScreenCallbacks & { reopenWorkspace: ReturnType<typeof vi.fn> } {
+  return {
+    newDoc: vi.fn(),
+    newSpeechDoc: vi.fn(),
+    open: vi.fn(),
+    openRecent: vi.fn(),
+    manageQuickCards: vi.fn(),
+    reopenWorkspace: vi.fn(),
+  };
+}
+
+function seedWorkspace(paths: string[]): void {
+  reportWindowWorkspace(
+    'windows',
+    paths.map((path) => ({ path, filename: path.split('/').pop()!, format: 'cmir' as const })),
+  );
+  saveWorkspaceNow();
+}
+
+const items = (): HTMLInputElement[] =>
+  Array.from(document.querySelectorAll<HTMLInputElement>('.pmd-home-workspace-item input'));
+const openBtn = (): HTMLButtonElement =>
+  document.querySelector<HTMLButtonElement>('.pmd-home-workspace-open')!;
+const selectBtn = (label: string): HTMLButtonElement =>
+  Array.from(document.querySelectorAll<HTMLButtonElement>('.pmd-home-workspace-select')).find(
+    (b) => b.textContent === label,
+  )!;
+
+describe('home screen — last workspace', () => {
+  let cb: ReturnType<typeof makeCallbacks>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '';
+    seedWorkspace(['/w/a.cmir', '/w/b.cmir', '/w/c.cmir']);
+    cb = makeCallbacks();
+    homeScreen.mount(document.body, cb);
+    homeScreen.show();
+  });
+
+  afterEach(() => {
+    homeScreen.hide();
+  });
+
+  it('lists every document, all ticked, with a Reopen button for the lot', () => {
+    expect(items()).toHaveLength(3);
+    expect(items().every((b) => b.checked)).toBe(true);
+    expect(openBtn().textContent).toContain('Reopen 3 documents');
+  });
+
+  it('reopens only the ticked documents', () => {
+    const [, second] = items();
+    second!.checked = false;
+    second!.dispatchEvent(new Event('change'));
+    expect(openBtn().textContent).toContain('Reopen 2 documents');
+    openBtn().click();
+    expect(cb.reopenWorkspace).toHaveBeenCalledTimes(1);
+    expect(cb.reopenWorkspace.mock.calls[0]![0].docs.map((d: { path: string }) => d.path)).toEqual([
+      '/w/a.cmir',
+      '/w/c.cmir',
+    ]);
+  });
+
+  it('None clears every tick and disables Reopen; All puts them back', () => {
+    selectBtn('None').click();
+    expect(items().some((b) => b.checked)).toBe(false);
+    expect(openBtn().disabled).toBe(true);
+    expect(openBtn().textContent).toContain('Nothing selected');
+    openBtn().click();
+    expect(cb.reopenWorkspace).not.toHaveBeenCalled();
+
+    selectBtn('All').click();
+    expect(items().every((b) => b.checked)).toBe(true);
+    expect(openBtn().disabled).toBe(false);
+    openBtn().click();
+    expect(cb.reopenWorkspace.mock.calls[0]![0].docs).toHaveLength(3);
+  });
+
+  it('keeps the ticks through a re-show, and resets them for a new snapshot', () => {
+    const [first] = items();
+    first!.checked = false;
+    first!.dispatchEvent(new Event('change'));
+    homeScreen.hide();
+    homeScreen.show();
+    expect(items()[0]!.checked).toBe(false);
+
+    // A different snapshot underneath: every document starts ticked.
+    seedWorkspace(['/w/x.cmir', '/w/y.cmir']);
+    homeScreen.hide();
+    homeScreen.show();
+    expect(items()).toHaveLength(2);
+    expect(items().every((b) => b.checked)).toBe(true);
+  });
+
+  it('hides the section entirely when there is no snapshot', () => {
+    localStorage.clear();
+    homeScreen.hide();
+    homeScreen.show();
+    expect(
+      document.querySelector<HTMLElement>('.pmd-home-workspace-section')!.hidden,
+    ).toBe(true);
+  });
+});

--- a/tests/editor/workspace-store.test.ts
+++ b/tests/editor/workspace-store.test.ts
@@ -19,6 +19,8 @@ import {
   saveWorkspaceNow,
   clearLastWorkspace,
   subscribeLastWorkspace,
+  setWorkspaceExcluded,
+  selectedDocs,
 } from '../../src/editor/workspace-store.js';
 
 const LIVE_KEY = 'pmd-live-workspace';
@@ -171,6 +173,50 @@ describe('workspace store', () => {
     );
     window.dispatchEvent(new StorageEvent('storage', { key: LAST_KEY }));
     expect(seen).toEqual([1, null, 1]);
+  });
+
+  it('unticks persist across a roll-over for documents still in the set', () => {
+    report(['/w/a.cmir', '/w/b.cmir']);
+    rolloverLastWorkspace();
+    setWorkspaceExcluded(['/w/b.cmir']);
+    // Next session: both were open again at quit.
+    report(['/w/a.cmir', '/w/b.cmir']);
+    const rolled = rolloverLastWorkspace()!;
+    expect(rolled.excluded).toEqual(['/w/b.cmir']);
+    expect(selectedDocs(rolled).map((d) => d.path)).toEqual(['/w/a.cmir']);
+  });
+
+  it('drops an untick once its document leaves the set', () => {
+    report(['/w/a.cmir', '/w/b.cmir']);
+    rolloverLastWorkspace();
+    setWorkspaceExcluded(['/w/b.cmir']);
+    report(['/w/a.cmir']); // b wasn't open this time
+    expect(rolloverLastWorkspace()!.excluded).toEqual([]);
+    // And if b comes back later it is ticked again, not silently suppressed.
+    report(['/w/a.cmir', '/w/b.cmir']);
+    const back = rolloverLastWorkspace()!;
+    expect(selectedDocs(back).map((d) => d.path)).toEqual(['/w/a.cmir', '/w/b.cmir']);
+  });
+
+  it('an explicit save keeps the standing unticks', () => {
+    report(['/w/a.cmir', '/w/b.cmir']);
+    rolloverLastWorkspace();
+    setWorkspaceExcluded(['/w/b.cmir']);
+    report(['/w/a.cmir', '/w/b.cmir']);
+    expect(saveWorkspaceNow()!.excluded).toEqual(['/w/b.cmir']);
+  });
+
+  it('ignores unticks for paths outside the snapshot', () => {
+    report(['/w/a.cmir']);
+    rolloverLastWorkspace();
+    setWorkspaceExcluded(['/w/a.cmir', '/w/nowhere.cmir']);
+    expect(lastWorkspace()!.excluded).toEqual(['/w/a.cmir']);
+  });
+
+  it('selectedDocs returns everything when nothing is unticked', () => {
+    report(['/w/a.cmir', '/w/b.cmir']);
+    const snapshot = rolloverLastWorkspace()!;
+    expect(selectedDocs(snapshot)).toHaveLength(2);
   });
 
   it('survives a corrupt record', () => {

--- a/tests/editor/workspace-store.test.ts
+++ b/tests/editor/workspace-store.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+/**
+ * Workspace store — the "reopen what I had open last time" snapshot.
+ *
+ * The interesting behaviours are the two-record dance: every window
+ * reports into the LIVE map, and the first window of a session folds
+ * that map into the LAST snapshot at boot and empties it. Notably a
+ * fold that finds nothing must KEEP the previous snapshot rather than
+ * blank it (launch → close everything → quit shouldn't destroy the set
+ * the user might still want back).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  reportWindowWorkspace,
+  rolloverLastWorkspace,
+  lastWorkspace,
+  saveWorkspaceNow,
+  clearLastWorkspace,
+  subscribeLastWorkspace,
+} from '../../src/editor/workspace-store.js';
+
+const LIVE_KEY = 'pmd-live-workspace';
+const LAST_KEY = 'pmd-last-workspace';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+function report(paths: string[]): void {
+  reportWindowWorkspace(
+    'windows',
+    paths.map((path) => ({ path, filename: path.split('/').pop()!, format: 'cmir' as const })),
+  );
+}
+
+/** Seed a LIVE entry as if it came from another window. */
+function seedLive(id: string, updatedAt: number, paths: string[], mode: 'panes' | 'windows' = 'windows'): void {
+  const live = JSON.parse(localStorage.getItem(LIVE_KEY) ?? '{}');
+  live[id] = {
+    updatedAt,
+    mode,
+    docs: paths.map((path) => ({
+      path,
+      filename: path.split('/').pop()!,
+      format: 'cmir',
+      slot: null,
+    })),
+  };
+  localStorage.setItem(LIVE_KEY, JSON.stringify(live));
+}
+
+describe('workspace store', () => {
+  it('folds the live map into a snapshot and empties it', () => {
+    report(['/w/a.cmir', '/w/b.cmir']);
+    const snapshot = rolloverLastWorkspace();
+    expect(snapshot?.docs.map((d) => d.path)).toEqual(['/w/a.cmir', '/w/b.cmir']);
+    expect(JSON.parse(localStorage.getItem(LIVE_KEY)!)).toEqual({});
+    expect(lastWorkspace()?.docs).toHaveLength(2);
+  });
+
+  it('drops docs with no reopenable path', () => {
+    reportWindowWorkspace('windows', [
+      { path: '/w/saved.cmir', filename: 'saved.cmir', format: 'cmir' },
+      { path: null, filename: 'untitled', format: null },
+      { path: {}, filename: 'web-handle.cmir', format: 'cmir' },
+      { path: '/w/nameless.cmir', filename: null, format: 'cmir' },
+    ]);
+    expect(rolloverLastWorkspace()?.docs.map((d) => d.path)).toEqual(['/w/saved.cmir']);
+  });
+
+  it('a fold with nothing open keeps the previous snapshot', () => {
+    report(['/w/a.cmir']);
+    rolloverLastWorkspace();
+    // Next session: nothing was open when it ended.
+    const kept = rolloverLastWorkspace();
+    expect(kept?.docs.map((d) => d.path)).toEqual(['/w/a.cmir']);
+  });
+
+  it('merges windows oldest-first and de-duplicates by path', () => {
+    seedLive('win-new', Date.now() - 1_000, ['/w/b.cmir', '/w/a.cmir']);
+    seedLive('win-old', Date.now() - 2_000, ['/w/a.cmir']);
+    expect(rolloverLastWorkspace()?.docs.map((d) => d.path)).toEqual(['/w/a.cmir', '/w/b.cmir']);
+  });
+
+  it('takes its mode from the most recently updated window', () => {
+    seedLive('win-old', Date.now() - 2_000, ['/w/a.cmir'], 'windows');
+    seedLive('win-new', Date.now() - 1_000, ['/w/b.cmir'], 'panes');
+    expect(rolloverLastWorkspace()?.mode).toBe('panes');
+  });
+
+  it('preserves slot assignments through a fold', () => {
+    reportWindowWorkspace('panes', [
+      { path: '/w/a.cmir', filename: 'a.cmir', format: 'cmir', slot: 'slot2' },
+    ]);
+    expect(rolloverLastWorkspace()?.docs[0]!.slot).toBe('slot2');
+  });
+
+  it('an explicit save writes the snapshot without emptying the live map', () => {
+    report(['/w/a.cmir']);
+    expect(saveWorkspaceNow()?.docs).toHaveLength(1);
+    expect(Object.keys(JSON.parse(localStorage.getItem(LIVE_KEY)!))).toHaveLength(1);
+    expect(lastWorkspace()?.docs.map((d) => d.path)).toEqual(['/w/a.cmir']);
+  });
+
+  it('an explicit save with nothing open is a no-op', () => {
+    report(['/w/a.cmir']);
+    saveWorkspaceNow();
+    report([]); // this window closed its doc
+    expect(saveWorkspaceNow()).toBeNull();
+    expect(lastWorkspace()?.docs.map((d) => d.path)).toEqual(['/w/a.cmir']);
+  });
+
+  it('ignores live entries older than the age cap', () => {
+    seedLive('ancient', Date.now() - 400 * 24 * 60 * 60 * 1000, ['/w/gone.cmir']);
+    expect(rolloverLastWorkspace()).toBeNull();
+  });
+
+  it('caps a snapshot at 24 documents', () => {
+    report(Array.from({ length: 40 }, (_, i) => `/w/f${i}.cmir`));
+    expect(rolloverLastWorkspace()?.docs).toHaveLength(24);
+  });
+
+  it('notifies subscribers on save, clear, and another window’s write', () => {
+    const seen: Array<number | null> = [];
+    subscribeLastWorkspace((s) => seen.push(s ? s.docs.length : null));
+    report(['/w/a.cmir']);
+    saveWorkspaceNow();
+    clearLastWorkspace();
+    expect(lastWorkspace()).toBeNull();
+    // A write from ANOTHER window arrives as a DOM storage event.
+    localStorage.setItem(
+      LAST_KEY,
+      JSON.stringify({
+        savedAt: Date.now(),
+        mode: 'windows',
+        docs: [{ path: '/w/z.cmir', filename: 'z.cmir', format: 'cmir', slot: null }],
+      }),
+    );
+    window.dispatchEvent(new StorageEvent('storage', { key: LAST_KEY }));
+    expect(seen).toEqual([1, null, 1]);
+  });
+
+  it('survives a corrupt record', () => {
+    localStorage.setItem(LIVE_KEY, '{not json');
+    localStorage.setItem(LAST_KEY, '{not json');
+    expect(lastWorkspace()).toBeNull();
+    expect(rolloverLastWorkspace()).toBeNull();
+  });
+});

--- a/tests/editor/workspace-store.test.ts
+++ b/tests/editor/workspace-store.test.ts
@@ -4,10 +4,11 @@
  *
  * The interesting behaviours are the two-record dance: every window
  * reports into the LIVE map, and the first window of a session folds
- * that map into the LAST snapshot at boot and empties it. Notably a
- * fold that finds nothing must KEEP the previous snapshot rather than
- * blank it (launch → close everything → quit shouldn't destroy the set
- * the user might still want back).
+ * that map into the LAST snapshot at boot and empties it. A fold that
+ * finds nothing CLEARS the snapshot — closing everything before you
+ * quit is taken at face value — except when the standing snapshot was
+ * pinned by an explicit Save Workspace, which is the whole reason to
+ * reach for that command.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -69,12 +70,30 @@ describe('workspace store', () => {
     expect(rolloverLastWorkspace()?.docs.map((d) => d.path)).toEqual(['/w/saved.cmir']);
   });
 
-  it('a fold with nothing open keeps the previous snapshot', () => {
+  it('a fold with nothing open clears an automatic snapshot', () => {
     report(['/w/a.cmir']);
     rolloverLastWorkspace();
-    // Next session: nothing was open when it ended.
+    // Next session: everything was closed before quitting.
+    expect(rolloverLastWorkspace()).toBeNull();
+    expect(lastWorkspace()).toBeNull();
+  });
+
+  it('a fold with nothing open keeps a pinned snapshot', () => {
+    report(['/w/a.cmir']);
+    expect(saveWorkspaceNow()?.pinned).toBe(true);
+    report([]); // closed it again before quitting
     const kept = rolloverLastWorkspace();
     expect(kept?.docs.map((d) => d.path)).toEqual(['/w/a.cmir']);
+    expect(kept?.pinned).toBe(true);
+  });
+
+  it('a session that ends with docs open replaces even a pinned snapshot', () => {
+    report(['/w/pinned.cmir']);
+    saveWorkspaceNow();
+    report(['/w/later.cmir']);
+    const rolled = rolloverLastWorkspace();
+    expect(rolled?.docs.map((d) => d.path)).toEqual(['/w/later.cmir']);
+    expect(rolled?.pinned).toBe(false);
   });
 
   it('merges windows oldest-first and de-duplicates by path', () => {
@@ -109,6 +128,19 @@ describe('workspace store', () => {
     report([]); // this window closed its doc
     expect(saveWorkspaceNow()).toBeNull();
     expect(lastWorkspace()?.docs.map((d) => d.path)).toEqual(['/w/a.cmir']);
+  });
+
+  it('a snapshot written before pinning existed reads as unpinned', () => {
+    localStorage.setItem(
+      LAST_KEY,
+      JSON.stringify({
+        savedAt: Date.now(),
+        mode: 'windows',
+        docs: [{ path: '/w/old.cmir', filename: 'old.cmir', format: 'cmir', slot: null }],
+      }),
+    );
+    expect(lastWorkspace()?.pinned).toBe(false);
+    expect(rolloverLastWorkspace()).toBeNull();
   });
 
   it('ignores live entries older than the age cap', () => {


### PR DESCRIPTION
## What

Adds a "reopen my last set of open documents" feature. Today recents reopen one file at a time, and the only machinery that ever reopened a *set* of documents is the internal mode-switch reload — this generalizes that idea into a user-facing feature without touching the mode-switch path.

- **Home screen → Last workspace**: one row that reopens the whole set the previous session ended with (with **Forget** to drop the snapshot).
- **Two commands** (unbound by default, in the File group): **Save Workspace** (aliases: "save session", "save tabs") and **Reopen Last Workspace** (aliases: "restore session", "open previous session").
- **Settings → General → Workspace → Reopen last workspace at launch** (default off) for automatic restore.

## How

`src/editor/workspace-store.ts` keeps two localStorage records:

- **LIVE** — windowId → the docs that window currently has open. Every window rewrites its own entry when its open set changes: single-doc from `updateWindowTitle` / `setCurrentDocHandle` (memoized on a `path|name|format` key so the hot dirty-marker refresh doesn't hammer storage), three-pane from `refreshLayout` (where every open / close / send-to-slot already lands) plus `setFocusedFile` for Save As. Nothing clears it on quit — a killed app leaves exactly what was open, which is the point.
- **LAST** — the offerable snapshot. The first window of a session folds LIVE into it at boot and empties LIVE, *before* mounting anything (then re-reports), so a doc reported first isn't swept back out. Firstness is settled at the top of `initSingleDocBoot` so the roll-over also runs on the OS-open path, which returns early with a spawn payload. A fold that finds nothing open **keeps** the previous snapshot — launch → close everything → quit shouldn't destroy the set the user might still want back.

Restoring is mode-aware: three-pane hands the set to the shell, which loads each doc into the slot it was saved from (a single-doc snapshot has no slots, so those fill slot1 → slot2 → slot3); single-doc mounts the first doc in place when the window still holds the pristine starter and spawns a window for each of the rest. Both paths reuse the existing duplicate-open guards (`findOpenRecordByHandle` / `openPathCheck`), so nothing is opened twice, and both substitute blank-document bytes for a genuinely-empty file the way `resolveOpenedFile` does. Missing files are counted and reported in one toast.

The launch restore runs **after** startup recovery (a recovered draft keeps its window/slot and is skipped as already open) and never on a mode-switch reload, which reopens an exact doc set of its own.

Desktop-only throughout: the web edition can't serialize a `FileSystemFileHandle` (same limitation as `recents-store.ts`), so docs with no string path are never recorded and the home-screen section is omitted rather than shown dead.

## Testing

- `tsc --noEmit` clean.
- New `tests/editor/workspace-store.test.ts` (12 tests): fold + empty, dropping unreopenable docs, the keep-previous-on-empty-fold rule, oldest-first merge with path de-dup, mode and slot preservation, explicit save vs. roll-over, the age cap, the 24-doc cap, subscriber notification incl. the cross-window `storage` event, and corrupt-record tolerance.
- Full `tests/editor` directory green locally: 236 files / 2515 tests.

## Docs

MANUAL.md §16 (Opening files), plus `## Unreleased` entries in CHANGELOG.md and DETAILED_CHANGELOG.md.

https://claude.ai/code/session_012yTw18MHLP8U7vgAEGr2kC